### PR TITLE
Stop publishing the empiricism test harness

### DIFF
--- a/empiricism/pom.xml
+++ b/empiricism/pom.xml
@@ -10,6 +10,11 @@
   </parent>
 
   <name>empiricism</name>
+
+  <properties>
+    <!-- Internal test harness; never publish it. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
   <url>https://github.com/OWASP/java-html-sanitizer</url>
   <description>
     HTML metadata derived by interrogating a browser's HTML parser


### PR DESCRIPTION
`empiricism` is an internal measurement harness, yet it has been deployed to Maven Central with every release (see https://repo1.maven.org/maven2/com/googlecode/owasp-java-html-sanitizer/empiricism/). Set `maven.deploy.skip` so the publication profile leaves it out of the staging directory that JReleaser uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKUuD1GhUfpvrDvJen6r91