### PR TITLE
Fix allowAttributes().globally() (#247)

### DIFF
--- a/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -968,12 +968,11 @@ public class HtmlPolicyBuilder {
      */
     @SuppressWarnings("synthetic-access")
     public HtmlPolicyBuilder globally() {
-      if(!attributeNames.isEmpty() && attributeNames.get(0).equals("style")) {
-        return allowStyling();
-      } else {
-        return HtmlPolicyBuilder.this.allowAttributesGlobally(
-            policy, attributeNames);
+      if (attributeNames.contains("style")) {
+        allowStyling();
       }
+      return HtmlPolicyBuilder.this.allowAttributesGlobally(
+          policy, attributeNames);
     }
 
     /**

--- a/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -968,7 +968,7 @@ public class HtmlPolicyBuilder {
      */
     @SuppressWarnings("synthetic-access")
     public HtmlPolicyBuilder globally() {
-      if(attributeNames.get(0).equals("style")) {
+      if(!attributeNames.isEmpty() && attributeNames.get(0).equals("style")) {
         return allowStyling();
       } else {
         return HtmlPolicyBuilder.this.allowAttributesGlobally(

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -994,6 +994,11 @@ public class HtmlPolicyBuilderTest extends TestCase {
     assertEquals("x<textArea>y</textArea>", textAreaPolicy.sanitize(input));
   }
 
+  @Test
+  public static final void testHtmlPolicyBuilderDefinitionWithNoAttributesDefinedGlobally() {
+    new HtmlPolicyBuilder().allowElements().allowAttributes().globally().toFactory();
+  }
+
   private static String apply(HtmlPolicyBuilder b) {
     return apply(b, EXAMPLE);
   }


### PR DESCRIPTION
Add guard to .globally() method of HtmlPolicyBuilder to prevent
ArrayOutOfBoundsException when checking to see if the zeroth
element of the attributeNames list contains 'style'.

This restores behaviour present in version 202180219.1 which
allowed for an empty allowed attributes names list to be
specified globally through the builder.