### PR TITLE
Allows start, end, justify-all and match-parent as text-align values.

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -452,7 +452,7 @@ public final class CssSchema {
     Set<String> tableLayoutLiterals0 = j8().setOf(
         "auto", "fixed", "inherit");
     Set<String> textAlignLiterals0 = j8().setOf(
-        "center", "inherit", "justify");
+        "center", "end", "inherit", "justify", "justify-all", "match-parent", "start");
     Set<String> textDecorationLiterals0 = j8().setOf(
         "blink", "line-through", "overline", "underline");
     Set<String> textTransformLiterals0 = j8().setOf(

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -1295,6 +1295,23 @@ public class HtmlPolicyBuilderTest extends TestCase {
   }
 
   @Test
+  public final void testCSSTextAlign() {
+    HtmlPolicyBuilder builder = new HtmlPolicyBuilder();
+    PolicyFactory factory = builder.allowElements("span")
+        .allowAttributes("style").onElements("span").allowStyling()
+        .toFactory();
+
+    String toSanitizeTextAlignStart = "<span style=\"text-align:start\">start</span>";
+    assertEquals(toSanitizeTextAlignStart, factory.sanitize(toSanitizeTextAlignStart));
+
+    String toSanitizeTextAlignEnd = "<span style=\"text-align:end\">end</span>";
+    assertEquals(toSanitizeTextAlignEnd, factory.sanitize(toSanitizeTextAlignEnd));
+
+    String toSanitizeTextAlignFoo = "<span style=\"text-align:foo\">foo</span>";
+    assertEquals("foo", factory.sanitize(toSanitizeTextAlignFoo));
+  }
+
+  @Test
   public final void testCSSFontSize() {
     HtmlPolicyBuilder builder = new HtmlPolicyBuilder();
     PolicyFactory factory = builder.allowElements("span")


### PR DESCRIPTION
After this change, all values currently listed on MDN for text-align are allowed: https://developer.mozilla.org/en-US/docs/Web/CSS/text-align#values

`left` and `right` are not in `textAlignLiterals0`, but they are already included through `azimuthLiterals1`:

https://github.com/OWASP/java-html-sanitizer/blob/f729a089b20aef49ed9ffd7ed1c7e207eee71dc5/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java#L315

https://github.com/OWASP/java-html-sanitizer/blob/f729a089b20aef49ed9ffd7ed1c7e207eee71dc5/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java#L714-L716