### PR TITLE
Require at least Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A fast and easy to configure HTML Sanitizer written in Java which lets
 you include HTML authored by third-parties in your web application while
 protecting against XSS.
 
-The existing dependency is on JSR 305. The other jars
+The HTML Sanitizer requires at least Java 11.
+The only existing dependency is on JSR 305. The other jars
 are only needed by the test suite.  The JSR 305 dependency is a
 compile-only dependency, only needed for annotations.
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -179,17 +179,13 @@ application while protecting against XSS.
                 <value>bar</value>
               </property>
             </javaApiLinks>
-            <source>6</source>
+            <source>${maven.compiler.source}</source>
           </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
-          <configuration>
-            <source>9</source>
-            <target>9</target>
-          </configuration>
+          <version>3.12.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,9 +88,9 @@ application while protecting against XSS.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>9</maven.compiler.source>
-    <maven.compiler.target>9</maven.compiler.target>
-    <maven.compiler.release>9</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
 


### PR DESCRIPTION
Currently, the Java JDK requirement is inconsistent and not enforced. This PR documents and makes the HTML Sanitizer consistently require JDK11 - this is fine for a new release.

If there are reasons why JDK8 needs to be further supported or security fixes are needed, PR #321 can be considered or just a new release prepared that still uses Guava.