### PR TITLE
Update the maven-compiler-plugin to make the --release check work

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -185,11 +185,7 @@ application while protecting against XSS.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
-          <configuration>
-            <source>9</source>
-            <target>9</target>
-          </configuration>
+          <version>3.12.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
For the compiler --release check to work, we need a more recent maven-compiler-plugin version (at least [3.6](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html)).

relates to issue #301