### PR TITLE
Table formatting issue fix

### DIFF
--- a/src/main/java/org/owasp/html/HtmlElementTables.java
+++ b/src/main/java/org/owasp/html/HtmlElementTables.java
@@ -142,10 +142,10 @@ public final class HtmlElementTables {
             TD_TAG, new int[] { TR_TAG, TD_TAG, TH_TAG },
             new int[] { TABLE_TAG, TBODY_TAG, TR_TAG }),
         new FreeWrapper(
-            TH_TAG, new int[] { TR_TAG, TD_TAG, TR_TAG },
+            TH_TAG, new int[] { TR_TAG, TD_TAG, TH_TAG },
             new int[] { TABLE_TAG, TBODY_TAG, TR_TAG }),
         new FreeWrapper(
-            TR_TAG, new int[] { TBODY_TAG, THEAD_TAG, TFOOT_TAG, TR_TAG },
+            TR_TAG, new int[] { TBODY_TAG, THEAD_TAG, TFOOT_TAG, TR_TAG, TD_TAG, TH_TAG },
             new int[] { TABLE_TAG, TBODY_TAG }),
         new FreeWrapper(
             TBODY_TAG, new int[] { TABLE_TAG, THEAD_TAG, TBODY_TAG, TFOOT_TAG },

--- a/src/test/java/org/owasp/html/ExamplesTest.java
+++ b/src/test/java/org/owasp/html/ExamplesTest.java
@@ -101,4 +101,13 @@ public class ExamplesTest extends TestCase {
         "<a href=\"../good.html\" rel=\"nofollow\">click here</a>",
         sanitized);
   }
+
+  @Test
+  public static final void testTableStructure() {
+      String input = "<TABLE><TR><TD>Green Zone Bulk mail<TD>21 entries<TR><TH>Type<TH>Date<TH>Size<TH>Country<TR><TD>Junk<TD>March 26<TD>25KB<TD>US";
+      String sanitized = Sanitizers.TABLES.sanitize(input);
+      assertEquals(
+          "<table><tbody><tr><td>Green Zone Bulk mail</td><td>21 entries</td></tr><tr><th>Type</th><th>Date</th><th>Size</th><th>Country</th></tr><tr><td>Junk</td><td>March 26</td><td>25KB</td><td>US</td></tr></tbody></table>",
+          sanitized);
+  }
 }


### PR DESCRIPTION
Sample HTML code:
```
<TABLE border='0' cellspacing='0' cellpadding='4' width='1100'>
<TR height='30' bgcolor='#7FED4B'><TD style='white-space:nowrap' colspan='9'><B><FONT size='+2' class='font-large'>&nbsp;Green Zone &#8212; Bulk mail, including subscriptions and advertisements</FONT></B><TD class='right' align='right'><B><FONT size='+1' class='font-medium'>21 entries&nbsp;</FONT></B>
<TR align='left' bgcolor='#E3E2E2'><TH width='50'>View<TH width='36'>Type<TH width='100'>Date<TH width='75'>Time<TH width='75'>Size<TH width='35'>Country<TH width='150'>Sender<TH width='200'>Mailbox<TH width='200'>Subject<TH width='100%'>Direction
<TR>
<TD height='22' width='50'><A href='http://example.com'>View</A>
<TD height='22' width='36'>Junk
<TD height='22' width='100'>Mar&nbsp;26
<TD height='22' width='75'>9:02<SPAN class='am'><font size='-1' class='am'>PM</font></SPAN>
<TD height='22' width='75'>25KB
<TD height='22' width='35'>US
<TD height='22' width='150'>ABC
<TD height='22' width='200'>&lt;468b.1c.195562763.slnl...@example.org&gt;
<TD height='22' width='200'>Teacher Evaluation
<TD height='22' width='75'>Inbound
```

Sanitized code before fix(Using Sanitizers.TABLES policy):
```
<table><tbody><tr><td> Green Zone — Bulk mail, including subscriptions and advertisements</td><td align="right">21 entries 
<table><tbody><tr align="left"><th>View<table><tbody><tr><th>Type<table><tbody><tr><th>Date<table><tbody><tr><th>Time<table><tbody><tr><th>Size<table><tbody><tr><th>Country<table><tbody><tr><th>Sender<table><tbody><tr><th>Mailbox<table><tbody><tr><th>Subject<table><tbody><tr><th>Direction
<table><tbody><tr><td>View
</td><td>Junk
</td><td>Mar 26
</td><td>9:02PM
</td><td>25KB
</td><td>US
</td><td>ABC
</td><td>&lt;468b.1c.195562763.slnl...&#64;example.org&gt;
</td><td>Teacher Evaluation
</td><td>Inbound
</td></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></th></tr></tbody></table></td></tr></tbody></table>
```

Sanitized code after fix(Using Sanitizers.TABLES policy):
```
<table><tbody><tr><td> Green Zone — Bulk mail, including subscriptions and advertisements</td><td align="right">21 entries 
</td></tr><tr align="left"><th>View</th><th>Type</th><th>Date</th><th>Time</th><th>Size</th><th>Country</th><th>Sender</th><th>Mailbox</th><th>Subject</th><th>Direction
</th></tr><tr><td>View
</td><td>Junk
</td><td>Mar 26
</td><td>9:02PM
</td><td>25KB
</td><td>US
</td><td>ABC
</td><td>&lt;468b.1c.195562763.slnl...&#64;example.org&gt;
</td><td>Teacher Evaluation
</td><td>Inbound
</td></tr></tbody></table>
```

<img width="1110" alt="SampleTable" src="https://user-images.githubusercontent.com/26221278/65674801-ce12bb00-e06a-11e9-9391-853739899751.png">



