### PR TITLE
Add GitHub actions for testing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    paths-ignore:
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/maven.yml'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/maven.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java: [ '11', '17', '21' ]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.Java }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ matrix.Java }}
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn --batch-mode --errors --fail-at-end --show-version --update-snapshots verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Build with Maven
       run: mvn --batch-mode --errors --fail-at-end --show-version --update-snapshots verify
     - name: Store artifact
+      if: ${{ matrix.Java == 11 }}
       uses: actions/upload-artifact@v4
       with:
         name: jar-jdk${{ matrix.Java }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,3 +34,9 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn --batch-mode --errors --fail-at-end --show-version --update-snapshots verify
+    - name: Store artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: jar-jdk${{ matrix.Java }}
+        path: target/*.jar
+        retention-days: 7


### PR DESCRIPTION
Use GitHub actions for testing

Currently it will fail because of issue #301 (cf. https://github.com/csware/java-html-sanitizer/actions/runs/7623931014) and commit 91c5fdc146a01aab1e8b0db38be449a960fe88c1.

See that it works in principle: <https://github.com/csware/java-html-sanitizer/actions/runs/7623897965> which is based on commit 8277dbc2f7f7725861c8c0af2f001bd3b7385855 and passes the tests

It would also be nice if workflows could be allowed by default (as no GitHub secrets are used)

Btw. I noticed that Travis was used, however, it does not work any more. Should the references (e.g., in README.md) be removed? Also, the coverage report seems to be way outdated.