### PR TITLE
Update valid word-break CSS property values

### DIFF
--- a/src/main/java/org/owasp/html/CssSchema.java
+++ b/src/main/java/org/owasp/html/CssSchema.java
@@ -473,8 +473,10 @@ public final class CssSchema {
     Set<String> whiteSpaceLiterals0 = Set.of(
         "-moz-pre-wrap", "-o-pre-wrap", "-pre-wrap", "nowrap", "pre",
         "pre-line", "pre-wrap");
+    Set<String> wordBreakLiterals0 = Set.of(
+        "break-all", "break-word", "keep-all", "normal");
     Set<String> wordWrapLiterals0 = Set.of(
-        "break-word", "normal");
+        "anywhere", "break-word", "normal");
     Set<String> rgb$FunLiterals0 = Set.of(",");
     Set<String> linearGradient$FunLiterals0 = Set.of(
         ",", "to");
@@ -748,6 +750,7 @@ public final class CssSchema {
     Property whiteSpace = new Property(
         0, union(fontStyleLiterals0, whiteSpaceLiterals0), zeroFns);
     builder.put("white-space", whiteSpace);
+    builder.put("word-break", new Property(0, wordBreakLiterals0, zeroFns));
     builder.put("word-wrap", new Property(0, wordWrapLiterals0, zeroFns));
     builder.put("zoom", new Property(1, fontStretchLiterals1, zeroFns));
     Property rgb$Fun = new Property(1, rgb$FunLiterals0, zeroFns);


### PR DESCRIPTION
Based on https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

What about the generic values such as `inherit`, `initial`, etc.`?

refers to issue #192 