### PR TITLE
Allow colspan attribute on td and th elements

### DIFF
--- a/src/main/java/org/owasp/html/Sanitizers.java
+++ b/src/main/java/org/owasp/html/Sanitizers.java
@@ -93,6 +93,7 @@ public final class Sanitizers {
     .onElements("table", "tr", "td", "th",
                 "colgroup", "col",
                 "thead", "tbody", "tfoot")
+    .allowAttributes("colspan").onElements("td", "th)
     .allowTextIn("table")  // WIDGY
     .toFactory();
 

--- a/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/src/test/java/org/owasp/html/SanitizersTest.java
@@ -434,6 +434,24 @@ public class SanitizersTest extends TestCase {
         pf.sanitize(input));
   }
 
+  @Test
+  public static final void testColspanAttributeInTable() {
+    String input = ""
+        + "<table>"
+        + "<tr><th colspan=\"2\">Foo</th></tr>"
+        + "<tr><td colspan=\"2\">Bar</td></tr>"
+        + "</table>";
+    PolicyFactory pf = Sanitizers.BLOCKS
+        .and(Sanitizers.FORMATTING)
+        .and(Sanitizers.TABLES);
+    assertEquals(
+        "<table><tbody>"
+        + "<tr><th colspan=\"2\">Foo</th></tr>"
+        + "<tr><td colspan=\"2\">Bar</td></tr>"
+        + "</tbody></table>",
+        pf.sanitize(input));
+  }
+  
   static int fac(int n) {
     int ifac = 1;
     for (int i = 1; i <= n; ++i) {


### PR DESCRIPTION
Allow the `colspan` attribute on `td` and `th` table elements in the `TABLES` policy factory.

Fixes #195 