### PR TITLE
Remove Guava dependency and update to Java 9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,8 +88,11 @@ application while protecting against XSS.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <guava.version>30.1-jre</guava.version>
+    <maven.compiler.source>9</maven.compiler.source>
+    <maven.compiler.target>9</maven.compiler.target>
+    <maven.compiler.release>9</maven.compiler.release>
   </properties>
+
 
   <build>
     <pluginManagement>
@@ -184,8 +187,8 @@ application while protecting against XSS.
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.3</version>
           <configuration>
-            <source>6</source>
-            <target>6</target>
+            <source>9</source>
+            <target>9</target>
           </configuration>
         </plugin>
         <plugin>
@@ -235,14 +238,9 @@ application while protecting against XSS.
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>[1.4,)</version>
+        <version>[1.15,)</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Export-Package>org.owasp.html</Export-Package>
+          </instructions>
+        </configuration>
       </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -81,10 +86,6 @@
   </build>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>

--- a/src/main/java/org/owasp/html/AttributePolicy.java
+++ b/src/main/java/org/owasp/html/AttributePolicy.java
@@ -28,9 +28,8 @@
 
 package org.owasp.html;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.CheckReturnValue;
@@ -91,11 +90,11 @@ import org.owasp.html.Joinable.JoinHelper;
       }
 
       @Override
