### PR TITLE
Document inAttribute parameter in HtmlEntities (rebased #267)

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlEntities.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlEntities.java
@@ -2323,6 +2323,7 @@ final class HtmlEntities {
    * @param offset the position of the sequence to decode in {@code html}.
    * @param limit the last position that could be part of the sequence to decode
    *    in {@code html}.
+   * @param inAttribute is html in an attribute value?
    * @param sb string builder to append to.
    * @return The offset after the end of the decoded sequence in {@code html}.
    */
@@ -2440,7 +2441,7 @@ final class HtmlEntities {
         char nameChar = html.charAt(i);
         t = t.lookup(nameChar);
         if (t == null) { break; }
-        if (t.isTerminal() && mayComplete(inAttribute, html, i, limit)) {
+        if (t.isTerminal() && mayComplete(html, inAttribute, i, limit)) {
           longestDecode = t;
           tail = i + 1;
         }
@@ -2453,7 +2454,7 @@ final class HtmlEntities {
           if ('Z' >= nameChar && nameChar >= 'A') { nameChar |= 32; }
           t = t.lookup(nameChar);
           if (t == null) { break; }
-          if (t.isTerminal() && mayComplete(inAttribute, html, i, limit)) {
+          if (t.isTerminal() && mayComplete(html, inAttribute, i, limit)) {
             longestDecode = t;
             tail = i + 1;
           }
@@ -2481,7 +2482,7 @@ final class HtmlEntities {
   }
 
   /** True if the character at i in html may complete a named character reference */
-  private static boolean mayComplete(boolean inAttribute, String html, int i, int limit) {
+  private static boolean mayComplete(String html, boolean inAttribute, int i, int limit) {
     if (inAttribute && html.charAt(i) != ';' && i + 1 < limit) {
       // See if the next character blocks treating this as a full match.
       // This avoids problems like "&para" being treated as a decoding in


### PR DESCRIPTION
Rebase of #267 by @yangbongsoo onto the module layout, preserving their authorship. Adds the missing `@param inAttribute` Javadoc and puts the `mayComplete` parameters in the same order as the public method. No behaviour change. Supersedes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKUuD1GhUfpvrDvJen6r91