### PR TITLE
Fix invalid nested <select> when sanitizing <optgroup>

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlElementTables.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlElementTables.java
@@ -109,7 +109,7 @@ public final class HtmlElementTables {
     LI_TAG = indexForName("li");
     SELECT_TAG = indexForName("select");
     OPTION_TAG = indexForName("option");
-    OPTGROUP_TAG = indexForName("opgroup");
+    OPTGROUP_TAG = indexForName("optgroup");
     SCRIPT_TAG = indexForName("script");
     STYLE_TAG = indexForName("style");
     TABLE_TAG = indexForName("table");

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/OptgroupBugTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/OptgroupBugTest.java
@@ -1,0 +1,27 @@
+package org.owasp.html;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class OptgroupBugTest {
+    
+    /**
+     * Test that optgroup elements inside select are not corrupted with extra select tags.
+     * 
+     * Before fix: <select><optgroup><select><option></option></select></optgroup></select>
+     * After fix:  <select><optgroup><option></option></optgroup></select>
+     */
+    @Test
+    public void testOptgroupInsideSelectDoesNotAddExtraSelectTags() {
+        PolicyFactory factory = new HtmlPolicyBuilder()
+            .allowElements("select", "optgroup", "option")
+            .allowAttributes("label").globally()
+            .toFactory();
+        
+        String input = "<select><optgroup label=\"mygroup\"><option>My option</option></optgroup></select>";
+        String result = factory.sanitize(input);
+        
+        // The key assertion: no extra select tags should be inserted
+        assertEquals(input, result);
+    }
+}


### PR DESCRIPTION
**Problem**
When using `<optgroup>` elements within `<select>` tags, the HTML sanitizer was incorrectly inserting extra `<select>` tags, producing invalid HTML.

**Input:**
<select><optgroup label="mygroup"><option>My option</option></optgroup></select>

**Broken Output**
<select><optgroup label="mygroup"><select><option>My option</option></select></optgroup></select>

**Root Cause**
Simple typo in HtmlElementTables.java

**Fixes** #358 

**Note**
Similar behavior was observed with <datalist> but is not included in this PR.