### PR TITLE
Fix missing null checks in uses of consumeIdentOrUrlOrFunctions

### DIFF
--- a/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -440,6 +440,20 @@ public class HtmlSanitizerTest extends TestCase {
     }
   }
 
+  @Test
+  public static final void testIssue254SemicolonlessNamedCharactersInUrls() {
+    String input = "<a href=\"/test/?param1=valueOne&param2=valueTwo\">click me</a>";
+    String want = "<a href=\"/test/?param1&#61;valueOne&amp;param2&#61;valueTwo\">click me</a>";
+    assertEquals(want, sanitize(input));
+  }
+
+  @Test
+  public static final void testStylingCornerCase() {
+    String input = "<a style=\\006-\\000038";
+    String want = "";
+    assertEquals(want, sanitize(input));
+  }
+
   private static String sanitize(@Nullable String html) {
     StringBuilder sb = new StringBuilder();
     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(


### PR DESCRIPTION
CssTokens code assumed that consumeIdentOrUrlOrFunctions always
returned a token type and consumed characters.

This commit audits all uses of that function and checks that
they make progress.