### PR TITLE
Revert Dependabot bump of empiricism module version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Dependabot security updates are enabled for this repository. This file
+# exists only to stop Dependabot from treating the project's own reactor
+# modules as external dependencies. The modules reference each other via
+# ${project.version} (20000101-SNAPSHOT during development), which Dependabot
+# misreads as an ancient release and then tries to "bump" (see PR #383).
+#
+# open-pull-requests-limit: 0 keeps version-update PRs off; security
+# updates still run, and the ignore rules below apply to both.
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "com.googlecode.owasp-java-html-sanitizer:*"
+  - package-ecosystem: "maven"
+    directory: "/empiricism"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "com.googlecode.owasp-java-html-sanitizer:*"

--- a/empiricism/pom.xml
+++ b/empiricism/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>empiricism</artifactId>
-  <version>20211018.1</version>
+  <version>20000101-SNAPSHOT</version>
   <packaging>jar</packaging>
   <parent>
     <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>


### PR DESCRIPTION
Dependabot PR #383 changed the `empiricism` module's own `<version>` from `20000101-SNAPSHOT` to `20211018.1`. That module is part of this reactor, not an external dependency, so the bump made it look for `java8-shim:20211018.1` on Maven Central, which does not exist, and the main build has failed since.

Two commits:

1. Revert the version bump, restoring the snapshot version.
2. Add `.github/dependabot.yml` that ignores the project's own groupId in both Maven manifests, so Dependabot stops proposing this. Version-update PRs are kept off (`open-pull-requests-limit: 0`); security updates continue to run as before.

The Dependabot alert that prompted #383 was a false positive on `${project.version}` and is already dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKUuD1GhUfpvrDvJen6r91