### PR TITLE
Fix : CSS Child Combinator Parsing Bug

### DIFF
--- a/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -341,7 +341,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
           }
           break;
         case '>':
-          if (i >= 2 && sb.charAt(i - 2) == '-' && sb.charAt(i - 2) == '-') {
+          if (i >= 2 && sb.charAt(i - 2) == '-' && sb.charAt(i - 1) == '-') {
             if (innerStart < 0) { return i - 2; }
             // Merged start and end like <!--->
             if (innerStart + 6 > i) { return innerStart; }

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -994,6 +994,43 @@ public class HtmlPolicyBuilderTest extends TestCase {
     assertEquals("x<textArea>y</textArea>", textAreaPolicy.sanitize(input));
   }
 
+ @Test
+  public static final void testCSSChildCombinator() {
+	 HtmlPolicyBuilder builder = new HtmlPolicyBuilder();
+	 
+ 	 PolicyFactory factory = builder.allowElements("span","style","h1").allowTextIn("style","h1")
+ 	 .allowAttributes("type").onElements("style").allowStyling()
+ 	.toFactory();
+ 	
+ 	 
+ 	 String toSanitize = "<style type=\"text/css\">\n"
+ 	 		+ "<!--\n"
+ 	 		+ ".hdg-1 {\n"
+ 	 		+ "width:100%;\n"
+ 	 		+ "}\n"
+ 	 		+ "\n"
+ 	 		+ ".hdg-1>._inner {\n"
+ 	 		+ "background-color: #999;\n"
+ 	 		+ "}\n"
+ 	 		+ "-->\n"
+ 	 		+ "</style>\n"
+ 	 		+ "<h1>Test</h1>\n"
+ 	 		+ "\n"
+ 	 		+ "<style>\n"
+ 	 		+ "<!--\n"
+ 	 		+ ".hdg-1 {\n"
+ 	 		+ "width:100%;\n"
+ 	 		+ "}\n"
+ 	 		+ "\n"
+ 	 		+ ".hdg-1>._inner {\n"
+ 	 		+ "background-color: #666;\n"
+ 	 		+ "}\n"
+ 	 		+ "-->\n"
+ 	 		+ "</style>";
+ 	 assertEquals(toSanitize, factory.sanitize(toSanitize));
+  }
+ 
+
   private static String apply(HtmlPolicyBuilder b) {
     return apply(b, EXAMPLE);
   }


### PR DESCRIPTION
https://github.com/OWASP/java-html-sanitizer/commit/241b4b8a6cd37c486b36f12fc135a018881c3e4a#diff-0a08f29a5b7867e56d6aa9f6abe035e32ee9411a8bc96afa9a6acff2a6d6f07fR338 

The above commit was made to make parsing consistent with HTML5 Spec, but while this is being rewritten it looks like a regression was introduced when parsing for `>`

To ensure this entity `>` is part of a HTML Comment it seems to have been checked the previous two characters are `-` but with this commit only `char - 2` is checked twice. So if a CSS Child combinator with `-` selector is used, it was treated was a error and as a result user CSS was badly stripped. Fixing this and adding a test for it. 


Fixes https://github.com/OWASP/java-html-sanitizer/issues/251