### PR TITLE
Do not lcase element or attribute names that match SVG or MathML name…

### DIFF
--- a/src/main/java/org/owasp/html/ElementAndAttributePolicies.java
+++ b/src/main/java/org/owasp/html/ElementAndAttributePolicies.java
@@ -35,7 +35,7 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * Encapsulates all the information needed by the
- * {@link ElementAndAttributePolicySanitizerPolicy} to sanitize one kind
+ * {@link ElementAndAttributePolicyBasedSanitizerPolicy} to sanitize one kind
  * of element.
  */
 @Immutable

--- a/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -144,7 +144,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
       adjustedElementName = policies.elPolicy.apply(elementName, attrs);
       if (adjustedElementName != null) {
-        adjustedElementName = HtmlLexer.canonicalName(adjustedElementName);
+        adjustedElementName = HtmlLexer.canonicalElementName(adjustedElementName);
       }
     } else {
       adjustedElementName = null;

--- a/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -238,7 +238,7 @@ public class HtmlPolicyBuilder {
       ElementPolicy policy, String... elementNames) {
     invalidateCompiledState();
     for (String elementName : elementNames) {
-      elementName = HtmlLexer.canonicalName(elementName);
+      elementName = HtmlLexer.canonicalElementName(elementName);
       ElementPolicy newPolicy = ElementPolicy.Util.join(
           elPolicies.get(elementName), policy);
       // Don't remove if newPolicy is the always reject policy since we want
@@ -286,7 +286,7 @@ public class HtmlPolicyBuilder {
   public HtmlPolicyBuilder allowTextIn(String... elementNames) {
     invalidateCompiledState();
     for (String elementName : elementNames) {
-      elementName = HtmlLexer.canonicalName(elementName);
+      elementName = HtmlLexer.canonicalElementName(elementName);
       textContainers.put(elementName, true);
     }
     return this;
@@ -305,7 +305,7 @@ public class HtmlPolicyBuilder {
   public HtmlPolicyBuilder disallowTextIn(String... elementNames) {
     invalidateCompiledState();
     for (String elementName : elementNames) {
-      elementName = HtmlLexer.canonicalName(elementName);
+      elementName = HtmlLexer.canonicalElementName(elementName);
       textContainers.put(elementName, false);
     }
     return this;
@@ -321,7 +321,7 @@ public class HtmlPolicyBuilder {
   public HtmlPolicyBuilder allowWithoutAttributes(String... elementNames) {
     invalidateCompiledState();
     for (String elementName : elementNames) {
-      elementName = HtmlLexer.canonicalName(elementName);
+      elementName = HtmlLexer.canonicalElementName(elementName);
       skipIssueTagMap.put(elementName, HtmlTagSkipType.DO_NOT_SKIP);
     }
     return this;
@@ -336,7 +336,7 @@ public class HtmlPolicyBuilder {
   public HtmlPolicyBuilder disallowWithoutAttributes(String... elementNames) {
     invalidateCompiledState();
     for (String elementName : elementNames) {
-      elementName = HtmlLexer.canonicalName(elementName);
+      elementName = HtmlLexer.canonicalElementName(elementName);
       skipIssueTagMap.put(elementName, HtmlTagSkipType.SKIP);
     }
     return this;
@@ -349,7 +349,7 @@ public class HtmlPolicyBuilder {
   public AttributeBuilder allowAttributes(String... attributeNames) {
     ImmutableList.Builder<String> b = ImmutableList.builder();
     for (String attributeName : attributeNames) {
-      b.add(HtmlLexer.canonicalName(attributeName));
+      b.add(HtmlLexer.canonicalAttributeName(attributeName));
     }
     return new AttributeBuilder(b.build());
   }
@@ -432,7 +432,7 @@ public class HtmlPolicyBuilder {
       this.extraRelsForLinks = Sets.newLinkedHashSet();
     }
     for (String linkValue : linkValues) {
-      linkValue = HtmlLexer.canonicalName(linkValue);
+      linkValue = HtmlLexer.canonicalKeywordAttributeValue(linkValue);
       Preconditions.checkArgument(
           !Strings.containsHtmlSpace(linkValue),
           "spaces in input.  use f(\"foo\", \"bar\") not f(\"foo bar\")");
@@ -456,7 +456,7 @@ public class HtmlPolicyBuilder {
       this.skipRelsForLinks = Sets.newLinkedHashSet();
     }
     for (String linkValue : linkValues) {
-      linkValue = HtmlLexer.canonicalName(linkValue);
+      linkValue = HtmlLexer.canonicalKeywordAttributeValue(linkValue);
       Preconditions.checkArgument(
           !Strings.containsHtmlSpace(linkValue),
           "spaces in input.  use f(\"foo\", \"bar\") not f(\"foo bar\")");
@@ -980,7 +980,7 @@ public class HtmlPolicyBuilder {
     public HtmlPolicyBuilder onElements(String... elementNames) {
       ImmutableList.Builder<String> b = ImmutableList.builder();
       for (String elementName : elementNames) {
-        b.add(HtmlLexer.canonicalName(elementName));
+        b.add(HtmlLexer.canonicalElementName(elementName));
       }
       return HtmlPolicyBuilder.this.allowAttributesOnElements(
           policy, attributeNames, b.build());

--- a/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -152,7 +152,7 @@ public final class HtmlSanitizer {
           break;
         case TAGBEGIN:
           if (htmlContent.charAt(token.start + 1) == '/') {  // A close tag.
-            receiver.closeTag(HtmlLexer.canonicalName(
+            receiver.closeTag(HtmlLexer.canonicalElementName(
                 htmlContent.substring(token.start + 2, token.end)));
             while (lexer.hasNext()
                    && lexer.next().type != HtmlTokenType.TAGEND) {
@@ -173,7 +173,7 @@ public final class HtmlSanitizer {
                   } else {
                     attrsReadyForName = false;
                   }
-                  attrs.add(HtmlLexer.canonicalName(
+                  attrs.add(HtmlLexer.canonicalAttributeName(
                       htmlContent.substring(tagBodyToken.start, tagBodyToken.end)));
                   break;
                 case ATTRVALUE:
@@ -191,7 +191,7 @@ public final class HtmlSanitizer {
               attrs.add(attrs.getLast());
             }
             receiver.openTag(
-                HtmlLexer.canonicalName(
+                HtmlLexer.canonicalElementName(
                     htmlContent.substring(token.start + 1, token.end)),
                 attrs);
           }

--- a/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -187,7 +187,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
          attrIt.hasNext();) {
       String name = attrIt.next();
       String value = attrIt.next();
-      name = HtmlLexer.canonicalName(name);
+      name = HtmlLexer.canonicalAttributeName(name);
       if (!isValidHtmlName(name)) {
         error("Invalid attr name", name);
         continue;
@@ -234,7 +234,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   private final void writeCloseTag(String uncanonElementName)
       throws IOException {
     if (!open) { throw new IllegalStateException(); }
-    String elementName = HtmlLexer.canonicalName(uncanonElementName);
+    String elementName = HtmlLexer.canonicalElementName(uncanonElementName);
     if (!isValidHtmlName(elementName)) {
       error("Invalid element name", elementName);
       return;
@@ -386,7 +386,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
    * that has more consistent semantics.
    */
   static String safeName(String unsafeElementName) {
-    String elementName = HtmlLexer.canonicalName(unsafeElementName);
+    String elementName = HtmlLexer.canonicalElementName(unsafeElementName);
 
     // Substitute a reliably non-raw-text element for raw-text and
     // plain-text elements.

--- a/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -97,7 +97,7 @@ public class TagBalancingHtmlStreamEventReceiver
     if (DEBUG) {
       dumpState("open " + elementName);
     }
-    String canonElementName = HtmlLexer.canonicalName(elementName);
+    String canonElementName = HtmlLexer.canonicalElementName(elementName);
 
     int elIndex = METADATA.indexForName(canonElementName);
     // Treat unrecognized tags as void, but emit closing tags in closeTag().
@@ -238,7 +238,7 @@ public class TagBalancingHtmlStreamEventReceiver
     if (DEBUG) {
       dumpState("close " + elementName);
     }
-    String canonElementName = HtmlLexer.canonicalName(elementName);
+    String canonElementName = HtmlLexer.canonicalElementName(elementName);
 
     int elIndex = METADATA.indexForName(canonElementName);
     if (elIndex == UNRECOGNIZED_TAG) {  // Allow unrecognized end tags through.

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -975,6 +975,25 @@ public class HtmlPolicyBuilderTest extends TestCase {
         sanitized);
   }
 
+  @Test
+  public static final void testSvgNames() {
+    PolicyFactory policyFactory = new HtmlPolicyBuilder()
+            .allowElements("svg", "animateColor")
+            .allowAttributes("viewBox").onElements("svg")
+            .toFactory();
+    String svg = "<svg viewBox=\"0 0 0 0\"><animateColor></animateColor></svg>";
+    assertEquals(svg, policyFactory.sanitize(svg));
+  }
+
+  @Test
+  public static final void testTextareaIsNotTextArea() {
+    String input = "<textarea>x</textarea><textArea>y</textArea>";
+    PolicyFactory textareaPolicy = new HtmlPolicyBuilder().allowElements("textarea").toFactory();
+    PolicyFactory textAreaPolicy = new HtmlPolicyBuilder().allowElements("textArea").toFactory();
+    assertEquals("<textarea>x</textarea>y", textareaPolicy.sanitize(input));
+    assertEquals("x<textArea>y</textArea>", textAreaPolicy.sanitize(input));
+  }
+
   private static String apply(HtmlPolicyBuilder b) {
     return apply(b, EXAMPLE);
   }


### PR DESCRIPTION
…s exactly

> Currently all names are converted to lowercase which is ok when
> you're using it for HTML only, but if there is an SVG image nested
> inside the HTML it breaks.  For example, when `viewBox` attribute is
> converted to `viewbox` the image is not displayed correctly.

This commit splits *HtmlLexer*.*canonicalName* into variants which preserve
items on whitelists derived from the SVG and MathML specifications, and
adjusts callers of *canonicalName* to use the appropriate variant.

Fixes #182

@wookie41 @zeeneir do you have an example that I can turn into a unit test?