### PR TITLE
Fix resource loading in HtmlSanitizerFuzzerTest

### DIFF
--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerFuzzerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerFuzzerTest.java
@@ -29,6 +29,7 @@
 package org.owasp.html;
 
 import java.io.BufferedReader;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -36,8 +37,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
-import org.apache.commons.codec.Resources;
 
 /**
  * Throws malformed inputs at the HTML sanitizer to try and crash it.
@@ -62,9 +61,17 @@ public class HtmlSanitizerFuzzerTest extends FuzzyTestCase {
       };
 
   public final void testFuzzHtmlParser() throws Exception {
-    String html = new BufferedReader(new InputStreamReader(
-        Resources.getInputStream("benchmark-data/Yahoo!.html"),
-        StandardCharsets.UTF_8)).lines().collect(Collectors.joining()); 
+    String html;
+    try (InputStream resourceStream = getClass().getClassLoader()
+        .getResourceAsStream("benchmark-data/Yahoo!.html")) {
+      if (resourceStream == null) {
+        throw new IllegalArgumentException(
+            "Unable to resolve required resource: benchmark-data/Yahoo!.html");
+      }
+      html = new BufferedReader(new InputStreamReader(
+          resourceStream,
+          StandardCharsets.UTF_8)).lines().collect(Collectors.joining());
+    }
     int length = html.length();
 
     char[] fuzzyHtml0 = new char[length];


### PR DESCRIPTION
## Summary

Fix the failing `HtmlSanitizerFuzzerTest.testFuzzHtmlParser` test that was causing CI builds to fail.

## Problem

The test was using `org.apache.commons.codec.Resources.getInputStream()` to load the benchmark resource file `benchmark-data/Yahoo!.html`. This method uses the thread's context class loader, which may not have the test resources on its classpath in certain execution environments like GitHub Actions with Maven Surefire.

```
java.lang.IllegalArgumentException: Unable to resolve required resource: benchmark-data/Yahoo!.html
    at org.apache.commons.codec.Resources.getInputStream(Resources.java:41)
    at org.owasp.html.HtmlSanitizerFuzzerTest.testFuzzHtmlParser(HtmlSanitizerFuzzerTest.java:66)
```

## Solution

Replace the commons-codec `Resources` utility with the standard Java class loader approach:

```java
getClass().getClassLoader().getResourceAsStream("benchmark-data/Yahoo!.html")
```

This is more reliable because it uses the same class loader that loaded the test class itself, guaranteeing the resource will be found since both the test class and the resource file are in the same classpath scope (`target/test-classes/`).

## Changes

- Removed `org.apache.commons.codec.Resources` import
- Added `java.io.InputStream` import  
- Used standard Java resource loading with try-with-resources to properly handle the stream

## Testing

- All 324 tests pass locally with `./mvnw -B verify`