-      Optional<ImmutableList<AttributePolicy>> split(AttributePolicy x) {
+		Optional<List<AttributePolicy>> split(AttributePolicy x) {
         if (x instanceof JoinedAttributePolicy) {
           return Optional.of(((JoinedAttributePolicy) x).policies);
         } else {
-          return Optional.absent();
+			return Optional.empty();
         }
       }
 

--- a/src/main/java/org/owasp/html/CssSchema.java
+++ b/src/main/java/org/owasp/html/CssSchema.java
@@ -28,17 +28,17 @@
 
 package org.owasp.html;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 import javax.annotation.Nullable;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /** Describes the kinds of tokens a CSS property's value can safely contain. */
 @TCB
@@ -54,11 +54,11 @@ public final class CssSchema {
     /** A bitfield of BIT_* constants describing groups of allowed tokens. */
     final int bits;
     /** Specific allowed values. */
-    final ImmutableSet<String> literals;
+	final Set<String> literals;
     /**
      * Maps lower-case function tokens to the schema key for their parameters.
      */
-    final ImmutableMap<String, String> fnKeys;
+	final Map<String, String> fnKeys;
 
     /**
      * @param bits A bitfield of BIT_* constants describing groups of allowed tokens.
@@ -66,11 +66,11 @@ public final class CssSchema {
      * @param fnKeys Maps lower-case function tokens to the schema key for their parameters.
      */
     public Property(
-        int bits, ImmutableSet<String> literals,
-        ImmutableMap<String, String> fnKeys) {
+        int bits, Set<String> literals,
+        Map<String, String> fnKeys) {
       this.bits = bits;
-      this.literals = literals;
-      this.fnKeys = fnKeys;
+      this.literals = Set.copyOf(literals);
+      this.fnKeys = Map.copyOf(fnKeys);
     }
 
     @Override
@@ -125,11 +125,11 @@ public final class CssSchema {
   static final int BIT_UNICODE_RANGE = 128;
 
   static final Property DISALLOWED = new Property(
-      0, ImmutableSet.<String>of(), ImmutableMap.<String, String>of());
+      0, Collections.emptySet(), Collections.emptyMap());
 
-  private final ImmutableMap<String, Property> properties;
+  private final Map<String, Property> properties;
 
-  private CssSchema(ImmutableMap<String, Property> properties) {
+  private CssSchema(Map<String, Property> properties) {
     if (properties == null) { throw new NullPointerException(); }
     this.properties = properties;
   }
@@ -144,14 +144,14 @@ public final class CssSchema {
    */
   public static CssSchema withProperties(
       Iterable<? extends String> propertyNames) {
-    ImmutableMap.Builder<String, Property> propertiesBuilder =
-        ImmutableMap.builder();
+    Map<String, Property> propertiesBuilder =
+        new HashMap<>();
     for (String propertyName : propertyNames) {
       Property prop = DEFINITIONS.get(propertyName);
       if (prop == null) { throw new IllegalArgumentException(propertyName); }
       propertiesBuilder.put(propertyName, prop);
     }
-    return new CssSchema(propertiesBuilder.build());
+    return new CssSchema(Map.copyOf(propertiesBuilder));
   }
 
   /**
@@ -161,8 +161,8 @@ public final class CssSchema {
    */
   public static CssSchema withProperties(
       Map<? extends String, ? extends Property> properties) {
-    ImmutableMap<String, Property> propertyMap =
-        ImmutableMap.copyOf(properties);
+    Map<String, Property> propertyMap =
+        new HashMap<>();
     // check that all fnKeys are defined in properties.
     for (Map.Entry<String, Property> e : propertyMap.entrySet()) {
       Property property = e.getValue();
@@ -174,7 +174,7 @@ public final class CssSchema {
         }
       }
     }
-    return new CssSchema(propertyMap);
+    return new CssSchema(Map.copyOf(propertyMap));
   }
 
   /**
@@ -187,13 +187,17 @@ public final class CssSchema {
    */
   public static CssSchema union(CssSchema... cssSchemas) {
     if (cssSchemas.length == 1) { return cssSchemas[0]; }
-    Map<String, Property> properties = Maps.newLinkedHashMap();
+    Map<String, Property> properties = new LinkedHashMap<>();
     for (CssSchema cssSchema : cssSchemas) {
       for (Map.Entry<String, Property> e : cssSchema.properties.entrySet()) {
         String name = e.getKey();
         Property newProp = e.getValue();
-        Preconditions.checkNotNull(name);
-        Preconditions.checkNotNull(newProp);
+        if (Objects.isNull(name)) {
+          throw new NullPointerException("An entry was returned with null key from cssSchema.properties");
+        }
+        if (Objects.isNull(newProp)) {
+          throw new NullPointerException("An entry was returned with null value from cssSchema.properties");
+        }
         Property oldProp = properties.put(name, newProp);
         if (oldProp != null && !oldProp.equals(newProp)) {
           throw new IllegalArgumentException(
@@ -201,7 +205,7 @@ public final class CssSchema {
         }
       }
     }
-    return new CssSchema(ImmutableMap.copyOf(properties));
+    return new CssSchema(Map.copyOf(properties));
   }
 
   /**
@@ -221,6 +225,7 @@ public final class CssSchema {
     int n = propertyNameCanon.length();
     if (n != 0 && propertyNameCanon.charAt(0) == '-') {
       String barePropertyNameCanon = stripVendorPrefix(propertyNameCanon);
+      if (barePropertyNameCanon == null) { return DISALLOWED; }
       property = properties.get(barePropertyNameCanon);
       if (property != null) { return property; }
     }
@@ -252,14 +257,13 @@ public final class CssSchema {
   }
 
   /** Maps lower-cased CSS property names to information about them. */
-  static final ImmutableMap<String, Property> DEFINITIONS;
+  static final Map<String, Property> DEFINITIONS;
   static {
-    ImmutableMap<String, String> zeroFns = ImmutableMap.of();
-    ImmutableMap.Builder<String, Property> builder
-        = ImmutableMap.builder();
-    ImmutableSet<String> mozBorderRadiusLiterals0 = ImmutableSet.of("/");
-    ImmutableSet<String> mozOpacityLiterals0 = ImmutableSet.of("inherit");
-    ImmutableSet<String> mozOutlineLiterals0 = ImmutableSet.of(
+    Map<String, String> zeroFns = Collections.emptyMap();
+    Map<String, Property> builder = new HashMap<>();
+    Set<String> mozBorderRadiusLiterals0 = Set.of("/");
+    Set<String> mozOpacityLiterals0 = Set.of("inherit");
+    Set<String> mozOutlineLiterals0 = Set.of(
         "aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige",
         "bisque", "black", "blanchedalmond", "blue", "blueviolet", "brown",
         "burlywood", "cadetblue", "chartreuse", "chocolate", "coral",
@@ -287,122 +291,121 @@ public final class CssSchema {
         "silver", "skyblue", "slateblue", "slategray", "snow", "springgreen",
         "steelblue", "tan", "teal", "thistle", "tomato", "turquoise", "violet",
         "wheat", "white", "whitesmoke", "yellow", "yellowgreen");
-    ImmutableSet<String> mozOutlineLiterals1 = ImmutableSet.of(
+    Set<String> mozOutlineLiterals1 = Set.of(
         "dashed", "dotted", "double", "groove", "outset", "ridge", "solid");
-    ImmutableSet<String> mozOutlineLiterals2 = ImmutableSet.of("thick", "thin");
-    ImmutableSet<String> mozOutlineLiterals3 = ImmutableSet.of(
+    Set<String> mozOutlineLiterals2 = Set.of("thick", "thin");
+    Set<String> mozOutlineLiterals3 = Set.of(
         "hidden", "inherit", "inset", "invert", "medium", "none");
-    ImmutableMap<String, String> mozOutlineFunctions =
-      ImmutableMap.<String, String>of(
+    Map<String, String> mozOutlineFunctions =
+      Map.<String, String>of(
         "rgb(", "rgb()", "rgba(", "rgba()",
         "hsl(", "hsl()", "hsla(", "hsla()");
-    ImmutableSet<String> mozOutlineColorLiterals0 =
-      ImmutableSet.of("inherit", "invert");
-    ImmutableSet<String> mozOutlineStyleLiterals0 =
-      ImmutableSet.of("hidden", "inherit", "inset", "none");
-    ImmutableSet<String> mozOutlineWidthLiterals0 =
-      ImmutableSet.of("inherit", "medium");
-    ImmutableSet<String> oTextOverflowLiterals0 =
-      ImmutableSet.of("clip", "ellipsis");
-    ImmutableSet<String> azimuthLiterals0 = ImmutableSet.of(
+    Set<String> mozOutlineColorLiterals0 =
+      Set.of("inherit", "invert");
+    Set<String> mozOutlineStyleLiterals0 =
+      Set.of("hidden", "inherit", "inset", "none");
+    Set<String> mozOutlineWidthLiterals0 =
+      Set.of("inherit", "medium");
+    Set<String> oTextOverflowLiterals0 =
+      Set.of("clip", "ellipsis");
+    Set<String> azimuthLiterals0 = Set.of(
         "behind", "center-left", "center-right", "far-left", "far-right",
         "left-side", "leftwards", "right-side", "rightwards");
-    ImmutableSet<String> azimuthLiterals1 = ImmutableSet.of("left", "right");
-    ImmutableSet<String> azimuthLiterals2 =
-      ImmutableSet.of("center", "inherit");
-    ImmutableSet<String> backgroundLiterals0 = ImmutableSet.of(
+    Set<String> azimuthLiterals1 = Set.of("left", "right");
+    Set<String> azimuthLiterals2 =
+      Set.of("center", "inherit");
+    Set<String> backgroundLiterals0 = Set.of(
         "border-box", "contain", "content-box", "cover", "padding-box");
-    ImmutableSet<String> backgroundLiterals1 =
-      ImmutableSet.of("no-repeat", "repeat-x", "repeat-y", "round", "space");
-    ImmutableSet<String> backgroundLiterals2 = ImmutableSet.of("bottom", "top");
-    ImmutableSet<String> backgroundLiterals3 = ImmutableSet.of(
+    Set<String> backgroundLiterals1 =
+      Set.of("no-repeat", "repeat-x", "repeat-y", "round", "space");
+    Set<String> backgroundLiterals2 = Set.of("bottom", "top");
+    Set<String> backgroundLiterals3 = Set.of(
         ",", "/", "auto", "center", "fixed", "inherit", "local", "none",
         "repeat", "scroll", "transparent");
-    ImmutableMap<String, String> backgroundFunctions =
-      ImmutableMap.<String, String>builder()
-      .put("image(", "image()")
-      .put("linear-gradient(", "linear-gradient()")
-      .put("radial-gradient(", "radial-gradient()")
-      .put("repeating-linear-gradient(", "repeating-linear-gradient()")
-      .put("repeating-radial-gradient(", "repeating-radial-gradient()")
-      .put("rgb(", "rgb()").put("rgba(", "rgba()")
-      .put("hsl(", "hsl()").put("hsla(", "hsla()")
-      .build();
-    ImmutableSet<String> backgroundAttachmentLiterals0 =
-      ImmutableSet.of(",", "fixed", "local", "scroll");
-    ImmutableSet<String> backgroundColorLiterals0 =
-      ImmutableSet.of("inherit", "transparent");
-    ImmutableSet<String> backgroundImageLiterals0 =
-      ImmutableSet.of(",", "none");
-    ImmutableMap<String, String> backgroundImageFunctions =
-      ImmutableMap.<String, String>of(
+    Map<String, String> backgroundFunctions =
+      Map.of(
+      "image(", "image()",
+      "linear-gradient(", "linear-gradient()",
+      "radial-gradient(", "radial-gradient()",
+      "repeating-linear-gradient(", "repeating-linear-gradient()",
+      "repeating-radial-gradient(", "repeating-radial-gradient()",
+      "rgb(", "rgb()", "rgba(", "rgba()",
+      "hsl(", "hsl()", "hsla(", "hsla()");
+    Set<String> backgroundAttachmentLiterals0 =
+      Set.of(",", "fixed", "local", "scroll");
+    Set<String> backgroundColorLiterals0 =
+      Set.of("inherit", "transparent");
+    Set<String> backgroundImageLiterals0 =
+      Set.of(",", "none");
+    Map<String, String> backgroundImageFunctions =
+      Map.<String, String>of(
           "image(", "image()",
           "linear-gradient(", "linear-gradient()",
           "radial-gradient(", "radial-gradient()",
           "repeating-linear-gradient(", "repeating-linear-gradient()",
           "repeating-radial-gradient(", "repeating-radial-gradient()");
-    ImmutableSet<String> backgroundPositionLiterals0 = ImmutableSet.of(
+    Set<String> backgroundPositionLiterals0 = Set.of(
         ",", "center");
-    ImmutableSet<String> backgroundRepeatLiterals0 = ImmutableSet.of(
+    Set<String> backgroundRepeatLiterals0 = Set.of(
         ",", "repeat");
-    ImmutableSet<String> borderLiterals0 = ImmutableSet.of(
+    Set<String> borderLiterals0 = Set.of(
         "hidden", "inherit", "inset", "medium", "none", "transparent");
-    ImmutableSet<String> borderCollapseLiterals0 = ImmutableSet.of(
+    Set<String> borderCollapseLiterals0 = Set.of(
         "collapse", "inherit", "separate");
-    ImmutableSet<String> bottomLiterals0 = ImmutableSet.of("auto", "inherit");
-    ImmutableSet<String> boxShadowLiterals0 = ImmutableSet.of(
+    Set<String> bottomLiterals0 = Set.of("auto", "inherit");
+    Set<String> boxShadowLiterals0 = Set.of(
         ",", "inset", "none");
-    ImmutableSet<String> clearLiterals0 = ImmutableSet.of(
+    Set<String> clearLiterals0 = Set.of(
         "both", "inherit", "none");
-    ImmutableMap<String, String> clipFunctions =
-        ImmutableMap.<String, String>of("rect(", "rect()");
-    ImmutableSet<String> contentLiterals0 = ImmutableSet.of("none", "normal");
-    ImmutableSet<String> cueLiterals0 = ImmutableSet.of("inherit", "none");
-    ImmutableSet<String> cursorLiterals0 = ImmutableSet.of(
+    Map<String, String> clipFunctions =
+        Map.<String, String>of("rect(", "rect()");
+    Set<String> contentLiterals0 = Set.of("none", "normal");
+    Set<String> cueLiterals0 = Set.of("inherit", "none");
+    Set<String> cursorLiterals0 = Set.of(
         "all-scroll", "col-resize", "crosshair", "default", "e-resize",
         "hand", "help", "move", "n-resize", "ne-resize", "no-drop",
         "not-allowed", "nw-resize", "pointer", "progress", "row-resize",
         "s-resize", "se-resize", "sw-resize", "text", "vertical-text",
         "w-resize", "wait");
-    ImmutableSet<String> cursorLiterals1 = ImmutableSet.of(
+    Set<String> cursorLiterals1 = Set.of(
         ",", "auto", "inherit");
-    ImmutableSet<String> directionLiterals0 = ImmutableSet.of("ltr", "rtl");
-    ImmutableSet<String> displayLiterals0 = ImmutableSet.of(
+    Set<String> directionLiterals0 = Set.of("ltr", "rtl");
+    Set<String> displayLiterals0 = Set.of(
         "-moz-inline-box", "-moz-inline-stack", "block", "inline",
         "inline-block", "inline-table", "list-item", "run-in", "table",
         "table-caption", "table-cell", "table-column", "table-column-group",
         "table-footer-group", "table-header-group", "table-row",
         "table-row-group");
-    ImmutableSet<String> elevationLiterals0 = ImmutableSet.of(
+    Set<String> elevationLiterals0 = Set.of(
         "above", "below", "higher", "level", "lower");
-    ImmutableSet<String> emptyCellsLiterals0 = ImmutableSet.of("hide", "show");
-    //ImmutableMap<String, String> filterFunctions =
-    //  ImmutableMap.<String, String>of("alpha(", "alpha()");
-    ImmutableSet<String> fontLiterals0 = ImmutableSet.of(
+    Set<String> emptyCellsLiterals0 = Set.of("hide", "show");
+    //Map<String, String> filterFunctions =
+    //  Map.<String, String>of("alpha(", "alpha()");
+    Set<String> fontLiterals0 = Set.of(
         "100", "200", "300", "400", "500", "600", "700", "800", "900", "bold",
         "bolder", "lighter");
-    ImmutableSet<String> fontLiterals1 = ImmutableSet.of(
+    Set<String> fontLiterals1 = Set.of(
         "large", "larger", "small", "smaller", "x-large", "x-small",
         "xx-large", "xx-small", "xxx-large", "medium");
-    ImmutableSet<String> fontLiterals2 = ImmutableSet.of(
+    Set<String> fontLiterals2 = Set.of(
         "caption", "icon", "menu", "message-box", "small-caption",
         "status-bar");
-    ImmutableSet<String> fontLiterals3 = ImmutableSet.of(
+    Set<String> fontLiterals3 = Set.of(
         "cursive", "fantasy", "monospace", "sans-serif", "serif");
-    ImmutableSet<String> fontLiterals4 = ImmutableSet.of("italic", "oblique");
-    ImmutableSet<String> fontLiterals5 = ImmutableSet.of(
+    Set<String> fontLiterals4 = Set.of("italic", "oblique");
+    Set<String> fontLiterals5 = Set.of(
         ",", "/", "inherit", "medium", "normal", "small-caps");
-    ImmutableSet<String> fontFamilyLiterals0 = ImmutableSet.of(",", "inherit");
-    ImmutableSet<String> fontStretchLiterals0 = ImmutableSet.of(
+    Set<String> fontFamilyLiterals0 = Set.of(",", "inherit");
+    Set<String> fontStretchLiterals0 = Set.of(
         "condensed", "expanded", "extra-condensed", "extra-expanded",
         "narrower", "semi-condensed", "semi-expanded", "ultra-condensed",
         "ultra-expanded", "wider");
-    ImmutableSet<String> fontStretchLiterals1 = ImmutableSet.of("normal");
-    ImmutableSet<String> fontStyleLiterals0 = ImmutableSet.of(
+    Set<String> fontStretchLiterals1 = Set.of("normal");
+    Set<String> fontStyleLiterals0 = Set.of(
         "inherit", "normal");
-    ImmutableSet<String> fontVariantLiterals0 = ImmutableSet.of(
+    Set<String> fontVariantLiterals0 = Set.of(
         "inherit", "normal", "small-caps");
-    ImmutableSet<String> listStyleLiterals0 = ImmutableSet.of(
+    Set<String> listStyleLiterals0 = Set.of(
         "armenian", "cjk-decimal", "decimal", "decimal-leading-zero", "disc",
         "disclosure-closed", "disclosure-open", "ethiopic-numeric", "georgian",
         "hebrew", "hiragana", "hiragana-iroha", "japanese-formal",
@@ -412,78 +415,78 @@ public final class CssSchema {
         "lower-roman", "simp-chinese-formal", "simp-chinese-informal",
         "square", "trad-chinese-formal", "trad-chinese-informal",
         "upper-alpha", "upper-latin", "upper-roman");
-    ImmutableSet<String> listStyleLiterals1 = ImmutableSet.of(
+    Set<String> listStyleLiterals1 = Set.of(
         "inside", "outside");
-    ImmutableSet<String> listStyleLiterals2 = ImmutableSet.of(
+    Set<String> listStyleLiterals2 = Set.of(
         "circle", "inherit", "none");
-    ImmutableSet<String> maxHeightLiterals0 = ImmutableSet.of(
+    Set<String> maxHeightLiterals0 = Set.of(
         "auto", "inherit", "none");
-    ImmutableSet<String> overflowLiterals0 = ImmutableSet.of(
+    Set<String> overflowLiterals0 = Set.of(
         "auto", "hidden", "inherit", "scroll", "visible");
-    ImmutableSet<String> overflowXLiterals0 = ImmutableSet.of(
+    Set<String> overflowXLiterals0 = Set.of(
         "no-content", "no-display");
-    ImmutableSet<String> overflowXLiterals1 = ImmutableSet.of(
+    Set<String> overflowXLiterals1 = Set.of(
         "auto", "hidden", "scroll", "visible");
-    ImmutableSet<String> pageBreakAfterLiterals0 = ImmutableSet.of(
+    Set<String> pageBreakAfterLiterals0 = Set.of(
         "always", "auto", "avoid", "inherit");
-    ImmutableSet<String> pageBreakInsideLiterals0 = ImmutableSet.of(
+    Set<String> pageBreakInsideLiterals0 = Set.of(
         "auto", "avoid", "inherit");
-    ImmutableSet<String> pitchLiterals0 = ImmutableSet.of(
+    Set<String> pitchLiterals0 = Set.of(
         "high", "low", "x-high", "x-low");
-    ImmutableSet<String> playDuringLiterals0 = ImmutableSet.of(
+    Set<String> playDuringLiterals0 = Set.of(
         "auto", "inherit", "mix", "none", "repeat");
-    ImmutableSet<String> positionLiterals0 = ImmutableSet.of(
+    Set<String> positionLiterals0 = Set.of(
         "absolute", "relative", "static");
-    ImmutableSet<String> speakLiterals0 = ImmutableSet.of(
+    Set<String> speakLiterals0 = Set.of(
         "inherit", "none", "normal", "spell-out");
-    ImmutableSet<String> speakHeaderLiterals0 = ImmutableSet.of(
+    Set<String> speakHeaderLiterals0 = Set.of(
         "always", "inherit", "once");
-    ImmutableSet<String> speakNumeralLiterals0 = ImmutableSet.of(
+    Set<String> speakNumeralLiterals0 = Set.of(
         "continuous", "digits");
-    ImmutableSet<String> speakPunctuationLiterals0 = ImmutableSet.of(
+    Set<String> speakPunctuationLiterals0 = Set.of(
         "code", "inherit", "none");
-    ImmutableSet<String> speechRateLiterals0 = ImmutableSet.of(
+    Set<String> speechRateLiterals0 = Set.of(
         "fast", "faster", "slow", "slower", "x-fast", "x-slow");
-    ImmutableSet<String> tableLayoutLiterals0 = ImmutableSet.of(
+    Set<String> tableLayoutLiterals0 = Set.of(
         "auto", "fixed", "inherit");
-    ImmutableSet<String> textAlignLiterals0 = ImmutableSet.of(
+    Set<String> textAlignLiterals0 = Set.of(
         "center", "inherit", "justify");
-    ImmutableSet<String> textDecorationLiterals0 = ImmutableSet.of(
+    Set<String> textDecorationLiterals0 = Set.of(
         "blink", "line-through", "overline", "underline");
-    ImmutableSet<String> textTransformLiterals0 = ImmutableSet.of(
+    Set<String> textTransformLiterals0 = Set.of(
         "capitalize", "lowercase", "uppercase");
-    ImmutableSet<String> textWrapLiterals0 = ImmutableSet.of(
+    Set<String> textWrapLiterals0 = Set.of(
         "suppress", "unrestricted");
-    ImmutableSet<String> unicodeBidiLiterals0 = ImmutableSet.of(
+    Set<String> unicodeBidiLiterals0 = Set.of(
         "bidi-override", "embed");
-    ImmutableSet<String> verticalAlignLiterals0 = ImmutableSet.of(
+    Set<String> verticalAlignLiterals0 = Set.of(
         "baseline", "middle", "sub", "super", "text-bottom", "text-top");
-    ImmutableSet<String> visibilityLiterals0 = ImmutableSet.of(
+    Set<String> visibilityLiterals0 = Set.of(
         "collapse", "hidden", "inherit", "visible");
-    ImmutableSet<String> voiceFamilyLiterals0 = ImmutableSet.of(
+    Set<String> voiceFamilyLiterals0 = Set.of(
         "child", "female", "male");
-    ImmutableSet<String> volumeLiterals0 = ImmutableSet.of(
+    Set<String> volumeLiterals0 = Set.of(
         "loud", "silent", "soft", "x-loud", "x-soft");
-    ImmutableSet<String> whiteSpaceLiterals0 = ImmutableSet.of(
+    Set<String> whiteSpaceLiterals0 = Set.of(
         "-moz-pre-wrap", "-o-pre-wrap", "-pre-wrap", "nowrap", "pre",
         "pre-line", "pre-wrap");
-    ImmutableSet<String> wordWrapLiterals0 = ImmutableSet.of(
+    Set<String> wordWrapLiterals0 = Set.of(
         "break-word", "normal");
-    ImmutableSet<String> rgb$FunLiterals0 = ImmutableSet.of(",");
-    ImmutableSet<String> linearGradient$FunLiterals0 = ImmutableSet.of(
+    Set<String> rgb$FunLiterals0 = Set.of(",");
+    Set<String> linearGradient$FunLiterals0 = Set.of(
         ",", "to");
-    ImmutableSet<String> radialGradient$FunLiterals0 = ImmutableSet.of(
+    Set<String> radialGradient$FunLiterals0 = Set.of(
         "at", "closest-corner", "closest-side", "ellipse", "farthest-corner",
         "farthest-side");
-    ImmutableSet<String> radialGradient$FunLiterals1 = ImmutableSet.of(
+    Set<String> radialGradient$FunLiterals1 = Set.of(
         ",", "center", "circle");
-    ImmutableSet<String> rect$FunLiterals0 = ImmutableSet.of(",", "auto");
-    //ImmutableSet<String> alpha$FunLiterals0 = ImmutableSet.of("=", "opacity");
+    Set<String> rect$FunLiterals0 = Set.of(",", "auto");
+	//Set<String> alpha$FunLiterals0 = Set.of("=", "opacity");
     Property mozBorderRadius =
        new Property(5, mozBorderRadiusLiterals0, zeroFns);
     builder.put("-moz-border-radius", mozBorderRadius);
     Property mozBorderRadiusBottomleft =
-       new Property(5, ImmutableSet.<String>of(), zeroFns);
+       new Property(5, Set.<String>of(), zeroFns);
     builder.put("-moz-border-radius-bottomleft", mozBorderRadiusBottomleft);
     Property mozOpacity = new Property(1, mozOpacityLiterals0, zeroFns);
     builder.put("-moz-opacity", mozOpacity);
@@ -843,19 +846,18 @@ public final class CssSchema {
     builder.put("z-index", bottom);
     builder.put("repeating-linear-gradient()", linearGradient$Fun);
     builder.put("repeating-radial-gradient()", radialGradient$Fun);
-    DEFINITIONS = builder.build();
+	DEFINITIONS = Map.copyOf(builder);
   }
 
-  private static <T> ImmutableSet<T> union(
-      @SuppressWarnings("unchecked") ImmutableSet<T>... subsets) {
-    ImmutableSet.Builder<T> all = ImmutableSet.builder();
-    for (ImmutableSet<T> subset : subsets) {
+  private static <T> Set<T> union(Set<T>... subsets) {
+    Set<T> all = new HashSet<>();
+    for (Set<T> subset : subsets) {
       all.addAll(subset);
     }
-    return all.build();
+    return Set.copyOf(all);
   }
 
-  static final ImmutableSet<String> DEFAULT_WHITELIST = ImmutableSet.of(
+  static final Set<String> DEFAULT_WHITELIST = Set.of(
       "-moz-border-radius",
       "-moz-border-radius-bottomleft",
       "-moz-border-radius-bottomright",
@@ -1002,10 +1004,10 @@ public final class CssSchema {
 
   /** Dumps key and literal list to stdout for easy examination. */
   public static void main(String... argv) {
-    SortedSet<String> keys = Sets.newTreeSet();
-    SortedSet<String> literals = Sets.newTreeSet();
+    SortedSet<String> keys = new TreeSet<>();
+    SortedSet<String> literals = new TreeSet<>();
 
-    for (ImmutableMap.Entry<String, Property> e : DEFINITIONS.entrySet()) {
+    for (Map.Entry<String, Property> e : DEFINITIONS.entrySet()) {
       keys.add(e.getKey());
       literals.addAll(e.getValue().literals);
     }

--- a/src/main/java/org/owasp/html/CssTokens.java
+++ b/src/main/java/org/owasp/html/CssTokens.java
@@ -31,11 +31,10 @@ package org.owasp.html;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import javax.annotation.Nullable;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Given a string of CSS, produces a string of normalized CSS with certain
@@ -1464,34 +1463,34 @@ final class CssTokens implements Iterable<String> {
    * See http://dev.w3.org/csswg/css-values/#lengths and
    *     http://dev.w3.org/csswg/css-values/#other-units
    */
-  private static final Trie<Integer> UNIT_TRIE = new Trie<Integer>(
-      ImmutableMap.<String, Integer>builder()
-        .put("em", LENGTH_UNIT_TYPE)
-        .put("ex", LENGTH_UNIT_TYPE)
-        .put("ch", LENGTH_UNIT_TYPE)  // Width of zero character
-        .put("rem", LENGTH_UNIT_TYPE)  // Root element font-size
-        .put("vh", LENGTH_UNIT_TYPE)
-        .put("vw", LENGTH_UNIT_TYPE)
-        .put("vmin", LENGTH_UNIT_TYPE)
-        .put("vmax", LENGTH_UNIT_TYPE)
-        .put("px", LENGTH_UNIT_TYPE)
-        .put("mm", LENGTH_UNIT_TYPE)
-        .put("cm", LENGTH_UNIT_TYPE)
-        .put("in", LENGTH_UNIT_TYPE)
-        .put("pt", LENGTH_UNIT_TYPE)
-        .put("pc", LENGTH_UNIT_TYPE)
-        .put("deg", ANGLE_UNIT_TYPE)
-        .put("rad", ANGLE_UNIT_TYPE)
-        .put("grad", ANGLE_UNIT_TYPE)
-        .put("turn", ANGLE_UNIT_TYPE)
-        .put("s", TIME_UNIT_TYPE)
-        .put("ms", TIME_UNIT_TYPE)
-        .put("hz", FREQUENCY_UNIT_TYPE)
-        .put("khz", FREQUENCY_UNIT_TYPE)
-        .put("dpi", RESOLUTION_UNIT_TYPE)
-        .put("dpcm", RESOLUTION_UNIT_TYPE)
-        .put("dppx", RESOLUTION_UNIT_TYPE)
-        .build());
+  private static final Trie<Integer> UNIT_TRIE = new Trie<>(
+      Map.ofEntries(
+        Map.entry("em", LENGTH_UNIT_TYPE),
+        Map.entry("ex", LENGTH_UNIT_TYPE),
+        Map.entry("ch", LENGTH_UNIT_TYPE),  // Width of zero character
+        Map.entry("rem", LENGTH_UNIT_TYPE),  // Root element font-size
+        Map.entry("vh", LENGTH_UNIT_TYPE),
+        Map.entry("vw", LENGTH_UNIT_TYPE),
+        Map.entry("vmin", LENGTH_UNIT_TYPE),
+        Map.entry("vmax", LENGTH_UNIT_TYPE),
+        Map.entry("px", LENGTH_UNIT_TYPE),
+        Map.entry("mm", LENGTH_UNIT_TYPE),
+        Map.entry("cm", LENGTH_UNIT_TYPE),
+        Map.entry("in", LENGTH_UNIT_TYPE),
+        Map.entry("pt", LENGTH_UNIT_TYPE),
+        Map.entry("pc", LENGTH_UNIT_TYPE),
+        Map.entry("deg", ANGLE_UNIT_TYPE),
+        Map.entry("rad", ANGLE_UNIT_TYPE),
+        Map.entry("grad", ANGLE_UNIT_TYPE),
+        Map.entry("turn", ANGLE_UNIT_TYPE),
+        Map.entry("s", TIME_UNIT_TYPE),
+        Map.entry("ms", TIME_UNIT_TYPE),
+        Map.entry("hz", FREQUENCY_UNIT_TYPE),
+        Map.entry("khz", FREQUENCY_UNIT_TYPE),
+        Map.entry("dpi", RESOLUTION_UNIT_TYPE),
+        Map.entry("dpcm", RESOLUTION_UNIT_TYPE),
+        Map.entry("dppx", RESOLUTION_UNIT_TYPE))
+        );
 
   static boolean isWellKnownUnit(CharSequence s, int start, int end) {
     if (start == end) { return false; }

--- a/src/main/java/org/owasp/html/ElementAndAttributePolicies.java
+++ b/src/main/java/org/owasp/html/ElementAndAttributePolicies.java
@@ -28,9 +28,9 @@
 
 package org.owasp.html;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.Immutable;
 final class ElementAndAttributePolicies {
   final String elementName;
   final ElementPolicy elPolicy;
-  final ImmutableMap<String, AttributePolicy> attrPolicies;
+  final Map<String, AttributePolicy> attrPolicies;
   final HtmlTagSkipType htmlTagSkipType;
 
   ElementAndAttributePolicies(
@@ -53,15 +53,15 @@ final class ElementAndAttributePolicies {
       HtmlTagSkipType htmlTagSkipType) {
     this.elementName = elementName;
     this.elPolicy = elPolicy;
-    this.attrPolicies = ImmutableMap.copyOf(attrPolicies);
+    this.attrPolicies = Map.copyOf(attrPolicies);
     this.htmlTagSkipType = htmlTagSkipType;
   }
 
   ElementAndAttributePolicies and(ElementAndAttributePolicies p) {
     assert elementName.equals(p.elementName):
       elementName + " != " + p.elementName;
-    ImmutableMap.Builder<String, AttributePolicy> joinedAttrPolicies
-        = ImmutableMap.builder();
+    Map<String, AttributePolicy> joinedAttrPolicies
+        = new HashMap<>();
     for (Map.Entry<String, AttributePolicy> e : this.attrPolicies.entrySet()) {
       String attrName = e.getKey();
       AttributePolicy a = e.getValue();
@@ -81,7 +81,7 @@ final class ElementAndAttributePolicies {
     return new ElementAndAttributePolicies(
         elementName,
         ElementPolicy.Util.join(elPolicy, p.elPolicy),
-        joinedAttrPolicies.build(),
+        Map.copyOf(joinedAttrPolicies),
         this.htmlTagSkipType.and(p.htmlTagSkipType));
   }
 
@@ -98,7 +98,7 @@ final class ElementAndAttributePolicies {
             attrPolicy, globalAttrPolicy);
         if (!joined.equals(attrPolicy)) {
           if (anded == null) {
-            anded = Maps.newLinkedHashMap();
+            anded = new LinkedHashMap<>();
             anded.putAll(this.attrPolicies);
           }
           anded.put(attrName, joined);
@@ -109,7 +109,7 @@ final class ElementAndAttributePolicies {
       String attrName = e.getKey();
       if (!this.attrPolicies.containsKey(attrName)) {
         if (anded == null) {
-          anded = Maps.newLinkedHashMap();
+          anded = new LinkedHashMap<>();
           anded.putAll(this.attrPolicies);
         }
         anded.put(attrName, e.getValue());

--- a/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -28,15 +28,14 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 
 /**
  * A sanitizer policy that applies element and attribute policies to tags.
@@ -45,8 +44,8 @@ import com.google.common.collect.Lists;
 @NotThreadSafe
 class ElementAndAttributePolicyBasedSanitizerPolicy
     implements HtmlSanitizer.Policy {
-  final ImmutableMap<String, ElementAndAttributePolicies> elAndAttrPolicies;
-  final ImmutableSet<String> allowedTextContainers;
+  final Map<String, ElementAndAttributePolicies> elAndAttrPolicies;
+  final Set<String> allowedTextContainers;
   private final HtmlStreamEventReceiver out;
   /**
    * True to skip textual content.  Used to ignore the content of embedded CDATA
@@ -57,19 +56,19 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    * Alternating input names and adjusted names of elements opened by the
    * caller.
    */
-  private final List<String> openElementStack = Lists.newArrayList();
+  private final List<String> openElementStack = new ArrayList<>();
 
   ElementAndAttributePolicyBasedSanitizerPolicy(
       HtmlStreamEventReceiver out,
-      ImmutableMap<String, ElementAndAttributePolicies> elAndAttrPolicies,
-      ImmutableSet<String> allowedTextContainers) {
+      Map<String, ElementAndAttributePolicies> elAndAttrPolicies,
+      Set<String> allowedTextContainers) {
     this.out = out;
-    this.elAndAttrPolicies = elAndAttrPolicies;
-    this.allowedTextContainers = allowedTextContainers;
+    this.elAndAttrPolicies = Map.copyOf(elAndAttrPolicies);
+    this.allowedTextContainers = Set.copyOf(allowedTextContainers);
   }
 
-  static final ImmutableSet<String> SKIPPABLE_ELEMENT_CONTENT
-      = ImmutableSet.of(
+  static final Set<String> SKIPPABLE_ELEMENT_CONTENT
+      = Set.of(
           "script", "style", "noscript", "nostyle", "noembed", "noframes",
           "iframe", "object", "frame", "frameset", "title");
 

--- a/src/main/java/org/owasp/html/ElementPolicy.java
+++ b/src/main/java/org/owasp/html/ElementPolicy.java
@@ -28,16 +28,15 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.owasp.html.Joinable.JoinHelper;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 
 /**
  * A policy that can be applied to an element to decide whether or not to
@@ -90,11 +89,11 @@ import com.google.common.collect.ImmutableList;
       }
 
       @Override
-      Optional<ImmutableList<ElementPolicy>> split(ElementPolicy x) {
+      Optional<List<ElementPolicy>> split(ElementPolicy x) {
         if (x instanceof JoinedElementPolicy) {
           return Optional.of(((JoinedElementPolicy) x).policies);
         }
-        return Optional.absent();
+        return Optional.empty();
       }
 
       @Override
@@ -129,10 +128,12 @@ import com.google.common.collect.ImmutableList;
 
 @Immutable
 final class JoinedElementPolicy implements ElementPolicy {
-  final ImmutableList<ElementPolicy> policies;
+  final List<ElementPolicy> policies;
 
   JoinedElementPolicy(Iterable<? extends ElementPolicy> policies) {
-    this.policies = ImmutableList.copyOf(policies);
+    List<ElementPolicy> builder = new ArrayList<>();
+	policies.forEach(builder::add);
+    this.policies = List.copyOf(builder);
   }
 
   public @Nullable String apply(String elementName, List<String> attrs) {

--- a/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
+++ b/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
@@ -28,9 +28,10 @@
 
 package org.owasp.html;
 
-import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
+import javax.annotation.Nullable;
 
 /**
  * An attribute policy for attributes whose values are URLs that requires that
@@ -56,14 +57,16 @@ import com.google.common.collect.ImmutableSet;
  */
 @TCB
 public class FilterUrlByProtocolAttributePolicy implements AttributePolicy {
-  private final ImmutableSet<String> protocols;
+  private final Set<String> protocols;
 
   /**
    * @param protocols lower-case protocol names without any trailing colon (":")
    */
   public FilterUrlByProtocolAttributePolicy(
       Iterable<? extends String> protocols) {
-    this.protocols = ImmutableSet.copyOf(protocols);
+    Set<String> builder = new HashSet<>();
+    protocols.forEach(builder::add);
+    this.protocols = Set.copyOf(builder);
   }
 
   public @Nullable String apply(

--- a/src/main/java/org/owasp/html/HtmlEntities.java
+++ b/src/main/java/org/owasp/html/HtmlEntities.java
@@ -28,9 +28,8 @@
 
 package org.owasp.html;
 
+import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Utilities for decoding HTML entities, e.g., {@code &amp;}.
@@ -2279,7 +2278,7 @@ final class HtmlEntities {
       "zwnj;", "\u200c",
     };
 
-    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    final Map<String, String> builder = new HashMap<>();
 
     int longestEntityName = 0;
     for (int i = 0, n = pairs.length; i < n; i += 2) {
@@ -2291,7 +2290,7 @@ final class HtmlEntities {
       }
     }
 
-    final Map<String, String> entityNameToCodePointMap = builder.build();
+    final Map<String, String> entityNameToCodePointMap = Map.copyOf(builder);
 
     ENTITY_TRIE = new Trie<String>(entityNameToCodePointMap);
     LONGEST_ENTITY_NAME = longestEntityName;

--- a/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/src/main/java/org/owasp/html/HtmlLexer.java
@@ -28,8 +28,6 @@
 
 package org.owasp.html;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import java.util.LinkedList;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -235,7 +233,7 @@ final class HtmlLexer extends AbstractTokenStream {
     return HtmlToken.instance(a.start, b.end, a.type);
   }
 
-  private final LinkedList<HtmlToken> lookahead = Lists.newLinkedList();
+  private final LinkedList<HtmlToken> lookahead = new LinkedList<>();
   private HtmlToken readToken() {
     if (!lookahead.isEmpty()) {
       return lookahead.remove();
@@ -263,12 +261,12 @@ final class HtmlLexer extends AbstractTokenStream {
   }
 
   // From http://issues.apache.org/jira/browse/XALANC-519
-  private static final Set<String> VALUELESS_ATTRIB_NAMES = ImmutableSet.of(
+  private static final Set<String> VALUELESS_ATTRIB_NAMES = Set.of(
       "checked", "compact", "declare", "defer", "disabled",
       "ismap", "multiple", "nohref", "noresize", "noshade",
       "nowrap", "readonly", "selected");
 
-  private static final ImmutableSet<String> mixedCaseForeignAttributeNames = ImmutableSet.of(
+  private static final Set<String> mixedCaseForeignAttributeNames = Set.of(
           "attributeName",
           "attributeType",
           "baseFrequency",
@@ -349,7 +347,7 @@ final class HtmlLexer extends AbstractTokenStream {
           "zoomAndPan"
   );
 
-  private static final ImmutableSet<String> mixedCaseForeignElementNames = ImmutableSet.of(
+  private static final Set<String> mixedCaseForeignElementNames = Set.of(
           "animateColor",
           "animateMotion",
           "animateTransform",

--- a/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -32,8 +32,6 @@ import java.util.LinkedList;
 import java.util.List;
 import javax.annotation.Nullable;
 
-import com.google.common.collect.Lists;
-
 /**
  * Consumes an HTML stream, and dispatches events to a policy object which
  * decides which elements and attributes to allow.
@@ -138,7 +136,7 @@ public final class HtmlSanitizer {
     HtmlLexer lexer = new HtmlLexer(htmlContent);
     // Use a linked list so that policies can use Iterator.remove() in an O(1)
     // way.
-    LinkedList<String> attrs = Lists.newLinkedList();
+    LinkedList<String> attrs = new LinkedList<>();
     while (lexer.hasNext()) {
       HtmlToken token = lexer.next();
       switch (token.type) {

--- a/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -28,16 +28,12 @@
 
 package org.owasp.html;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
-
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
+
 import javax.annotation.WillCloseWhenClosed;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -355,7 +351,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     return innerStart;
   }
 
-  @VisibleForTesting
+  // only visible for testing
   static boolean isValidHtmlName(String name) {
     int n = name.length();
     if (n == 0) { return false; }

--- a/src/main/java/org/owasp/html/HtmlTextEscapingMode.java
+++ b/src/main/java/org/owasp/html/HtmlTextEscapingMode.java
@@ -28,7 +28,7 @@
 
 package org.owasp.html;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 /**
  * From section 8.1.2.6 of http://www.whatwg.org/specs/web-apps/current-work/
@@ -82,15 +82,15 @@ public enum HtmlTextEscapingMode {
   VOID,
   ;
 
-  private static final ImmutableMap<String, HtmlTextEscapingMode> ESCAPING_MODES
-      = ImmutableMap.<String, HtmlTextEscapingMode>builder()
-      .put("iframe", CDATA)
+  private static final Map<String, HtmlTextEscapingMode> ESCAPING_MODES
+      = Map.ofEntries(
+      Map.entry("iframe", CDATA),
       // HTML5 does not treat listing as CDATA and treats XMP as deprecated,
       // but HTML2 does at
       // http://www.w3.org/MarkUp/1995-archive/NonStandard.html
       // Listing is not supported by browsers.
-      .put("listing", CDATA_SOMETIMES)
-      .put("xmp", CDATA)
+      Map.entry("listing", CDATA_SOMETIMES),
+      Map.entry("xmp", CDATA),
 
       // Technically, noembed, noscript and noframes are CDATA_SOMETIMES but
       // we can only be hurt by allowing tag content that looks like text so
@@ -98,41 +98,40 @@ public enum HtmlTextEscapingMode {
       //.put("noembed", CDATA_SOMETIMES)
       //.put("noframes", CDATA_SOMETIMES)
       //.put("noscript", CDATA_SOMETIMES)
-      .put("comment", CDATA_SOMETIMES)  // IE only
+      Map.entry("comment", CDATA_SOMETIMES),  // IE only
 
       // Runs till end of file.
-      .put("plaintext", PLAIN_TEXT)
+      Map.entry("plaintext", PLAIN_TEXT),
 
-      .put("script", CDATA)
-      .put("style", CDATA)
+      Map.entry("script", CDATA),
+      Map.entry("style", CDATA),
 
       // Textarea and Title are RCDATA, not CDATA, so decode entity references.
-      .put("textarea", RCDATA)
-      .put("title", RCDATA)
+      Map.entry("textarea", RCDATA),
+      Map.entry("title", RCDATA),
 
       // Nodes that can't contain content.
       // http://www.w3.org/TR/html-markup/syntax.html#void-elements
-      .put("area", VOID)
-      .put("base", VOID)
-      .put("br", VOID)
-      .put("col", VOID)
-      .put("command", VOID)
-      .put("embed", VOID)
-      .put("hr", VOID)
-      .put("img", VOID)
-      .put("input", VOID)
-      .put("keygen", VOID)
-      .put("link", VOID)
-      .put("meta", VOID)
-      .put("param", VOID)
-      .put("source", VOID)
-      .put("track", VOID)
-      .put("wbr", VOID)
+      Map.entry("area", VOID),
+      Map.entry("base", VOID),
+      Map.entry("br", VOID),
+      Map.entry("col", VOID),
+      Map.entry("command", VOID),
+      Map.entry("embed", VOID),
+      Map.entry("hr", VOID),
+      Map.entry("img", VOID),
+      Map.entry("input", VOID),
+      Map.entry("keygen", VOID),
+      Map.entry("link", VOID),
+      Map.entry("meta", VOID),
+      Map.entry("param", VOID),
+      Map.entry("source", VOID),
+      Map.entry("track", VOID),
+      Map.entry("wbr", VOID),
 
        // EMPTY per http://www.w3.org/TR/REC-html32#basefont
-      .put("basefont", VOID)
-      .put("isindex", VOID)
-      .build();
+      Map.entry("basefont", VOID),
+      Map.entry("isindex", VOID));
 
 
   /**

--- a/src/main/java/org/owasp/html/IntVector.java
+++ b/src/main/java/org/owasp/html/IntVector.java
@@ -1,7 +1,5 @@
 package org.owasp.html;
 
-import com.google.common.base.Preconditions;
-
 final class IntVector {
   private int[] contents = ZERO_INTS;
   private int left, size;
@@ -39,7 +37,9 @@ final class IntVector {
   }
 
   public int remove(int i) {
-    Preconditions.checkArgument(0 <= i && i < size);
+    if (i < 0 || i >= size) {
+      throw new IllegalArgumentException("Invalid index");
+    }
     int bufsize = contents.length;
     int idx = (left + i) % bufsize;
     int result = contents[idx];
@@ -56,7 +56,9 @@ final class IntVector {
       // They do.
       int itemShiftedAround = contents[0];
       int right = (left + size) % bufsize;
-      Preconditions.checkState(right <= left);
+      if (right > left) {
+        throw new IllegalStateException();
+      }
       System.arraycopy(contents, 1, contents, 0, right);
       System.arraycopy(contents, idx + 1, contents, idx, bufsize - idx - 1);
       contents[bufsize - 1] = itemShiftedAround;

--- a/src/main/java/org/owasp/html/Joinable.java
+++ b/src/main/java/org/owasp/html/Joinable.java
@@ -1,14 +1,12 @@
 package org.owasp.html;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * Something that can request special joining.
@@ -54,8 +52,8 @@ interface Joinable<T> {
         T identityValue) {
       this.baseType = baseType;
       this.specialJoinableType = specialJoinableType;
-      this.zeroValue = Preconditions.checkNotNull(zeroValue);
-      this.identityValue = Preconditions.checkNotNull(identityValue);
+      this.zeroValue = Objects.requireNonNull(zeroValue);
+      this.identityValue = Objects.requireNonNull(identityValue);
     }
 
     abstract Optional<? extends Iterable<? extends T>> split(T x);
@@ -76,17 +74,17 @@ interface Joinable<T> {
         JoinStrategy<SJ> strategy = sj.getJoinStrategy();
 
         if (requireSpecialJoining == null) {
-          requireSpecialJoining = Maps.newLinkedHashMap();
+          requireSpecialJoining = new LinkedHashMap<Joinable.JoinStrategy<SJ>, Set<SJ>>();
         }
         Set<SJ> toJoinTogether = requireSpecialJoining.get(strategy);
         if (toJoinTogether == null) {
-          toJoinTogether = Sets.newLinkedHashSet();
+          toJoinTogether = new LinkedHashSet<SJ>();
           requireSpecialJoining.put(strategy, toJoinTogether);
         }
 
         toJoinTogether.add(sj);
       } else {
-        uniq.add(Preconditions.checkNotNull(x));
+        uniq.add(Objects.requireNonNull(x));
       }
     }
 
@@ -111,7 +109,7 @@ interface Joinable<T> {
               ? toJoin.iterator().next()
               : strategy.join(toJoin);
 
-          uniq.add(Preconditions.checkNotNull(baseType.cast(joined)));
+          uniq.add(Objects.requireNonNull(baseType.cast(joined)));
         }
       }
 

--- a/src/main/java/org/owasp/html/JoinedAttributePolicy.java
+++ b/src/main/java/org/owasp/html/JoinedAttributePolicy.java
@@ -28,9 +28,10 @@
 
 package org.owasp.html;
 
-import com.google.common.collect.ImmutableList;
-
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -38,10 +39,10 @@ import javax.annotation.concurrent.Immutable;
 
 @Immutable
 final class JoinedAttributePolicy implements AttributePolicy {
-  final ImmutableList<AttributePolicy> policies;
+	final List<AttributePolicy> policies;
 
-  JoinedAttributePolicy(Collection<? extends AttributePolicy> policies) {
-    this.policies = ImmutableList.copyOf(policies);
+	JoinedAttributePolicy(Collection<? extends AttributePolicy> policies) {
+		this.policies = Collections.unmodifiableList(policies.stream().collect(Collectors.<AttributePolicy>toList()));
   }
 
   public @Nullable String apply(

--- a/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/src/main/java/org/owasp/html/StylingPolicy.java
@@ -28,16 +28,13 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
 import org.owasp.html.AttributePolicy.JoinableAttributePolicy;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.collect.Lists;
 
 /**
  * An HTML sanitizer policy that tries to preserve simple CSS by white-listing
@@ -67,7 +64,7 @@ final class StylingPolicy implements JoinableAttributePolicy {
    *
    * @return A sanitized version of the input.
    */
-  @VisibleForTesting
+  //only visible for testing
   String sanitizeCssProperties(String style) {
     final StringBuilder sanitizedCss = new StringBuilder();
     CssGrammar.parsePropertyGroup(style, new CssGrammar.PropertyHandler() {
@@ -129,7 +126,7 @@ final class StylingPolicy implements JoinableAttributePolicy {
 
       public void startFunction(String uncanonToken) {
         closeQuotedIdents();
-        if (cssProperties == null) { cssProperties = Lists.newArrayList(); }
+        if (cssProperties == null) { cssProperties = new ArrayList<>(); }
         cssProperties.add(cssProperty);
         String token = Strings.toLowerCase(uncanonToken);
         String key = cssProperty.fnKeys.get(token);
@@ -274,7 +271,7 @@ final class StylingPolicy implements JoinableAttributePolicy {
 
     public JoinableAttributePolicy join(
         Iterable<? extends JoinableAttributePolicy> toJoin) {
-      Function<String, String> identity = Functions.<String>identity();
+      Function<String, String> identity = Function.<String>identity();
       CssSchema cssSchema = null;
       Function<String, String> urlRewriter = identity;
       for (JoinableAttributePolicy p : toJoin) {
@@ -284,7 +281,7 @@ final class StylingPolicy implements JoinableAttributePolicy {
         urlRewriter = urlRewriter.equals(identity)
             || urlRewriter.equals(sp.urlRewriter)
             ? sp.urlRewriter
-            : Functions.compose(urlRewriter, sp.urlRewriter);
+            : urlRewriter.compose(sp.urlRewriter);
       }
       return new StylingPolicy(cssSchema, urlRewriter);
     }

--- a/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -28,13 +28,11 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
 import org.owasp.html.HtmlElementTables.HtmlElementNames;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 /**
  * Wraps an HTML stream event receiver to fill in missing close tags.
@@ -125,7 +123,7 @@ public class TagBalancingHtmlStreamEventReceiver
       // Open implied elements, such as list-items and table cells & rows.
       int[] impliedElIndices = METADATA.impliedElements(top, elIndex);
       if (impliedElIndices.length != 0) {
-        List<String> attrs = Lists.<String>newArrayList();
+        List<String> attrs = new ArrayList<>();
 
         int startPos = 0;
         for (int i = 0, n = impliedElIndices.length; i < n; ++i) {
@@ -183,7 +181,7 @@ public class TagBalancingHtmlStreamEventReceiver
         if (openElements.size() < nestingLimit) {
           underlying.openTag(
               METADATA.canonNameForIndex(toResume),
-              Lists.<String>newArrayList());
+              new ArrayList<>());
         }
         openElements.add(toResume);
       } else {
@@ -216,7 +214,9 @@ public class TagBalancingHtmlStreamEventReceiver
    */
   private boolean canContain(
       int child, int container, int containerIndexOnStack) {
-    Preconditions.checkArgument(containerIndexOnStack >= 0);
+    if (containerIndexOnStack < 0) {
+      throw new IllegalArgumentException("negative container index");
+    }
     if (child == HtmlElementTables.TEXT_NODE && hasSpecialTextMode(container)) {
       // If there's a select element on the stack, then we need to be extra careful.
       int selectElementIndex = METADATA.indexForName("select");

--- a/src/main/java/org/owasp/html/examples/EbayPolicyExample.java
+++ b/src/main/java/org/owasp/html/examples/EbayPolicyExample.java
@@ -28,19 +28,19 @@
 
 package org.owasp.html.examples;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.owasp.html.Handler;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.HtmlSanitizer;
 import org.owasp.html.HtmlStreamRenderer;
 import org.owasp.html.PolicyFactory;
-
-import com.google.common.base.Charsets;
-import com.google.common.base.Predicate;
-import com.google.common.io.CharStreams;
 
 /**
  * Based on the
@@ -208,8 +208,10 @@ public class EbayPolicyExample {
     }
     System.err.println("[Reading from STDIN]");
     // Fetch the HTML to sanitize.
-    String html = CharStreams.toString(
-        new InputStreamReader(System.in, Charsets.UTF_8));
+	String html = new BufferedReader(
+        new InputStreamReader(System.in, StandardCharsets.UTF_8))
+            .lines()
+	        .collect(Collectors.joining("\n"));
     // Set up an output channel to receive the sanitized HTML.
     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(
         System.out,

--- a/src/main/java/org/owasp/html/examples/SlashdotPolicyExample.java
+++ b/src/main/java/org/owasp/html/examples/SlashdotPolicyExample.java
@@ -28,19 +28,19 @@
 
 package org.owasp.html.examples;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.owasp.html.Handler;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.HtmlSanitizer;
 import org.owasp.html.HtmlStreamEventReceiver;
 import org.owasp.html.HtmlStreamRenderer;
-
-import com.google.common.base.Charsets;
-import com.google.common.base.Function;
-import com.google.common.io.CharStreams;
 
 /**
  * Based on the
@@ -99,8 +99,10 @@ public class SlashdotPolicyExample {
     }
     System.err.println("[Reading from STDIN]");
     // Fetch the HTML to sanitize.
-    String html = CharStreams.toString(
-        new InputStreamReader(System.in, Charsets.UTF_8));
+    String html = new BufferedReader(
+        new InputStreamReader(System.in, StandardCharsets.UTF_8))
+            .lines()
+            .collect(Collectors.joining("\n"));
     // Set up an output channel to receive the sanitized HTML.
     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(
         System.out,

--- a/src/main/java/org/owasp/html/examples/UrlTextExample.java
+++ b/src/main/java/org/owasp/html/examples/UrlTextExample.java
@@ -30,16 +30,16 @@ package org.owasp.html.examples;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.HtmlStreamEventProcessor;
 import org.owasp.html.HtmlStreamEventReceiver;
 import org.owasp.html.HtmlStreamEventReceiverWrapper;
 import org.owasp.html.HtmlTextEscapingMode;
 import org.owasp.html.PolicyFactory;
-import org.owasp.html.HtmlStreamEventProcessor;
-
-import com.google.common.base.Joiner;
 
 /**
  * Uses a custom event receiver to emit the domain of a link or inline image
@@ -134,7 +134,7 @@ public class UrlTextExample {
           }
       ).toFactory();
 
-    out.append(policyBuilder.sanitize(Joiner.on('\n').join(inputs)));
+    out.append(policyBuilder.sanitize(Arrays.stream(inputs).collect(Collectors.joining("\n"))));
   }
 
   /**

--- a/src/test/java/org/owasp/html/Benchmark.java
+++ b/src/test/java/org/owasp/html/Benchmark.java
@@ -30,14 +30,13 @@ package org.owasp.html;
 
 import java.io.File;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.ListIterator;
 
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
-
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 
 import nu.validator.htmlparser.dom.HtmlDocumentBuilder;
 
@@ -59,7 +58,7 @@ public class Benchmark {
    * specifies a benchmark to run and unspecified ones are not run.
    */
   public static void main(String[] args) throws Exception {
-    String html = Files.asCharSource(new File(args[0]), Charsets.UTF_8).read();
+    String html = Files.readString(new File(args[0]).toPath(), StandardCharsets.UTF_8);
 
     boolean timeLibhtmlparser = true;
     boolean timeSanitize = true;

--- a/src/test/java/org/owasp/html/CssFuzzerTest.java
+++ b/src/test/java/org/owasp/html/CssFuzzerTest.java
@@ -36,8 +36,6 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 import org.owasp.html.CssTokens.TokenType;
 
-import com.google.common.collect.Maps;
-
 @SuppressWarnings("javadoc")
 public class CssFuzzerTest extends FuzzyTestCase {
 
@@ -171,7 +169,7 @@ public class CssFuzzerTest extends FuzzyTestCase {
   }
 
   private static final EnumMap<CssTokens.TokenType, Pattern> TOKEN_TYPE_FILTERS
-    = Maps.newEnumMap(CssTokens.TokenType.class);
+    = new EnumMap<>(CssTokens.TokenType.class);
   static {
     String NUMBER = "-?(?:0|[1-9][0-9]*)(?:\\.[0-9]*[1-9])?(?:e-?[1-9][0-9]*)?";
     String IDENT_START = "[a-zA-Z_\\u0080-\udbff\udfff\\-]";

--- a/src/test/java/org/owasp/html/CssGrammarTest.java
+++ b/src/test/java/org/owasp/html/CssGrammarTest.java
@@ -28,12 +28,12 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 
 import junit.framework.TestCase;
 
@@ -41,7 +41,7 @@ import junit.framework.TestCase;
 public class CssGrammarTest extends TestCase {
   @Test
   public static final void testLex() {
-    CssTokens tokens = CssTokens.lex(Joiner.on('\n').join(
+    CssTokens tokens = CssTokens.lex(Arrays.stream(new String[] {
         "/* A comment */",
         "words with-dashes #hashes .dots. -and-leading-dashes",
         "quantities: 3px 4ex -.5pt 12.5%",
@@ -50,9 +50,9 @@ public class CssGrammarTest extends TestCase {
         "rgb(255, 127, 127)",
         "'strings' \"oh \\\"my\" 'foo bar'",
         "color:blue!important",
-        ""));
+        ""}).collect(Collectors.joining("\n")));
 
-    List<String> actualTokens = Lists.newArrayList();
+    List<String> actualTokens = new ArrayList<>();
     for (CssTokens.TokenIterator it = tokens.iterator(); it.hasNext();) {
       CssTokens.TokenType type = it.type();
       String token = it.next();
@@ -62,7 +62,7 @@ public class CssGrammarTest extends TestCase {
     }
 
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             // "/* A comment */",  // Comments are elided.
             "words:IDENT",
             "with-dashes:IDENT",
@@ -103,8 +103,8 @@ public class CssGrammarTest extends TestCase {
             "!:DELIM",
             "important:IDENT",
             "]:RIGHT_SQUARE"  // Manufactured due to unmatched '['.
-            ),
-        Joiner.on('\n').join(actualTokens));
+        }).collect(Collectors.joining("\n")),
+        actualTokens.stream().collect(Collectors.joining("\n")));
   }
 
   @Test

--- a/src/test/java/org/owasp/html/CssTokensTest.java
+++ b/src/test/java/org/owasp/html/CssTokensTest.java
@@ -28,17 +28,23 @@
 
 package org.owasp.html;
 
+import static org.owasp.html.CssTokens.TokenType.COLUMN;
+import static org.owasp.html.CssTokens.TokenType.IDENT;
+import static org.owasp.html.CssTokens.TokenType.LEFT_PAREN;
+import static org.owasp.html.CssTokens.TokenType.LEFT_SQUARE;
+import static org.owasp.html.CssTokens.TokenType.RIGHT_PAREN;
+import static org.owasp.html.CssTokens.TokenType.RIGHT_SQUARE;
+import static org.owasp.html.CssTokens.TokenType.STRING;
+import static org.owasp.html.CssTokens.TokenType.WHITESPACE;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.junit.Test;
 import org.owasp.html.CssTokens.TokenType;
 
-import com.google.common.collect.Lists;
-
-import static org.owasp.html.CssTokens.TokenType.*;
+import junit.framework.TestCase;
 
 @SuppressWarnings({ "javadoc" })
 public class CssTokensTest extends TestCase {
@@ -58,9 +64,9 @@ public class CssTokensTest extends TestCase {
     CssTokens tokens = lex("([foo[[||]])");
     assertEquals("([foo[[||]]])", tokens.normalizedCss);
 
-    List<String> tokenTexts = Lists.newArrayList();
-    List<CssTokens.TokenType> types = Lists.newArrayList();
-    List<Integer> partners = Lists.newArrayList();
+	List<String> tokenTexts = new ArrayList<>();
+    List<CssTokens.TokenType> types = new ArrayList<>();
+    List<Integer> partners = new ArrayList<>();
     for (CssTokens.TokenIterator it = tokens.iterator(); it.hasNext();) {
       types.add(it.type());
       partners.add(tokens.brackets.partner(it.tokenIndex()));
@@ -395,7 +401,7 @@ public class CssTokensTest extends TestCase {
   }
 
   private static final void assertTokens(String css, String... goldens) {
-    List<String> expected = Lists.newArrayList();
+    List<String> expected = new ArrayList<>();
     for (String golden : goldens) {
       if (" ".equals(golden)) {
         expected.add(" :" + WHITESPACE.name());
@@ -406,7 +412,7 @@ public class CssTokensTest extends TestCase {
             + CssTokens.TokenType.valueOf(golden.substring(colon+1)).name());
       }
     }
-    List<String> actual = Lists.newArrayList();
+    List<String> actual = new ArrayList<>();
     for (CssTokens.TokenIterator it = lex(css).iterator();
          it.hasNext(); it.advance()) {
       actual.add(it.token() + ":" + it.type());
@@ -419,7 +425,7 @@ public class CssTokensTest extends TestCase {
   }
 
   private static void assertLexedCss(String input, String... goldens) {
-    List<String> actual = Lists.newArrayList();
+    List<String> actual = new ArrayList<>();
     for (String token : lex(input)) {
       actual.add(token);
     }

--- a/src/test/java/org/owasp/html/ElementPolicyTest.java
+++ b/src/test/java/org/owasp/html/ElementPolicyTest.java
@@ -1,5 +1,6 @@
 package org.owasp.html;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -8,9 +9,6 @@ import javax.annotation.Nullable;
 import org.junit.Test;
 
 import junit.framework.TestCase;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import static org.owasp.html.ElementPolicy.REJECT_ALL_ELEMENT_POLICY;
 import static org.owasp.html.ElementPolicy.IDENTITY_ELEMENT_POLICY;
@@ -39,17 +37,17 @@ public final class ElementPolicyTest extends TestCase {
   }
 
   private static void assertPassed(ElementPolicy p, String... expected) {
-    List<String> attrs = Lists.newArrayList();
-    ImmutableList.Builder<String> actual = ImmutableList.builder();
+    List<String> attrs = new ArrayList<>();
+    List<String> actual = new ArrayList<>();
     for (String elName : TEST_EL_NAMES) {
       if (p.apply(elName, attrs) != null) {
         actual.add(elName);
       }
     }
-    assertEquals(p.toString(), Arrays.asList(expected), actual.build());
+    assertEquals(p.toString(), Arrays.asList(expected), actual);
   }
 
-  private static List<String> TEST_EL_NAMES = ImmutableList.of(
+  private static List<String> TEST_EL_NAMES = List.of(
       "abacus", "abracadabra", "bar", "foo", "far", "cadr", "cdr");
 
   @Test

--- a/src/test/java/org/owasp/html/HtmlLexerTest.java
+++ b/src/test/java/org/owasp/html/HtmlLexerTest.java
@@ -28,16 +28,16 @@
 
 package org.owasp.html;
 
-import junit.framework.TestCase;
-
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
-import com.google.common.collect.Lists;
-import com.google.common.io.Resources;
+import junit.framework.TestCase;
 
 @SuppressWarnings("javadoc")
 public class HtmlLexerTest extends TestCase {
@@ -45,16 +45,12 @@ public class HtmlLexerTest extends TestCase {
   @Test
   public final void testHtmlLexer() throws Exception {
     // Do the lexing.
-    String input = Resources.toString(
-        Resources.getResource(getClass(), "htmllexerinput1.html"),
-        Charsets.UTF_8);
+    String input = new String(Files.readString(Paths.get(getClass().getResource("htmllexerinput1.html").toURI()), StandardCharsets.UTF_8));
     StringBuilder actual = new StringBuilder();
     lex(input, actual);
 
     // Get the golden.
-    String golden = Resources.toString(
-        Resources.getResource(getClass(), "htmllexergolden1.txt"),
-        Charsets.UTF_8);
+    String golden = new String(Files.readString(Paths.get(getClass().getResource("htmllexergolden1.txt").toURI()), StandardCharsets.UTF_8));
 
     // Compare.
     assertEquals(golden, actual.toString());
@@ -147,7 +143,7 @@ public class HtmlLexerTest extends TestCase {
 
   private static void assertTokens(String markup, String... golden) {
     HtmlLexer lexer = new HtmlLexer(markup);
-    List<String> actual = Lists.newArrayList();
+    List<String> actual = new ArrayList<>();
     while (lexer.hasNext()) {
       HtmlToken t = lexer.next();
       actual.add(t.type + ": " + markup.substring(t.start, t.end));

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderFuzzerTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderFuzzerTest.java
@@ -28,13 +28,12 @@
 
 package org.owasp.html;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.function.Function;
 
 import org.w3c.dom.Attr;
 import org.w3c.dom.NamedNodeMap;
@@ -93,7 +92,7 @@ public class HtmlPolicyBuilderFuzzerTest extends FuzzyTestCase {
         HtmlSanitizer.Policy policy = policyFactory.apply(
             HtmlStreamRenderer.create(sb, Handler.DO_NOTHING));
         policy.openDocument();
-        List<String> attributes = Lists.newArrayList();
+        List<String> attributes = new ArrayList<>();
         for (int j = 50; --j >= 0;) {
           int r = rnd.nextInt(3);
           switch (r) {

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -28,21 +28,21 @@
 
 package org.owasp.html;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 
 import junit.framework.TestCase;
 
 @SuppressWarnings("javadoc")
 public class HtmlPolicyBuilderTest extends TestCase {
 
-  static final String EXAMPLE = Joiner.on('\n').join(
+  static final String EXAMPLE = Arrays.stream(new String[] {
       "<h1 id='foo'>Header</h1>",
       "<p onclick='alert(42)'>Paragraph 1<script>evil()</script></p>",
       ("<p><a href='java\0script:bad()'>Click</a> <a href='foo.html'>me</a>"
@@ -54,12 +54,12 @@ public class HtmlPolicyBuilderTest extends TestCase {
       "          /* direction: ltr */; font-weight: bold'>Stylish Para 1</p>",
       "<p style='color: red; font-weight; expression(foo());",
       "          direction: rtl; font-weight: bold'>Stylish Para 2</p>",
-      "");
+      ""}).collect(Collectors.joining("\n"));
 
   @Test
   public static final void testTextFilter() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             "Click me out",
@@ -67,14 +67,14 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "Fancy with soupy tags.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()));
   }
 
   @Test
   public static final void testCannedFormattingTagFilter() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             "Click me out",
@@ -82,7 +82,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "<b>Fancy</b> with <i><b>soupy</b></i><b> tags</b>.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowCommonInlineFormattingElements()));
   }
@@ -90,7 +90,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testCannedFormattingTagFilterNoItalics() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             "Click me out",
@@ -98,7 +98,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "<b>Fancy</b> with <b>soupy</b><b> tags</b>.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowCommonInlineFormattingElements()
               .disallowElements("I")));
@@ -107,7 +107,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testSimpleTagFilter() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "<h1>Header</h1>",
             "Paragraph 1",
             "Click me out",
@@ -115,7 +115,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "Fancy with <i>soupy</i> tags.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowElements("h1", "i")));
   }
@@ -123,7 +123,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testLinksAllowed() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             // We haven't allowed any protocols so only relative URLs are OK.
@@ -132,7 +132,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "Fancy with soupy tags.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowElements("a")
               .allowAttributes("href").onElements("a")));
@@ -141,7 +141,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testExternalLinksAllowed() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             "Click <a href=\"foo.html\">me</a>"
@@ -150,7 +150,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "Fancy with soupy tags.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowElements("a")
               // Allows http.
@@ -161,7 +161,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testLinksWithNofollow() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             "Click <a href=\"foo.html\" rel=\"nofollow\">me</a> out",
@@ -169,7 +169,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "Fancy with soupy tags.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowElements("a")
               // Allows http.
@@ -192,7 +192,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testImagesAllowed() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             "Click me out",
@@ -201,7 +201,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "Fancy with soupy tags.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowElements("img")
               .allowAttributes("src", "alt").onElements("img")
@@ -211,7 +211,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testStyleFiltering() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "<h1>Header</h1>",
             "<p>Paragraph 1</p>",
             "<p>Click me out</p>",
@@ -221,7 +221,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
              + "Stylish Para 1</p>"),
             ("<p style=\"color:red;direction:rtl;font-weight:bold\">"
              + "Stylish Para 2</p>"),
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowCommonInlineFormattingElements()
               .allowCommonBlockElements()
@@ -232,7 +232,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testElementTransforming() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "<div class=\"header-h1\">Header</div>",
             "<p>Paragraph 1</p>",
             "<p>Click me out</p>",
@@ -240,7 +240,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "<p>Fancy with soupy tags.",
             "</p><p>Stylish Para 1</p>",
             "<p>Stylish Para 2</p>",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
               .allowElements("h1", "p", "div")
               .allowElements(
@@ -273,7 +273,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
   @Test
   public static final void testAllowUrlProtocols() {
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Header",
             "Paragraph 1",
             "Click me out",
@@ -282,7 +282,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
             "Fancy with soupy tags.",
             "Stylish Para 1",
             "Stylish Para 2",
-            ""),
+            ""}).collect(Collectors.joining("\n")),
         apply(new HtmlPolicyBuilder()
             .allowElements("img")
             .allowAttributes("src", "alt").onElements("img")
@@ -807,14 +807,14 @@ public class HtmlPolicyBuilderTest extends TestCase {
       // Should be ("nofollow", "noreferrer")
       new HtmlPolicyBuilder().requireRelsOnLinks("nofollow noreferrer");
       failed = false;
-    } catch (@SuppressWarnings("unused") IllegalArgumentException ex) {
+	} catch (@SuppressWarnings("unused") IllegalArgumentException ex) {
       failed = true;
     }
     assertTrue(failed);
     try {
       new HtmlPolicyBuilder().skipRelsOnLinks("nofollow noreferrer");
       failed = false;
-    } catch (@SuppressWarnings("unused") IllegalArgumentException ex) {
+	} catch (@SuppressWarnings("unused") IllegalArgumentException ex) {
       failed = true;
     }
     assertTrue(failed);
@@ -919,7 +919,7 @@ public class HtmlPolicyBuilderTest extends TestCase {
         // allow contents in this script tag
         .allowTextIn("script")
         // keep type attribute in application/json script tag
-        .allowAttributes("type").matching(true, ImmutableSet.of("application/json")).onElements("script")
+        .allowAttributes("type").matching(true, Set.of("application/json")).onElements("script")
         .toFactory();
 
     String mismatchedHtmlComments = "<script type=\"application/json\">\n" +

--- a/src/test/java/org/owasp/html/HtmlSanitizerFuzzerTest.java
+++ b/src/test/java/org/owasp/html/HtmlSanitizerFuzzerTest.java
@@ -28,13 +28,16 @@
 
 package org.owasp.html;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
+import org.apache.commons.codec.Resources;
 
 /**
  * Throws malformed inputs at the HTML sanitizer to try and crash it.
@@ -59,8 +62,9 @@ public class HtmlSanitizerFuzzerTest extends FuzzyTestCase {
       };
 
   public final void testFuzzHtmlParser() throws Exception {
-    String html = Resources.toString(
-        Resources.getResource("benchmark-data/Yahoo!.html"), Charsets.UTF_8);
+    String html = new BufferedReader(new InputStreamReader(
+        Resources.getInputStream("benchmark-data/Yahoo!.html"),
+        StandardCharsets.UTF_8)).lines().collect(Collectors.joining()); 
     int length = html.length();
 
     char[] fuzzyHtml0 = new char[length];

--- a/src/test/java/org/owasp/html/HtmlStreamRendererTest.java
+++ b/src/test/java/org/owasp/html/HtmlStreamRendererTest.java
@@ -28,18 +28,17 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import java.util.stream.Collectors;
 
 import junit.framework.TestCase;
 
 @SuppressWarnings("javadoc")
 public class HtmlStreamRendererTest extends TestCase {
 
-  private final List<String> errors = Lists.newArrayList();
+	private final List<String> errors = new ArrayList<>();
   private final StringBuilder rendered = new StringBuilder();
   private final HtmlStreamRenderer renderer = HtmlStreamRenderer.create(
       rendered, new Handler<String>() {
@@ -100,53 +99,53 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testIllegalElementName() throws Exception {
     renderer.openDocument();
-    renderer.openTag(":svg", ImmutableList.<String>of());
-    renderer.openTag("svg:", ImmutableList.<String>of());
-    renderer.openTag("-1", ImmutableList.<String>of());
-    renderer.openTag("svg::svg", ImmutableList.<String>of());
-    renderer.openTag("a@b", ImmutableList.<String>of());
+    renderer.openTag(":svg", List.<String>of());
+    renderer.openTag("svg:", List.<String>of());
+    renderer.openTag("-1", List.<String>of());
+    renderer.openTag("svg::svg", List.<String>of());
+    renderer.openTag("a@b", List.<String>of());
     renderer.closeDocument();
 
     String output = rendered.toString();
     assertFalse(output, output.contains("<"));
 
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Invalid element name : :svg",
             "Invalid element name : svg:",
             "Invalid element name : -1",
             "Invalid element name : svg::svg",
-            "Invalid element name : a@b"),
-        Joiner.on('\n').join(errors));
+            "Invalid element name : a@b"}).collect(Collectors.joining("\n")),
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
   public final void testIllegalAttributeName() throws Exception {
     renderer.openDocument();
-    renderer.openTag("div", ImmutableList.of(":svg", "x"));
-    renderer.openTag("div", ImmutableList.of("svg:", "x"));
-    renderer.openTag("div", ImmutableList.of("-1", "x"));
-    renderer.openTag("div", ImmutableList.of("svg::svg", "x"));
-    renderer.openTag("div", ImmutableList.of("a@b", "x"));
+    renderer.openTag("div", List.of(":svg", "x"));
+    renderer.openTag("div", List.of("svg:", "x"));
+    renderer.openTag("div", List.of("-1", "x"));
+    renderer.openTag("div", List.of("svg::svg", "x"));
+    renderer.openTag("div", List.of("a@b", "x"));
     renderer.closeDocument();
 
     String output = rendered.toString();
     assertFalse(output, output.contains("="));
 
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Invalid attr name : :svg",
             "Invalid attr name : svg:",
             "Invalid attr name : -1",
             "Invalid attr name : svg::svg",
-            "Invalid attr name : a@b"),
-        Joiner.on('\n').join(errors));
+            "Invalid attr name : a@b"}).collect(Collectors.joining("\n")),
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
   public final void testCdataContainsEndTag1() throws Exception {
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.of("type", "text/javascript"));
+    renderer.openTag("script", List.of("type", "text/javascript"));
     renderer.text("document.write('<SCRIPT>alert(42)</SCRIPT>')");
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -155,13 +154,13 @@ public class HtmlStreamRendererTest extends TestCase {
         "<script type=\"text/javascript\"></script>", rendered.toString());
     assertEquals(
         "Invalid CDATA text content : </SCRIPT>'",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
   public final void testCdataContainsEndTag2() throws Exception {
     renderer.openDocument();
-    renderer.openTag("style", ImmutableList.of("type", "text/css"));
+    renderer.openTag("style", List.of("type", "text/css"));
     renderer.text("/* </St");
     // Split into two text chunks, and insert NULs.
     renderer.text("\0yle> */");
@@ -172,13 +171,13 @@ public class HtmlStreamRendererTest extends TestCase {
         "<style type=\"text/css\"></style>", rendered.toString());
     assertEquals(
         "Invalid CDATA text content : </Style> *",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
   public final void testRcdataContainsEndTag() throws Exception {
     renderer.openDocument();
-    renderer.openTag("textarea", ImmutableList.<String>of());
+    renderer.openTag("textarea", List.<String>of());
     renderer.text("<textarea></textarea>");
     renderer.closeTag("textarea");
     renderer.closeDocument();
@@ -194,7 +193,7 @@ public class HtmlStreamRendererTest extends TestCase {
         "<script><!--document.write('<SCRIPT>alert(42)</SCRIPT>')--></script>");
     assertEquals(
         "Invalid CDATA text content : <SCRIPT>al",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
@@ -205,7 +204,7 @@ public class HtmlStreamRendererTest extends TestCase {
         + "  console.log(example);\n";
 
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text(js);
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -215,7 +214,7 @@ public class HtmlStreamRendererTest extends TestCase {
         rendered.toString());
     assertEquals(
         "Invalid CDATA text content : <script>';",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
@@ -223,7 +222,7 @@ public class HtmlStreamRendererTest extends TestCase {
     String js = "if (x<!--y) { ... }\n";
 
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text(js);
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -233,7 +232,7 @@ public class HtmlStreamRendererTest extends TestCase {
         rendered.toString());
     assertEquals(
         "Invalid CDATA text content : <!--y) { .",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
@@ -241,7 +240,7 @@ public class HtmlStreamRendererTest extends TestCase {
     String js = "if (x-->y) { ... }\n";
 
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text(js);
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -252,7 +251,7 @@ public class HtmlStreamRendererTest extends TestCase {
         rendered.toString());
     assertEquals(
         "Invalid CDATA text content : -->y) { ..",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
@@ -260,7 +259,7 @@ public class HtmlStreamRendererTest extends TestCase {
     String js = "// <!----> <!--->";
 
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text(js);
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -271,7 +270,7 @@ public class HtmlStreamRendererTest extends TestCase {
         rendered.toString());
     assertEquals(
         "Invalid CDATA text content : <!--->",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
@@ -279,7 +278,7 @@ public class HtmlStreamRendererTest extends TestCase {
     String js = "<!-- if ( player<script ) { ... } -->";
 
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text(js);
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -289,7 +288,7 @@ public class HtmlStreamRendererTest extends TestCase {
         rendered.toString());
     assertEquals(
         "Invalid CDATA text content : <script ) ",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
@@ -303,7 +302,7 @@ public class HtmlStreamRendererTest extends TestCase {
         + "-->";
 
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text(js);
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -323,10 +322,10 @@ public class HtmlStreamRendererTest extends TestCase {
     String str = "// <!----> <!---> <!--";
 
     renderer.openDocument();
-    renderer.openTag("title", ImmutableList.<String>of());
+    renderer.openTag("title", List.<String>of());
     renderer.text(str);
     renderer.closeTag("title");
-    renderer.openTag("textarea", ImmutableList.<String>of());
+    renderer.openTag("textarea", List.<String>of());
     renderer.text(str);
     renderer.closeTag("textarea");
     renderer.closeDocument();
@@ -339,9 +338,9 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testTagInCdata() throws Exception {
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text("alert('");
-    renderer.openTag("b", ImmutableList.<String>of());
+    renderer.openTag("b", List.<String>of());
     renderer.text("foo");
     renderer.closeTag("b");
     renderer.text("')");
@@ -351,16 +350,16 @@ public class HtmlStreamRendererTest extends TestCase {
     assertEquals(
         "<script>alert('foo')</script>", rendered.toString());
     assertEquals(
-        Joiner.on('\n').join(
+        Arrays.stream(new String[] {
             "Tag content cannot appear inside CDATA element : b",
-            "Tag content cannot appear inside CDATA element : b"),
-        Joiner.on('\n').join(errors));
+            "Tag content cannot appear inside CDATA element : b"}).collect(Collectors.joining("\n")),
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
   public final void testUnclosedEscapingTextSpan() throws Exception {
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text("<!--alert('</script>')");
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -368,13 +367,13 @@ public class HtmlStreamRendererTest extends TestCase {
     assertEquals("<script></script>", rendered.toString());
     assertEquals(
         "Invalid CDATA text content : </script>'",
-        Joiner.on('\n').join(errors));
+        errors.stream().collect(Collectors.joining("\n")));
     errors.clear();
   }
 
   public final void testAlmostCompleteEndTag() throws Exception {
     renderer.openDocument();
-    renderer.openTag("script", ImmutableList.<String>of());
+    renderer.openTag("script", List.<String>of());
     renderer.text("//</scrip");
     renderer.closeTag("script");
     renderer.closeDocument();
@@ -384,7 +383,7 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testBalancedCommentInNoscript() throws Exception {
     renderer.openDocument();
-    renderer.openTag("noscript", ImmutableList.<String>of());
+    renderer.openTag("noscript", List.<String>of());
     renderer.text("<!--<script>foo</script>-->");
     renderer.closeTag("noscript");
     renderer.closeDocument();
@@ -396,10 +395,10 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testUnbalancedCommentInNoscript() throws Exception {
     renderer.openDocument();
-    renderer.openTag("noscript", ImmutableList.<String>of());
+    renderer.openTag("noscript", List.<String>of());
     renderer.text("<!--<script>foo</script>--");
     renderer.closeTag("noscript");
-    renderer.openTag("noscript", ImmutableList.<String>of());
+    renderer.openTag("noscript", List.<String>of());
     renderer.text("<script>foo</script>-->");
     renderer.closeTag("noscript");
     renderer.closeDocument();
@@ -423,7 +422,7 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testPreSubstitutes1() throws Exception {
     renderer.openDocument();
-    renderer.openTag("Xmp", ImmutableList.<String>of());
+    renderer.openTag("Xmp", List.<String>of());
     renderer.text("<form>Hello, World</form>");
     renderer.closeTag("Xmp");
     renderer.closeDocument();
@@ -434,7 +433,7 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testPreSubstitutes2() throws Exception {
     renderer.openDocument();
-    renderer.openTag("xmp", ImmutableList.<String>of());
+    renderer.openTag("xmp", List.<String>of());
     renderer.text("<form>Hello, World</form>");
     renderer.closeTag("xmp");
     renderer.closeDocument();
@@ -445,7 +444,7 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testPreSubstitutes3() throws Exception {
     renderer.openDocument();
-    renderer.openTag("LISTING", ImmutableList.<String>of());
+    renderer.openTag("LISTING", List.<String>of());
     renderer.text("<form>Hello, World</form>");
     renderer.closeTag("LISTING");
     renderer.closeDocument();
@@ -456,7 +455,7 @@ public class HtmlStreamRendererTest extends TestCase {
 
   public final void testPreSubstitutes4() throws Exception {
     renderer.openDocument();
-    renderer.openTag("plaintext", ImmutableList.<String>of());
+    renderer.openTag("plaintext", List.<String>of());
     renderer.text("<form>Hello, World</form>");
     renderer.closeDocument();
 

--- a/src/test/java/org/owasp/html/PolicyFactoryTest.java
+++ b/src/test/java/org/owasp/html/PolicyFactoryTest.java
@@ -32,10 +32,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
-
-import com.google.common.base.Joiner;
 
 import junit.framework.TestCase;
 
@@ -619,7 +618,7 @@ public final class PolicyFactoryTest extends TestCase {
           outParts.add(part);
         }
       }
-      return Joiner.on(" , ").join(outParts);
+      return outParts.stream().collect(Collectors.joining(" , "));
     }
   }
 }

--- a/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/src/test/java/org/owasp/html/SanitizersTest.java
@@ -30,15 +30,14 @@ package org.owasp.html;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
 import junit.framework.TestCase;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 @SuppressWarnings("javadoc")
 public class SanitizersTest extends TestCase {
@@ -516,7 +515,7 @@ public class SanitizersTest extends TestCase {
    * elements are assumed distinct.
    */
   private static class Permutations<T> implements Iterable<List<T>> {
-    final ImmutableList<T> elements;
+    final List<T> elements;
     /** Permutation size. */
     final int k;
 
@@ -526,7 +525,9 @@ public class SanitizersTest extends TestCase {
 
     Permutations(int k, @SuppressWarnings("unchecked") T... elements) {
       this.k = k;
-      this.elements = ImmutableList.copyOf(elements);
+      List<T> builder = new ArrayList<>();
+      Arrays.stream(elements).forEach(builder::add);
+      this.elements = List.copyOf(builder);
     }
 
     public Iterator<List<T>> iterator() {
@@ -559,7 +560,7 @@ public class SanitizersTest extends TestCase {
         private void fill() {
           if (pending != null || i == limit) { return; }
 
-          List<T> permutation = Lists.newArrayListWithCapacity(k);
+          List<T> permutation = new ArrayList<>(k);
           mask.clear();
 
           for (int j = 0, p = i; j < k; ++j) {

--- a/src/test/java/org/owasp/html/StylingPolicyTest.java
+++ b/src/test/java/org/owasp/html/StylingPolicyTest.java
@@ -28,11 +28,11 @@
 
 package org.owasp.html;
 
+import java.util.function.Function;
+
 import javax.annotation.Nullable;
 
 import org.junit.Test;
-
-import com.google.common.base.Function;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -28,16 +28,16 @@
 
 package org.owasp.html;
 
-import com.google.common.collect.ImmutableList;
-
-import junit.framework.TestCase;
-
-import org.junit.Test;
-import org.junit.Before;
-import org.junit.Ignore;
-
 import static org.owasp.html.TagBalancingHtmlStreamEventReceiver
               .isInterElementWhitespace;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import junit.framework.TestCase;
 
 
 @SuppressWarnings("javadoc")
@@ -60,17 +60,17 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testTagBalancing() {
     balancer.openDocument();
-    balancer.openTag("html", ImmutableList.<String>of());
-    balancer.openTag("head", ImmutableList.<String>of());
-    balancer.openTag("title", ImmutableList.<String>of());
+	balancer.openTag("html", List.<String>of());
+	balancer.openTag("head", List.<String>of());
+	balancer.openTag("title", List.<String>of());
     balancer.text("Hello, <<World>>!");
     // TITLE closed with case-sensitively different name.
     balancer.closeTag("TITLE");
     balancer.closeTag("head");
-    balancer.openTag("body", ImmutableList.<String>of());
-    balancer.openTag("p", ImmutableList.of("id", "p'0"));
+	balancer.openTag("body", List.<String>of());
+	balancer.openTag("p", List.of("id", "p'0"));
     balancer.text("Hello,");
-    balancer.openTag("Br", ImmutableList.<String>of());
+	balancer.openTag("Br", List.<String>of());
     balancer.text("<<World>>!");
     // HTML, P, and BODY unclosed, but BR not.
     balancer.closeDocument();
@@ -85,9 +85,9 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testTagSoupIronedOut() {
     balancer.openDocument();
-    balancer.openTag("i", ImmutableList.<String>of());
+	balancer.openTag("i", List.<String>of());
     balancer.text("x");
-    balancer.openTag("b", ImmutableList.<String>of());
+	balancer.openTag("b", List.<String>of());
     balancer.text("y");
     balancer.closeTag("i");
     balancer.text("z");
@@ -101,12 +101,12 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testListInListDirectly() {
     balancer.openDocument();
-    balancer.openTag("ul", ImmutableList.<String>of());
-    balancer.openTag("li", ImmutableList.<String>of());
+	balancer.openTag("ul", List.<String>of());
+	balancer.openTag("li", List.<String>of());
     balancer.text("foo");
     balancer.closeTag("li");
-    balancer.openTag("ul", ImmutableList.<String>of());
-    balancer.openTag("li", ImmutableList.<String>of());
+	balancer.openTag("ul", List.<String>of());
+	balancer.openTag("li", List.<String>of());
     balancer.text("bar");
     balancer.closeTag("li");
     balancer.closeTag("ul");
@@ -121,28 +121,28 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testTextContent() {
     balancer.openDocument();
-    balancer.openTag("title", ImmutableList.<String>of());
+	balancer.openTag("title", List.<String>of());
     balancer.text("Hello, World!");
     balancer.closeTag("title");
     balancer.text("Hello, ");
-    balancer.openTag("b", ImmutableList.<String>of());
+	balancer.openTag("b", List.<String>of());
     balancer.text("World!");
     balancer.closeTag("b");
-    balancer.openTag("p", ImmutableList.<String>of());
+	balancer.openTag("p", List.<String>of());
     balancer.text("Hello, ");
-    balancer.openTag("textarea", ImmutableList.<String>of());
+	balancer.openTag("textarea", List.<String>of());
     balancer.text("World!");
     balancer.closeTag("textarea");
     balancer.closeTag("p");
-    balancer.openTag("h1", ImmutableList.<String>of());
+	balancer.openTag("h1", List.<String>of());
     balancer.text("Hello");
-    balancer.openTag("style", ImmutableList.<String>of("type", "text/css"));
+	balancer.openTag("style", List.<String>of("type", "text/css"));
     balancer.text("\n.World {\n  color: blue\n}\n");
     balancer.closeTag("style");
     balancer.closeTag("h1");
-    balancer.openTag("ul", ImmutableList.<String>of());
+	balancer.openTag("ul", List.<String>of());
     balancer.text("\n  ");
-    balancer.openTag("li", ImmutableList.<String>of());
+	balancer.openTag("li", List.<String>of());
     balancer.text("Hello,");
     balancer.closeTag("li");
     balancer.text("\n  ");
@@ -170,20 +170,20 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testMismatchedHeaders() {
     balancer.openDocument();
-    balancer.openTag("H1", ImmutableList.<String>of());
+	balancer.openTag("H1", List.<String>of());
     balancer.text("header");
     balancer.closeTag("h1");
     balancer.text("body");
-    balancer.openTag("H2", ImmutableList.<String>of());
+	balancer.openTag("H2", List.<String>of());
     balancer.text("sub-header");
     balancer.closeTag("h3");
     balancer.text("sub-body");
-    balancer.openTag("h3", ImmutableList.<String>of());
+	balancer.openTag("h3", List.<String>of());
     balancer.text("sub-sub-");
     balancer.closeTag("hr"); // hr is not a header tag so does not close an h3.
     balancer.text("header");
     // <h3> is not allowed in h3.
-    balancer.openTag("h3", ImmutableList.<String>of());
+	balancer.openTag("h3", List.<String>of());
     balancer.closeTag("h3");
     balancer.text("sub-sub-body");
     balancer.closeTag("H4");
@@ -201,10 +201,10 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testListNesting() {
     balancer.openDocument();
-    balancer.openTag("ul", ImmutableList.<String>of());
-    balancer.openTag("li", ImmutableList.<String>of());
-    balancer.openTag("ul", ImmutableList.<String>of());
-    balancer.openTag("li", ImmutableList.<String>of());
+	balancer.openTag("ul", List.<String>of());
+	balancer.openTag("li", List.<String>of());
+	balancer.openTag("ul", List.<String>of());
+	balancer.openTag("li", List.<String>of());
     balancer.text("foo");
     balancer.closeTag("li");
     // Does not closes the second <ul> since only </ol> and </ul> can close a
@@ -212,8 +212,8 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     // tree building algo.
     balancer.closeTag("li");
     // This would append inside a list, not an item.  We insert an <li>.
-    balancer.openTag("ul", ImmutableList.<String>of());
-    balancer.openTag("li", ImmutableList.<String>of());
+	balancer.openTag("ul", List.<String>of());
+	balancer.openTag("li", List.<String>of());
     balancer.text("bar");
     balancer.closeDocument();
 
@@ -225,18 +225,18 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testTableNesting() {
     balancer.openDocument();
-    balancer.openTag("table", ImmutableList.<String>of());
-    balancer.openTag("tbody", ImmutableList.<String>of());
-    balancer.openTag("tr", ImmutableList.<String>of());
-    balancer.openTag("td", ImmutableList.<String>of());
+	balancer.openTag("table", List.<String>of());
+	balancer.openTag("tbody", List.<String>of());
+	balancer.openTag("tr", List.<String>of());
+	balancer.openTag("td", List.<String>of());
     balancer.text("foo");
     balancer.closeTag("td");
     // Chrome does not insert a td to contain this mis-nested table.
     // Instead, it ends one table and starts another.
-    balancer.openTag("table", ImmutableList.<String>of());
-    balancer.openTag("tbody", ImmutableList.<String>of());
-    balancer.openTag("tr", ImmutableList.<String>of());
-    balancer.openTag("th", ImmutableList.<String>of());
+	balancer.openTag("table", List.<String>of());
+	balancer.openTag("tbody", List.<String>of());
+	balancer.openTag("tr", List.<String>of());
+	balancer.openTag("th", List.<String>of());
     balancer.text("bar");
     balancer.closeTag("table");
     balancer.closeTag("table");
@@ -257,7 +257,7 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
     balancer.setNestingLimit(10);
     balancer.openDocument();
-    ImmutableList<String> attrs = ImmutableList.<String>of();
+	List<String> attrs = List.<String>of();
     for (int i = 20000; --i >= 0;) {
       balancer.openTag("div", attrs);
     }
@@ -273,29 +273,29 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   public final void testTablesGuarded() {
     // Derived from issue 12.
     balancer.openDocument();
-    balancer.openTag("html", ImmutableList.<String>of());
-    balancer.openTag("head", ImmutableList.<String>of());
-    balancer.openTag("meta", ImmutableList.<String>of());
+	balancer.openTag("html", List.<String>of());
+	balancer.openTag("head", List.<String>of());
+	balancer.openTag("meta", List.<String>of());
     balancer.closeTag("head");
-    balancer.openTag("body", ImmutableList.<String>of());
-    balancer.openTag("p", ImmutableList.<String>of());
+	balancer.openTag("body", List.<String>of());
+	balancer.openTag("p", List.<String>of());
     balancer.text("Hi");
     balancer.closeTag("p");
-    balancer.openTag("p", ImmutableList.<String>of());
+	balancer.openTag("p", List.<String>of());
     balancer.text("How are you");
     balancer.closeTag("p");
     balancer.text("\n");
-    balancer.openTag("ul", ImmutableList.<String>of());
-    balancer.openTag("li", ImmutableList.<String>of());
-    balancer.openTag("table", ImmutableList.<String>of());
-    balancer.openTag("tbody", ImmutableList.<String>of());
-    balancer.openTag("tr", ImmutableList.<String>of());
+	balancer.openTag("ul", List.<String>of());
+	balancer.openTag("li", List.<String>of());
+	balancer.openTag("table", List.<String>of());
+	balancer.openTag("tbody", List.<String>of());
+	balancer.openTag("tr", List.<String>of());
     for (int i = 2; --i >= 0;) {
-      balancer.openTag("td", ImmutableList.<String>of());
-      balancer.openTag("b", ImmutableList.<String>of());
-      balancer.openTag("font", ImmutableList.<String>of());
-      balancer.openTag("font", ImmutableList.<String>of());
-      balancer.openTag("p", ImmutableList.<String>of());
+		balancer.openTag("td", List.<String>of());
+		balancer.openTag("b", List.<String>of());
+		balancer.openTag("font", List.<String>of());
+		balancer.openTag("font", List.<String>of());
+		balancer.openTag("p", List.<String>of());
       balancer.text("Cell");
       balancer.closeTag("p");
       balancer.closeTag("font");
@@ -309,7 +309,7 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
     balancer.closeTag("table");
     balancer.closeTag("ul");
     balancer.text("\n");
-    balancer.openTag("p", ImmutableList.<String>of());
+	balancer.openTag("p", List.<String>of());
     balancer.text("x");
     balancer.closeTag("p");
     balancer.closeTag("body");
@@ -348,11 +348,11 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
   @Test
   public final void testAnchorTransparentToBlock() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
-    balancer.openTag("div", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
     balancer.openTag("a", hrefOnly);
-    balancer.openTag("div", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
     balancer.text("...");
     balancer.closeTag("div");
     balancer.closeTag("a");
@@ -367,11 +367,11 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
   @Test
   public final void testAnchorTransparentToSpans() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
-    balancer.openTag("span", ImmutableList.<String>of());
+		balancer.openTag("span", List.<String>of());
     balancer.openTag("a", hrefOnly);
-    balancer.openTag("span", ImmutableList.<String>of());
+		balancer.openTag("span", List.<String>of());
     balancer.text("...");
     balancer.closeTag("span");
     balancer.closeTag("a");
@@ -386,11 +386,11 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
   @Test
   public final void testAnchorWithInlineInBlock() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
-    balancer.openTag("div", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
     balancer.openTag("a", hrefOnly);
-    balancer.openTag("span", ImmutableList.<String>of());
+		balancer.openTag("span", List.<String>of());
     balancer.text("...");
     balancer.closeTag("span");
     balancer.closeTag("a");
@@ -404,9 +404,9 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
   @Test
   public final void testDirectlyNestedAnchor() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
-    balancer.openTag("span", ImmutableList.<String>of());
+		balancer.openTag("span", List.<String>of());
     balancer.openTag("a", hrefOnly);
     balancer.openTag("a", hrefOnly);
     balancer.text("...");
@@ -423,11 +423,11 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
   @Test
   public final void testAnchorClosedWhenBlockInInline() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
-    balancer.openTag("span", ImmutableList.<String>of());
+		balancer.openTag("span", List.<String>of());
     balancer.openTag("a", hrefOnly);
-    balancer.openTag("div", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
     balancer.text("...");
     balancer.closeTag("div");
     balancer.closeTag("a");
@@ -446,11 +446,11 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   @Ignore
   public final void failingtestAnchorInAnchorIndirectly() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
-    balancer.openTag("div", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
     balancer.openTag("a", hrefOnly);
-    balancer.openTag("div", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
     balancer.openTag("a", hrefOnly);
     balancer.text("...");
     balancer.closeTag("a");
@@ -466,12 +466,12 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
   @Test
   public final void testInteractiveInAnchorIndirectly() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
-    balancer.openTag("div", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
     balancer.openTag("a", hrefOnly);
-    balancer.openTag("div", ImmutableList.<String>of());
-    balancer.openTag("video", ImmutableList.<String>of());
+		balancer.openTag("div", List.<String>of());
+		balancer.openTag("video", List.<String>of());
     balancer.closeTag("video");
     balancer.closeTag("div");
     balancer.closeTag("a");
@@ -484,10 +484,10 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
 
   @Test
   public final void testAnchorWithBlockAtTopLevel() {
-    ImmutableList<String> hrefOnly = ImmutableList.of("href", "");
+		List<String> hrefOnly = List.of("href", "");
     balancer.openDocument();
     balancer.openTag("a", hrefOnly);
-    balancer.openTag("div", ImmutableList.<String>of());
+	balancer.openTag("div", List.<String>of());
     balancer.text("...");
     balancer.closeTag("div");
     balancer.closeTag("a");
@@ -500,11 +500,11 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   @Test
   public final void testResumedElementsAllowedWhereResumed() {
     balancer.openDocument();
-    balancer.openTag("a", ImmutableList.<String>of());
-    balancer.openTag("b", ImmutableList.<String>of());
+	balancer.openTag("a", List.<String>of());
+	balancer.openTag("b", List.<String>of());
     balancer.text("foo");
-    balancer.openTag("i", ImmutableList.<String>of());
-    balancer.openTag("a", ImmutableList.<String>of());
+	balancer.openTag("i", List.<String>of());
+	balancer.openTag("a", List.<String>of());
     balancer.text("bar");
     balancer.closeTag("a");
     balancer.closeTag("i");
@@ -520,11 +520,11 @@ public class TagBalancingHtmlStreamRendererTest extends TestCase {
   public final void testMenuItemNesting() {
     // issue 96
     balancer.openDocument();
-    balancer.openTag("div", ImmutableList.<String>of());
-    balancer.openTag("menu", ImmutableList.<String>of());
-    balancer.openTag("menuitem", ImmutableList.<String>of());
+	balancer.openTag("div", List.<String>of());
+	balancer.openTag("menu", List.<String>of());
+	balancer.openTag("menuitem", List.<String>of());
     balancer.closeTag("menuitem");
-    balancer.openTag("menuitem", ImmutableList.<String>of());
+	balancer.openTag("menuitem", List.<String>of());
     balancer.closeTag("menuitem");
     balancer.closeTag("menu");
     balancer.closeTag("div");


### PR DESCRIPTION
This PR remove Guava dependency and update Java target/source to 9.

Please note that:

1. ~Two annotations from Guava are copied to source:~
   - ~`@GwtCompatible`: need only for `@VisibleForTesting`.~
   - ~`@VisibleForTesting`: used in 2 internal methods that should be visible only for test scope. Maybe there are a better approach.~
1. ~Replaced Guava `Preconditions` with `assert`. I'm sure there are a better approach, but `assert` is already used in some places, so I stick with that.~
1. ~Java sets do not ensures order, so unit testing eventually fail in `HtmlPolicyBuilderTest` when checking ordered `noopener noreferrer`, then just run again. Maybe review unit test.~
1. Added `configuration` to `maven-bundle-plugin` because `maven-verifier-plugin` fails.

Fixes #157, fixes #162
Also fixes rebuilding this library, caused by CVEs found on Guava, with just version update.

---

**Edit**

1. Rebased with last commits;
1. Guava annotations removed;
1. Some `Set`'s replaced with `List` to ensure proper ordering of `noopener noreferrer`.

---

**Edit 2**

Replaced Guava `Preconditions` with control structures and explicit throws.
