### PR TITLE
Support standard attributes in TABLES Policy

### DIFF
--- a/src/main/java/org/owasp/html/Sanitizers.java
+++ b/src/main/java/org/owasp/html/Sanitizers.java
@@ -27,6 +27,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 package org.owasp.html;
+import java.util.Arrays;
+import java.util.List;
+
 
 /**
  * Pre-packaged HTML sanitizer policies.
@@ -52,6 +55,25 @@ package org.owasp.html;
  */
 public final class Sanitizers {
 
+  
+  /**
+   * An AttributePolicy to allow only string literals "row", "col", "rowgroup" and "colgroup" as attribute values for "scope" in element th
+   * Reference : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
+   */
+  private static final AttributePolicy TABLE_SCOPE_POLICY = new AttributePolicy() {
+
+	private List<String> thScopeWhitelistValues = Arrays.asList("row","col","rowgroup","colgroup");
+	  
+	@Override
+	public String apply(String elementName, String attributeName, String value) {
+		if("scope".equals(attributeName)) {
+			if(thScopeWhitelistValues.contains(value.toLowerCase()))	
+				return value;
+		}
+		return null;
+	}
+  };
+  
   /**
    * Allows common formatting elements including {@code <b>}, {@code <i>}, etc.
    */
@@ -93,6 +115,10 @@ public final class Sanitizers {
     .onElements("table", "tr", "td", "th",
                 "colgroup", "col",
                 "thead", "tbody", "tfoot")
+    .allowAttributes("colspan","rowspan","headers")
+    .onElements("td","th")
+    .allowAttributes("scope").matching(TABLE_SCOPE_POLICY)
+    .onElements("th")
     .allowTextIn("table")  // WIDGY
     .toFactory();
 

--- a/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/src/test/java/org/owasp/html/SanitizersTest.java
@@ -60,6 +60,18 @@ public class SanitizersTest extends TestCase {
   }
 
   @Test
+  public static final void testTableAttributes() {
+	  String input = "<table><tbody><tr align=\"center\"><th headers=\"test\">Month</th><th scope=\"rowgroup\">Test</th></tr>"
+	  		+ "<tr><td headers=\"name\">Test</td><td>A</td></tr><tr><td rowspan=\"2\">Test</td><td>B</td></tr><tr>"
+	  		+ "<td colspan=\"2\">Test</td></tr></tbody></table>";
+	  assertEquals(input, Sanitizers.TABLES.sanitize(input));
+	  
+	  //Negative test to ensure 'scope' doesn't allow random values
+	  assertEquals("<table><tbody><tr><th></th></tr></tbody></table>\n"
+			  	,Sanitizers.TABLES.sanitize("<table><tbody><tr><th scope=\"random\"></th></tr></tbody></table>\n"
+	  		+ ""));
+  }
+  @Test
   public static final void testBlockElements() {
     assertEquals("", Sanitizers.BLOCKS.sanitize(null));
     assertEquals(


### PR DESCRIPTION
Fixes https://github.com/OWASP/java-html-sanitizer/issues/195 and allows more attributes than existing PR

The goal is to allow common safe attributes in table context for in a single PR instead of handling one attribute at a time. Pl let me know if we want to allow more, or if there are issues with this one.