### PR TITLE
Make canContain return true for <table>, <thead>, <tbody>, <tfoot> an…

### DIFF
--- a/src/main/java/org/owasp/html/HtmlElementTables.java
+++ b/src/main/java/org/owasp/html/HtmlElementTables.java
@@ -75,6 +75,7 @@ public final class HtmlElementTables {
   /** {@code <noscript>}, {@code <noframes>}, etc. */
   private final DenseElementSet nofeatureElements;
 
+  private final DenseElementSet tableElements;
 
   /** */
   public HtmlElementTables(
@@ -186,16 +187,26 @@ public final class HtmlElementTables {
         nofeatureBits[indexForName("noframes")] =
             nofeatureBits[indexForName("noembed")] = true;
     this.nofeatureElements = new DenseElementSet(nofeatureBits);
+
+    boolean[] tableElements = new boolean[this.nElementTypes()];
+    tableElements[indexForName("table")] =
+        tableElements[indexForName("thead")] =
+            tableElements[indexForName("tbody")] =
+                tableElements[indexForName("tfoot")] =
+                    tableElements[indexForName("tr")] = true;
+    this.tableElements = new DenseElementSet(tableElements);
   }
 
 
   /** True if parent can directly contain child. */
   public boolean canContain(int parent, int child) {
-    if (nofeatureElements.get(parent)) {
+    if (nofeatureElements.get(parent) || tableElements.get(parent)) {
       // It's hard to interrogate a browser about the behavior of
       // <noscript> in scriptless mode using JavaScript, and the
       // behavior of <noscript> is more dangerous when in that mode,
       // so we hardcode that mode here as a worst case assumption.
+      // Return true for <table>, <thead>, <tbody>, <tfoot> and <tr> elements,
+      // so that it will not close the open table elements and break table layout.
       return true;
     }
 

--- a/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/src/test/java/org/owasp/html/SanitizersTest.java
@@ -313,7 +313,7 @@ public class SanitizersTest extends TestCase {
       .and(Sanitizers.STYLES)
       .and(Sanitizers.IMAGES)
       .and(Sanitizers.TABLES);
-    assertEquals("<table></table>Hallo\r\n\nEnde\n\r", pf.sanitize(input));
+    assertEquals("<table>Hallo\r\n\nEnde\n\r</table>", pf.sanitize(input));
   }
 
   @Test

--- a/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -229,8 +229,6 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     balancer.openTag("td", ImmutableList.<String>of());
     balancer.text("foo");
     balancer.closeTag("td");
-    // Chrome does not insert a td to contain this mis-nested table.
-    // Instead, it ends one table and starts another.
     balancer.openTag("table", ImmutableList.<String>of());
     balancer.openTag("tbody", ImmutableList.<String>of());
     balancer.openTag("tr", ImmutableList.<String>of());
@@ -241,8 +239,8 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     balancer.closeDocument();
 
     assertEquals(
-        "<table><tbody><tr><td>foo</td></tr></tbody></table>"
-        + "<table><tbody><tr><th>bar</th></tr></tbody></table>",
+        "<table><tbody><tr><td>foo</td><table><tbody><tr><th>bar</th>"
+        + "</tr></tbody></table></tr></tbody></table>",
 
         htmlOutputBuffer.toString());
   }


### PR DESCRIPTION
Make canContain return true for `<table>, <thead>, <tbody>, <tfoot> and <tr>` elements,
so that it will not close the open table elements and break table layout.