### PR TITLE
Run the Build workflow on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
The Build workflow only triggered on pushes to `main`, so open PRs never got a build result and only CodeQL ran against them. This adds a `pull_request` trigger for the same branch so contributors see a green or red check before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKUuD1GhUfpvrDvJen6r91