### PR TITLE
Add OSGI bundle packaging

### DIFF
--- a/html-types/pom.xml
+++ b/html-types/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
   <artifactId>html-types</artifactId>
   <version>20190610.2-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <parent>
     <relativePath>../parent</relativePath>
     <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
@@ -20,6 +20,26 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-verifier-plugin</artifactId>
+        <configuration>
+            <verificationFile>src/test/resources/osgi-integration-verification.xml</verificationFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>main</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/html-types/src/test/resources/osgi-integration-verification.xml
+++ b/html-types/src/test/resources/osgi-integration-verification.xml
@@ -1,0 +1,10 @@
+<verifications xmlns="http://maven.apache.org/verifications/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+  <files>
+    <file>
+      <location>target/classes/META-INF/MANIFEST.MF</location>
+      <contains>Export-Package: org.owasp.html.htmltypes</contains>
+    </file>
+  </files>
+</verifications>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -213,6 +213,17 @@ application while protecting against XSS.
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <extensions>true</extensions>
+          <version>3.5.0</version>
+        </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-verifier-plugin</artifactId>
+            <version>1.1</version>
+          </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,23 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <version>3.5.0</version>
       </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-verifier-plugin</artifactId>
+          <configuration>
+            <verificationFile>src/test/resources/osgi-integration-verification.xml</verificationFile>
+          </configuration>
+          <executions>
+            <execution>
+              <id>main</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>owasp-java-html-sanitizer</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <parent>
     <relativePath>parent</relativePath>
     <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
@@ -56,6 +56,12 @@
         <configuration>
           <repoToken>TENYw0IKRulLOXgkyzjGqNi0hQyhBiSiU</repoToken>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <version>3.5.0</version>
       </plugin>
     </plugins>
   </build>

--- a/src/test/resources/osgi-integration-verification.xml
+++ b/src/test/resources/osgi-integration-verification.xml
@@ -1,0 +1,10 @@
+<verifications xmlns="http://maven.apache.org/verifications/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+  <files>
+    <file>
+      <location>target/classes/META-INF/MANIFEST.MF</location>
+      <contains>Export-Package: org.owasp.html</contains>
+    </file>
+  </files>
+</verifications>


### PR DESCRIPTION
In its current state, this project does not work out-of-the-box within an OSGi environment. Adding the [Maven bundle plugin](https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html) and changing the packaging to bundle allows the project to be used more seamlessly. Without the resulting manifest files of the plugin, developers either need to embed this dependency in all bundles that use the project or need to separately wrap the java-html-sanitizer jar as a bundle using the standalone BND tool.