### PR TITLE
Test : Add test when raw string has rel="noopener noreferrer"

### DIFF
--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -801,6 +801,19 @@ public class HtmlPolicyBuilderTest extends TestCase {
   }
 
   @Test
+  public static final void testRelLinksWhenRelisPartOfData() {
+	  PolicyFactory pf = new HtmlPolicyBuilder()
+		        .allowElements("a")
+		        .allowAttributes("href").onElements("a")
+		        .allowAttributes("rel").onElements("a")
+		        .allowAttributes("target").onElements("a")
+		        .allowStandardUrlProtocols()
+		        .toFactory();
+	  String toSanitize = "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://google.com\">test</a>";
+	  assertTrue("Failure in testRelLinksWhenRelisPartOfData", pf.sanitize(toSanitize).equals(toSanitize));
+  }
+
+  @Test
   public static final void testFailFastOnSpaceSeparatedStrings() {
     boolean failed;
     try {


### PR DESCRIPTION


When the string to be sanitized already has rel="noopener noreferrer" the library appends it again causing it to be added twice. This PR gives a failing test. If it's fine, I'll create a PR for the fix in dev. 