### PR TITLE
Bump to the latest Guava version to avoid CVEs and be up to date

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,7 +88,7 @@ application while protecting against XSS.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <guava.version>30.1-jre</guava.version>
+    <guava.version>32.1.3-jre</guava.version>
   </properties>
 
   <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,7 +88,7 @@ application while protecting against XSS.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <guava.version>32.1.3-jre</guava.version>
+    <guava.version>33.0.0-jre</guava.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Upgrades past CVE-2023-2976 and CVE-2020-8908 to the latest [Guava version](https://mvnrepository.com/artifact/com.google.guava/guava).