### PR TITLE
Fixes issue 52 - block elements inside `<a>` elements

### DIFF
--- a/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -162,12 +162,21 @@ public class TagBalancingHtmlStreamEventReceiver
     // in the current element which allows us to prune the search.
     int transparencyAllowed = childTypes
         & (top.transparentToContents & ~contents);
-    for (int containerIndex = topIndex - 1;
-         transparencyAllowed != 0 && containerIndex >= 0;
+    for (int containerIndex = topIndex - 1; transparencyAllowed != 0;
         --containerIndex) {
+      if (containerIndex < 0) {
+        // When the element stack is empty, we don't check containment.
+        // This is effectively assuming, by omission, that any element can
+        // appear at the root of the document fragment.
+
+        // Allow transparent elements to contain any content that could be
+        // contained by any container of the document fragment.
+        // Revisit this decision if we start constraining what can be top-level.
+        contents |= transparencyAllowed;
+        break;
+      }
       ElementContainmentInfo container = openElements.get(containerIndex);
       contents |= transparencyAllowed & container.contents;
-      //System.err.println("\tcontainer=" + container.elementName);
       transparencyAllowed =
           transparencyAllowed & container.transparentToContents & ~contents;
     }

--- a/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -314,9 +314,9 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     assertEquals(
         "<html><head><meta /></head><body><p>Hi</p><p>How are you</p>\n"
         + "<p><table><tbody><tr>"
-        + "<td><b><font><font></font></font></b><b><p>Cell</p></b>\n</td>"
+        + "<td><b><font><font></font></font></b><p><b>Cell</b></p>\n</td>"
         // The close </p> tag does not close the whole table.
-        + "<td><b><font><font></font></font></b><b><p>Cell</p></b>\n</td>"
+        + "<td><b><font><font></font></font></b><p><b>Cell</b></p>\n</td>"
         + "</tr></tbody></table></p>\n"
         + "<p>x</p></body></html>",
         htmlOutputBuffer.toString());
@@ -469,6 +469,23 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     balancer.closeDocument();
     assertEquals(
         "<a href=\"\"><div>...</div></a>",
+        htmlOutputBuffer.toString());
+  }
+
+  @Test
+  public final void testResumedElementsAllowedWhereResumed() {
+    balancer.openDocument();
+    balancer.openTag("b", ImmutableList.<String>of());
+    balancer.text("foo");
+    balancer.openTag("i", ImmutableList.<String>of());
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.text("bar");
+    balancer.closeTag("div");
+    balancer.closeTag("i");
+    balancer.closeTag("b");
+    balancer.closeDocument();
+    assertEquals(
+        "<b>foo<i></i></b><div><b><i>bar</i></b></div>",
         htmlOutputBuffer.toString());
   }
 }

--- a/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -338,4 +338,122 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     assertFalse(isInterElementWhitespace("\u0000"));
   }
 
