### PR TITLE
Add regression test for #237

### DIFF
--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
@@ -607,6 +607,25 @@ public class SanitizersTest extends TestCase {
     assertEquals(want, policyBuilder.sanitize(input));
   }
 
+  /**
+   * Regression test for
+   * <a href="https://github.com/OWASP/java-html-sanitizer/issues/237">#237</a>:
+   * other attributes allowed globally alongside {@code style} must survive,
+   * and {@code style} must still be filtered through the CSS schema.
+   */
+  @Test
+  public static final void testStyleWithOtherAttributesGlobally() {
+    PolicyFactory policyBuilder = new HtmlPolicyBuilder()
+        .allowAttributes("style", "align").globally()
+        .allowElements("a", "label", "h1", "h2", "h3", "h4", "h5", "h6")
+        .toFactory();
+    String input = "<h1 style=\"color:green ;name:user ;\" align=\"center\">"
+        + "This is some green centered text</h1>";
+    String want = "<h1 style=\"color:green\" align=\"center\">"
+        + "This is some green centered text</h1>";
+    assertEquals(want, policyBuilder.sanitize(input));
+  }
+
   static int fac(int n) {
     int ifac = 1;
     for (int i = 1; i <= n; ++i) {


### PR DESCRIPTION
Adds the test case from #237 / #238 by @corebonts to `SanitizersTest`, credited to them. The bug it covers (global attributes dropped when `style` was in the list) was fixed by #248; this makes sure it stays fixed and that `style` is still schema-filtered alongside other global attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKUuD1GhUfpvrDvJen6r91