### PR TITLE
Allowing HTML attributes with _ as the first character in the name (#355)

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -393,8 +393,10 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
           if (i == 0 || i + 1 == n) { return false; }
           break;
         case '-':
-        case '_':
           if (i == 0 || i + 1 == n) { return false; }
+          break;
+        case '_':
+          if (i + 1 == n) { return false; }
           break;
         default:
           if (ch <= '9') {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -196,6 +196,13 @@ public class HtmlSanitizerTest extends TestCase {
   }
 
   @Test
+  public final void testAllowedAttributes() {
+    assertEquals(
+            "<div __foo=\"__foo\" __bar=\"foo\" foo-bar=\"foo-bar\"></div>",
+            sanitize("<div __foo __bar=\"foo\" foo-bar></div>"));
+  }
+
+  @Test
   public static final void testSgmlShortTags() {
     // We make no attempt to correctly handle SGML short tags since they are
     // not implemented consistently across browsers, and have been removed from
@@ -471,7 +478,8 @@ public class HtmlSanitizerTest extends TestCase {
            "ol", "p", "span", "ul", "noscript", "noframes", "noembed", "noxss")
        // And these attributes.
        .allowAttributes(
-           "dir", "checked", "class", "href", "id", "target", "title", "type")
+           "dir", "checked", "class", "href", "id", "target", "title", "type",
+               "__foo", "__bar", "foo-bar")
        .globally()
        // Cleanup IDs and CLASSes and prefix them with p- to move to a separate
        // name-space.


### PR DESCRIPTION
I changed the condition in the HtmlStreamRenderer.isValidHtmlName for `_` to not consider it invalid if it's the first character of the name. I also added a unit test that checks this case.


Fix for issue https://github.com/OWASP/java-html-sanitizer/issues/355