+  @Test
+  public final void testAnchorTransparentToBlock() {
+    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+    balancer.openDocument();
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.openTag("a", hrefOnly);
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.text("...");
+    balancer.closeTag("div");
+    balancer.closeTag("a");
+    balancer.closeTag("div");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<div><a href=\"\"><div>...</div></a></div>",
+        htmlOutputBuffer.toString());
+  }
+
+
+  @Test
+  public final void testAnchorTransparentToSpans() {
+    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+    balancer.openDocument();
+    balancer.openTag("span", ImmutableList.<String>of());
+    balancer.openTag("a", hrefOnly);
+    balancer.openTag("span", ImmutableList.<String>of());
+    balancer.text("...");
+    balancer.closeTag("span");
+    balancer.closeTag("a");
+    balancer.closeTag("span");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<span><a href=\"\"><span>...</span></a></span>",
+        htmlOutputBuffer.toString());
+  }
+
+
+  @Test
+  public final void testAnchorWithInlineInBlock() {
+    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+    balancer.openDocument();
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.openTag("a", hrefOnly);
+    balancer.openTag("span", ImmutableList.<String>of());
+    balancer.text("...");
+    balancer.closeTag("span");
+    balancer.closeTag("a");
+    balancer.closeTag("div");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<div><a href=\"\"><span>...</span></a></div>",
+        htmlOutputBuffer.toString());
+  }
+
+
+  @Test
+  public final void testAnchorClosedWhenBlockInInline() {
+    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+    balancer.openDocument();
+    balancer.openTag("span", ImmutableList.<String>of());
+    balancer.openTag("a", hrefOnly);
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.text("...");
+    balancer.closeTag("div");
+    balancer.closeTag("a");
+    balancer.closeTag("span");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<span><a href=\"\"></a></span><div>...</div>",
+        htmlOutputBuffer.toString());
+  }
+
+
+  @Test
+  public final void testAnchorInAnchorIndirectly() {
+    // TODO: Double check this test and handle nested anchors properly.
+    if (true) { return; }
+    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+    balancer.openDocument();
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.openTag("a", hrefOnly);
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.openTag("a", hrefOnly);
+    balancer.text("...");
+    balancer.closeTag("a");
+    balancer.closeTag("div");
+    balancer.closeTag("a");
+    balancer.closeTag("div");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<div><a href=\"\"><div></div></a><a href=\"\">...</a></a>",
+        htmlOutputBuffer.toString());
+  }
+
+  @Test
+  public final void testInteractiveInAnchorIndirectly() {
+    if (true) { return; }  // TODO: Handle media elements properly
+    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+    balancer.openDocument();
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.openTag("a", hrefOnly);
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.openTag("video", ImmutableList.<String>of());
+    balancer.closeTag("video");
+    balancer.closeTag("div");
+    balancer.closeTag("a");
+    balancer.closeTag("div");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<div><a href=\"\"><div></div></a><video></video></div>",
+        htmlOutputBuffer.toString());
+  }
+
 }

--- a/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -34,6 +34,7 @@ import junit.framework.TestCase;
 
 import org.junit.Test;
 import org.junit.Before;
+import org.junit.Ignore;
 
 import static org.owasp.html.TagBalancingHtmlStreamEventReceiver
               .isInterElementWhitespace;
@@ -414,10 +415,10 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   }
 
 
+  // TODO: Double check this test and handle nested anchors properly.
   @Test
-  public final void testAnchorInAnchorIndirectly() {
-    // TODO: Double check this test and handle nested anchors properly.
-    if (true) { return; }
+  @Ignore
+  public final void failingtestAnchorInAnchorIndirectly() {
     ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
     balancer.openDocument();
     balancer.openTag("div", ImmutableList.<String>of());
@@ -436,9 +437,10 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
         htmlOutputBuffer.toString());
   }
 
+  // TODO: Handle media elements properly
+  @Ignore
   @Test
-  public final void testInteractiveInAnchorIndirectly() {
-    if (true) { return; }  // TODO: Handle media elements properly
+  public final void failingtestInteractiveInAnchorIndirectly() {
     ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
     balancer.openDocument();
     balancer.openTag("div", ImmutableList.<String>of());
@@ -450,10 +452,23 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     balancer.closeTag("a");
     balancer.closeTag("div");
     balancer.closeDocument();
-
     assertEquals(
         "<div><a href=\"\"><div></div></a><video></video></div>",
         htmlOutputBuffer.toString());
   }
 
+  @Test
+  public final void testAnchorWithBlockAtTopLevel() {
+    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+    balancer.openDocument();
+    balancer.openTag("a", hrefOnly);
+    balancer.openTag("div", ImmutableList.<String>of());
+    balancer.text("...");
+    balancer.closeTag("div");
+    balancer.closeTag("a");
+    balancer.closeDocument();
+    assertEquals(
+        "<a href=\"\"><div>...</div></a>",
+        htmlOutputBuffer.toString());
+  }
 }


### PR DESCRIPTION
reworked TagBalancingHtmlStreamEventReceiver to handle transparency in `<a>` tags in a limited way to address issue 52.  This changes the element containment info tables to use a builder mode since the constructor calls were getting unwieldy.  It adds 4 tests, 2 of which fail currently since they are orthogonal to issue 52.  Fixing those last 2 will benefit from a larger structural change that also has the side-effect of making containment checking O(1).