### PR TITLE
Remove URL length constraint

### DIFF
--- a/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/src/main/java/org/owasp/html/StylingPolicy.java
@@ -93,13 +93,11 @@ final class StylingPolicy implements JoinableAttributePolicy {
       }
 
       private void sanitizeAndAppendUrl(String urlContent) {
-        if (urlContent.length() < 1024) {
-          String rewrittenUrl = urlRewriter.apply(urlContent);
-          if (rewrittenUrl != null && !rewrittenUrl.isEmpty()) {
-            if (hasTokens) { sanitizedCss.append(' '); }
-            sanitizedCss.append("url('").append(rewrittenUrl).append("')");
-            hasTokens = true;
-          }
+        String rewrittenUrl = urlRewriter.apply(urlContent);
+        if (rewrittenUrl != null && !rewrittenUrl.isEmpty()) {
+          if (hasTokens) { sanitizedCss.append(' '); }
+          sanitizedCss.append("url('").append(rewrittenUrl).append("')");
+          hasTokens = true;
         }
       }
 


### PR DESCRIPTION
Fix #187

The length of the input should not really be validated in sanitizer, rather the whole HTTP request body should be constrained. This PR removes the troublesome constraint.