### PR TITLE
allowAttributes("style").globally() shouldn't imply allowStyling() - Regression with 2024 version

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -967,9 +967,6 @@ public class HtmlPolicyBuilder {
      */
     @SuppressWarnings("synthetic-access")
     public HtmlPolicyBuilder globally() {
-      if (attributeNames.contains("style")) {
-        allowStyling();
-      }
       return HtmlPolicyBuilder.this.allowAttributesGlobally(
           policy, attributeNames);
     }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
@@ -541,17 +541,6 @@ public class SanitizersTest extends TestCase {
             pf.sanitize(input)
     );
   }
-
-  @Test
-  public static final void testStyleGlobally() {
-    PolicyFactory policyBuilder = new HtmlPolicyBuilder()
-        .allowAttributes("style").globally()
-        .allowElements("a", "label", "h1", "h2", "h3", "h4", "h5", "h6")
-        .toFactory();
-    String input = "<h1 style=\"color:green ;name:user ;\">This is some green text</h1>";
-    String want = "<h1 style=\"color:green\">This is some green text</h1>";
-    assertEquals(want, policyBuilder.sanitize(input));
-  }
   
   static int fac(int n) {
     int ifac = 1;


### PR DESCRIPTION
This recent breaking changes

- Forces validating global style content with CSSSchema - Earlier we had better options seperately
    allowAttributes("style").globally() - doesn't sanitize, allowStyling() - did sanitize.
- make disallowAttribute("style").globally() now does allowStyling() as pointed out in the PR by someone. 


@mikesamuel @jmanico : Can you kindly have a look as we are facing issues after 2024 version upgrade.


Fixes https://github.com/OWASP/java-html-sanitizer/issues/331