### PR TITLE
Feat: Add support for table span and image lazy-loading attributes

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Sanitizers.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Sanitizers.java
@@ -79,26 +79,9 @@ public final class Sanitizers {
       .allowAttributes("href").onElements("a").requireRelNofollowOnLinks()
       .toFactory();
 
-  /**
-   * Allows common table elements.
-   */
-  public static final PolicyFactory TABLES = new HtmlPolicyBuilder()
-    .allowStandardUrlProtocols()
-    .allowElements(
-                   "table", "tr", "td", "th",
-                   "colgroup", "caption", "col",
-                   "thead", "tbody", "tfoot")
-    .allowAttributes("summary").onElements("table")
-    .allowAttributes("align", "valign")
-    .onElements("table", "tr", "td", "th",
-                "colgroup", "col",
-                "thead", "tbody", "tfoot")
-    .allowTextIn("table")  // WIDGY
-    .toFactory();
-
   private static final AttributePolicy INTEGER = new AttributePolicy() {
     public String apply(
-        String elementName, String attributeName, String value) {
+            String elementName, String attributeName, String value) {
       int n = value.length();
       if (n == 0) { return null; }
       for (int i = 0; i < n; ++i) {
@@ -115,13 +98,33 @@ public final class Sanitizers {
   };
 
   /**
+   * Allows common table elements.
+   */
+  public static final PolicyFactory TABLES = new HtmlPolicyBuilder()
+    .allowStandardUrlProtocols()
+    .allowElements(
+                   "table", "tr", "td", "th",
+                   "colgroup", "caption", "col",
+                   "thead", "tbody", "tfoot")
+    .allowAttributes("summary").onElements("table")
+    .allowAttributes("align", "valign")
+    .onElements("table", "tr", "td", "th",
+                "colgroup", "col",
+                "thead", "tbody", "tfoot")
+    .allowAttributes("colspan", "rowspan").matching(INTEGER).onElements("td", "th")
+    .allowTextIn("table")  // WIDGY
+    .toFactory();
+
+  /**
    * Allows {@code <img>} elements from HTTP, HTTPS, and relative sources.
+   * Allows loading elements
    */
   public static final PolicyFactory IMAGES = new HtmlPolicyBuilder()
       .allowUrlProtocols("http", "https").allowElements("img")
       .allowAttributes("alt", "src").onElements("img")
       .allowAttributes("border", "height", "width").matching(INTEGER)
           .onElements("img")
+      .allowAttributes("loading").matching(true, "lazy", "eager").onElements("img")
       .toFactory();
 
   private Sanitizers() {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
@@ -156,6 +156,18 @@ public class SanitizersTest extends TestCase {
         s.sanitize(
             "<img src=\"x.png\" alt=\"y\" width=\"widgy\" height=64 border=0>")
         );
+    assertEquals(
+            "<img src=\"test.jpg\" loading=\"lazy\" />",
+            s.sanitize("<img src=\"test.jpg\" loading=\"lazy\">"));
+    assertEquals(
+            "<img src=\"test.jpg\" loading=\"eager\" />",
+            s.sanitize("<img src=\"test.jpg\" loading=\"eager\">"));
+    assertEquals(
+            "<img src=\"test.jpg\" />",
+            s.sanitize("<img src=\"test.jpg\" loading=\"auto\">"));
+    assertEquals(
+            "<img src=\"test.jpg\" />",
+            s.sanitize("<img src=\"test.jpg\" loading=\"javascript:alert(1337)\">"));
   }
 
   @Test
@@ -208,6 +220,24 @@ public class SanitizersTest extends TestCase {
             s.sanitize(
                 "<img src=\"x.png\" alt=\"y\" width=\"widgy\" height=596thin border=0>")
             );
+  }
+
+  @Test
+  public static final void testTableColspanRowspan() {
+    PolicyFactory s = Sanitizers.TABLES;
+
+    assertEquals(
+        "<table><tbody><tr><td colspan=\"3\">cell</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td colspan=\"3\">cell</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td rowspan=\"4\">cell</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td rowspan=\"4\">cell</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td>cell</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td colspan=\"three\">cell</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td colspan=\"3\">cell</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td colspan=\"3.5\">cell</td></tr></table>"));
   }
 
   @Test


### PR DESCRIPTION
## Add table and image sanitizer Policy
- added `colspan` and `rowspan` in `TABLES` policy
- added `loading` attributes in `IMAGES` policy

## Background
`colspan` and `rowspan` support had been requested before but never actually implemented. 
The loading attribute on `<img>` is also widely used in practice (e.g. Lighthouse performance scoring).
Both are now considered necessary to allow, so this PR proposes adding them.

`colspan` and `rowspan` are validated with the `INTEGER` policy. 
`loading` is restricted to a strict whitelist (`lazy`, `eager`) to prevent attribute injection.
