### PR TITLE
Prevent StringIndexOutOfBoundsException on empty default rel set

### DIFF
--- a/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -987,7 +987,7 @@ public class HtmlPolicyBuilder {
       if (indexOfAttributeValue("href", attrs) >= 0) {
         // It's a link.
         boolean hasTarget = indexOfAttributeValue("target", attrs) >= 0;
-        if (hasTarget || !extra.isEmpty()) {
+        if ((hasTarget && !whenTargetPresent.isEmpty()) || !extra.isEmpty()) {
           int relIndex = indexOfAttributeValue("rel", attrs);
           String relValue;
           if (relIndex < 0 && hasTarget && extra.isEmpty() && skip.isEmpty()) {

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -737,6 +737,21 @@ public class HtmlPolicyBuilderTest extends TestCase {
   }
 
   @Test
+  public static final void testEmptyDefaultLinkRelsSet() {
+    PolicyFactory pf = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href", "target").onElements("a")
+        .allowStandardUrlProtocols()
+        .skipRelsOnLinks("noopener", "noreferrer")
+        .toFactory();
+
+    assertEquals(
+        "<a href=\"http://example.com\" target=\"_blank\">eg</a>",
+        pf.sanitize("<a href=\"http://example.com\" target=\"_blank\">eg</a>")
+    );
+  }
+
+  @Test
   public static final void testScopingExitInNoContent() {
     PolicyFactory pf = new HtmlPolicyBuilder()
         .allowElements("table", "tr", "td", "noscript")


### PR DESCRIPTION
When using the `HtmlPolicyBuilder`, if both `noopener` and  `noreferrer` are supplied to `skipRelsOnLinks`, then a `StringIndexOutOfBoundsException` will get thrown when applying sanitization on elements that have both an `href` and `target`. This PR addresses that issue by only attempting to apply rels to the element if we actually have a non-zero set of rels to apply.

Addresses https://github.com/OWASP/java-html-sanitizer/issues/151