### PR TITLE
Issue-338 Changing Java8Shim fallback to catch Throwable

### DIFF
--- a/java8-shim/src/main/java/org/owasp/shim/Java8Shim.java
+++ b/java8-shim/src/main/java/org/owasp/shim/Java8Shim.java
@@ -19,7 +19,7 @@ public abstract class Java8Shim {
             try {
                 // This is compiled with -release 1.9 in a separate project.
                 _instance = Class.forName("org.owasp.shim.ForJava9AndLater").newInstance();
-            } catch (Error e) {
+            } catch (Throwable e) {
                 // This is co-located with this project and is a fall-back.
                 _instance = Class.forName("org.owasp.shim.ForJava8").newInstance();
             }


### PR DESCRIPTION
Java8Shim fallback expecting an Error, few implementations are throwing ClassNotFoundException for missing class ForJava9AndLater.