### PR TITLE
Correct the license statement to BSD 2-Clause and declare it in the POM

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
 You may use under either the Apache License Version 2.0 or the BSD
-3-Clause License.
+2-Clause License.
 
 ------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ We welcome [issue reports](https://github.com/OWASP/java-html-sanitizer/issues) 
 PRs that change behavior or that add functionality should include both positive and
 [negative tests](https://www.guru99.com/negative-testing.html).
 
-Please be aware that contributions fall under the [Apache 2.0 License](https://github.com/OWASP/java-html-sanitizer/blob/main/COPYING).
+Please be aware that contributions fall under the project's dual license: the
+[Apache License, Version 2.0 or the BSD 2-Clause License](https://github.com/OWASP/java-html-sanitizer/blob/main/COPYING),
+at the recipient's option.
 
 ## Credits
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,15 @@ application while protecting against XSS.
       <name>Apache License, Version 2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
+      <comments>Dual-licensed; you may use this software under either this
+        license or the BSD 2-Clause License. See COPYING.</comments>
+    </license>
+    <license>
+      <name>BSD 2-Clause License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
+      <distribution>repo</distribution>
+      <comments>Dual-licensed; you may use this software under either this
+        license or the Apache License, Version 2.0. See COPYING.</comments>
     </license>
   </licenses>
 


### PR DESCRIPTION
Fixes #271. Fixes #288.

## The contradiction

`COPYING` line 1 offers *"the Apache License Version 2.0 or the BSD 3-Clause License"*, but the BSD text that follows it has only **two** conditions — the "Neither the name of ... may be used to endorse or promote" clause is absent. That text is the BSD **2**-Clause License. Both reporters were right; the issues have been open since 2022 and 2023.

Separately, `pom.xml` declared Apache-2.0 as the sole license, so the POM disagreed with `COPYING`'s offer of a choice — anyone consuming the artifact's metadata rather than reading the repo would never learn the BSD option exists.

## The fix

The actual license text governs, so the heading is corrected to match the grant that has always been in the file:

- **`COPYING`** — "BSD 3-Clause License" → "BSD 2-Clause License".
- **`pom.xml`** — both licenses are now listed, each carrying a `<comments>` note making the *either/or* relationship explicit, since Maven's `<licenses>` element is otherwise ambiguous between "dual-licensed" and "all of these apply at once".
- **`README.md`** — the contribution note said contributions fall under the Apache 2.0 License alone; it now states the dual license.

## Why this needs no relicensing

BSD 2-Clause is strictly *more permissive* than BSD 3-Clause: it is the same license minus a restriction. Correcting the heading downward therefore grants no new rights and takes nothing away from any existing user — the sentence now simply describes the text printed beneath it. Going the other way, adding a third clause to match the heading, **would** narrow the grant and would require @mikesamuel's consent.

## Deliberately out of scope

The per-file headers in all 60 Java sources carry the BSD **3**-Clause form — they retain the no-endorsement clause. They are left untouched here. Stripping that clause would broaden the grant on existing copyrights and is a separate decision for the copyright holders, not a documentation fix. Repo-level `COPYING` already offers BSD-2 regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iLZCxwbTLngwvBzNqKuVg