### PR TITLE
Add 'BLOCK' to <a>'s content types, so that <div> could be part of an…

### DIFF
--- a/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -429,7 +429,7 @@ public class TagBalancingHtmlStreamEventReceiver
           "a", false, elementGroupBits(
               ElementGroup.INLINE
           ), elementGroupBits(
-              ElementGroup.INLINE_MINUS_A
+              ElementGroup.BLOCK, ElementGroup.INLINE_MINUS_A
           ));
       defineElement(
           "abbr", true, elementGroupBits(


### PR DESCRIPTION
… anchor node.

This is for https://github.com/OWASP/java-html-sanitizer/issues/52

> Changes in HTML5
>Although previous versions of HTML restricted the a element to only containing phrasing content (essentially, what was in previous versions referred to as “inline” content), the a element is now transparent; that is, an instance of the a element is now allowed to also contain flow content (essentially, what was in previous versions referred to as “block” content)—if the parent element of that instance of the a element is an element that is allowed to contain flow content.

Copied https://www.w3.org/TR/html-markup/a.html