### PR TITLE
'-' and '_' may be treated in plain letters.

### DIFF
--- a/src/main/java/org/owasp/html/HtmlEntities.java
+++ b/src/main/java/org/owasp/html/HtmlEntities.java
@@ -2232,6 +2232,7 @@ final class HtmlEntities {
         case 'y': case 'z':
         case '0': case '1': case '2': case '3': case '4': case '5':
         case '6': case '7': case '8': case '9':
+        case '-': case '_':
           break;
         case '=':
           // An equal sign after an entity missing a closing semicolon should

--- a/src/test/java/org/owasp/html/HtmlEntitiesTest.java
+++ b/src/test/java/org/owasp/html/HtmlEntitiesTest.java
@@ -1,0 +1,23 @@
+package org.owasp.html;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class HtmlEntitiesTest {
+
+	@Test
+	public void decodeTest() {
+		String input = "<a href=\"/t?a=1&order_id=2\">order</a>";
+		String output = Encoding.decodeHtml(input);
+		assertEquals("<a href=\"/t?a=1&order_id=2\">order</a>", output);
+
+		input = "<a href=\"/t?a=1&order-id=2\">order</a>";
+		output = Encoding.decodeHtml(input);
+		assertEquals("<a href=\"/t?a=1&order-id=2\">order</a>", output);
+
+		input = "<a href=\"/t?a=1&order=2\">order</a>";
+		output = Encoding.decodeHtml(input);
+		assertEquals("<a href=\"/t?a=1&order=2\">order</a>", output);
+	}
+}

--- a/src/test/java/org/owasp/html/HtmlEntitiesTest.java
+++ b/src/test/java/org/owasp/html/HtmlEntitiesTest.java
@@ -1,13 +1,14 @@
 package org.owasp.html;
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
 
-public class HtmlEntitiesTest {
+import junit.framework.TestCase;
+
+@SuppressWarnings("javadoc")
+public class HtmlEntitiesTest extends TestCase {
 
 	@Test
-	public void decodeTest() {
+	public void testAfterAmpString() {
 		String input = "<a href=\"/t?a=1&order_id=2\">order</a>";
 		String output = Encoding.decodeHtml(input);
 		assertEquals("<a href=\"/t?a=1&order_id=2\">order</a>", output);


### PR DESCRIPTION
#193 becaue of `_` char, `order` string  find it in ENTITY_TRIE and replace `ℴ` 
I think `-` and `_` may be treated in plain letters.
Please tell me if you think I'm wrong or if I lack a test.