### PR TITLE
Guava 32.0.0-jre fixes multiple CVE's

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,7 +88,7 @@ application while protecting against XSS.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <guava.version>30.1-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Fixes at least these two CVE's

```xml
    <suppress>
        <notes>
            <![CDATA[file name: guava.jar PrimeFaces does not use the temp directory functionality that is vulnerable]]></notes>
        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
        <cve>CVE-2020-8908</cve>
    </suppress>
    <suppress>
       <notes><![CDATA[file name: guava.jar PrimeFaces does not use the temp directory functionality that is vulnerable]]></notes>
       <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
       <cve>CVE-2023-2976</cve>
    </suppress>
```