### PR TITLE
Fix : Support xxx-large and medium css font-size values.

### DIFF
--- a/src/main/java/org/owasp/html/CssSchema.java
+++ b/src/main/java/org/owasp/html/CssSchema.java
@@ -383,7 +383,7 @@ public final class CssSchema {
         "bolder", "lighter");
     ImmutableSet<String> fontLiterals1 = ImmutableSet.of(
         "large", "larger", "small", "smaller", "x-large", "x-small",
-        "xx-large", "xx-small");
+        "xx-large", "xx-small","xxx-large","medium");
     ImmutableSet<String> fontLiterals2 = ImmutableSet.of(
         "caption", "icon", "menu", "message-box", "small-caption",
         "status-bar");

--- a/src/main/java/org/owasp/html/CssSchema.java
+++ b/src/main/java/org/owasp/html/CssSchema.java
@@ -383,7 +383,7 @@ public final class CssSchema {
         "bolder", "lighter");
     ImmutableSet<String> fontLiterals1 = ImmutableSet.of(
         "large", "larger", "small", "smaller", "x-large", "x-small",
-        "xx-large", "xx-small","xxx-large","medium");
+        "xx-large", "xx-small", "xxx-large", "medium");
     ImmutableSet<String> fontLiterals2 = ImmutableSet.of(
         "caption", "icon", "menu", "message-box", "small-caption",
         "status-bar");

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -994,6 +994,20 @@ public class HtmlPolicyBuilderTest extends TestCase {
     assertEquals("x<textArea>y</textArea>", textAreaPolicy.sanitize(input));
   }
 
+   @Test
+  public static final void testCSSFontSize() {
+	 HtmlPolicyBuilder builder = new HtmlPolicyBuilder();
+ 	 PolicyFactory factory = builder.allowElements("span")
+ 	 .allowAttributes("style").onElements("span").allowStyling()
+ 	.toFactory();
+ 	 String toSanitizeXXXLarge = "the <span style=\"font-size:xxx-large\">large</span> formatting issue with chrome";
+ 	 assertEquals(toSanitizeXXXLarge, factory.sanitize(toSanitizeXXXLarge)); 
+ 	 
+ 	 String toSanitizeMedium = "the <span style=\"font-size:medium\">medium</span> formatting issue with chrome";
+ 	 assertEquals(toSanitizeMedium, factory.sanitize(toSanitizeMedium)); 
+  }
+
+
   private static String apply(HtmlPolicyBuilder b) {
     return apply(b, EXAMPLE);
   }


### PR DESCRIPTION
xxx-large and medium are valid css font-size values.

https://developer.mozilla.org/en-US/docs/Web/CSS/font-size

This PR Fixes https://github.com/OWASP/java-html-sanitizer/issues/291