### PR TITLE
Expose StandardUrlAttributePolicy

### DIFF
--- a/src/main/java/org/owasp/html/StandardUrlAttributePolicy.java
+++ b/src/main/java/org/owasp/html/StandardUrlAttributePolicy.java
@@ -33,9 +33,9 @@ package org.owasp.html;
  * {@code http}, {@code https}, {@code mailto}.
  */
 @TCB
-final class StandardUrlAttributePolicy implements AttributePolicy {
+public final class StandardUrlAttributePolicy implements AttributePolicy {
 
-  static final StandardUrlAttributePolicy INSTANCE
+  public static final StandardUrlAttributePolicy INSTANCE
       = new StandardUrlAttributePolicy();
 
   private StandardUrlAttributePolicy() { /* singleton */ }

--- a/src/test/java/org/owasp/html/StandardUrlAttributePolicyTest.java
+++ b/src/test/java/org/owasp/html/StandardUrlAttributePolicyTest.java
@@ -1,0 +1,25 @@
+package org.owasp.html;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class StandardUrlAttributePolicyTest extends TestCase {
+  @Test
+  public static final void testApply() {
+    AttributePolicy attrPolicy = StandardUrlAttributePolicy.INSTANCE;
+
+    assertEquals("http://stuff",
+        attrPolicy.apply("", "", "http://stuff"));
+
+    assertEquals("https://stuff",
+        attrPolicy.apply("", "", "https://stuff"));
+
+    assertEquals("mailto://stuff",
+        attrPolicy.apply("", "", "mailto://stuff"));
+
+    assertEquals("not-a-url",
+        attrPolicy.apply("", "", "not-a-url"));
+
+    assertNull(attrPolicy.apply("", "", "data://stuff"));
+  }
+}


### PR DESCRIPTION
This makes public the `StandardUrlAttributePolicy` class and its singleton, so other libraries can use it.

This is useful for the matcher in step 4 of the "Inline/Embedded Images" pattern (https://owasp.org/www-project-java-html-sanitizer/migrated_content) to allow the data protocol for inline images.