### PR TITLE
Add a LICENSE file with the Apache-2.0 text so tooling detects a license

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /COPYING text
+/LICENSE text
 /src/test/resources/org/owasp/html/* text eol=lf
 .gitattributes text
 .gitignore text

--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,3 @@
-You may use under either the Apache License Version 2.0 or the BSD
-2-Clause License, at your option.
-
-SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause
-
-This file is the authoritative statement of the grant.  The full text of
-both licenses follows, and third-party code bundled in this repository
-under different terms is listed at the end.
-
-The separate LICENSE file contains only the Apache-2.0 arm, so that tooling
-which expects a single license file can identify one.  It does not narrow
-the choice offered here: recipients may still take either license.
-
-------------------------------------------------------------------
 
                                  Apache License
                            Version 2.0, January 2004
@@ -214,49 +200,3 @@ the choice offered here: recipients may still take either license.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-------------------------------------------------------------------
-
-Copyright (c) 2011, Mike Samuel
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-------------------------------------------------------------------
-
-THIRD-PARTY CODE
-
-The following files are not covered by the dual license above.  They
-originate from the OWASP AntiSamy project and are used here under the
-BSD 3-Clause License, which additionally forbids using the copyright
-holders' names to endorse derived products:
-
-  owasp-java-html-sanitizer/src/test/java/org/owasp/html/AntiSamyTest.java
-  owasp-java-html-sanitizer/src/test/java/org/owasp/html/AntiSamyBenchmark.java
-
-    Copyright (c) 2007-2010, Arshan Dabirsiaghi, Jason Li
-    SPDX-License-Identifier: BSD-3-Clause
-
-Each file carries its own license header.  Both are test sources only;
-neither is compiled into the distributed artifact.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ extensive test suite, and has undergone
 *  [Telemetry](#telemetry)
 *  [Questions\?](#questions)
 *  [Contributing](#contributing)
+*  [License](#license)
 *  [Credits](#credits)
 
 ## Getting Started
@@ -209,6 +210,22 @@ PRs that change behavior or that add functionality should include both positive 
 Please be aware that contributions fall under the project's dual license:
 `Apache-2.0 OR BSD-2-Clause`, at the recipient's option. See
 [COPYING](https://github.com/OWASP/java-html-sanitizer/blob/main/COPYING).
+
+## License
+
+Dual licensed: **`Apache-2.0 OR BSD-2-Clause`**.  You may use this software
+under either the [Apache License, Version 2.0](LICENSE) or the BSD 2-Clause
+License, at your option -- you do not need to comply with both.
+
+[COPYING](COPYING) is the authoritative statement of the grant and contains
+the full text of both licenses.  `LICENSE` holds only the Apache-2.0 arm, so
+that automated tooling which understands a single license file detects one;
+it does not narrow the choice offered by `COPYING`.
+
+Every source file carries an SPDX identifier.  Two AntiSamy-derived test
+files are third-party code under `BSD-3-Clause` and are listed under
+THIRD-PARTY CODE in `COPYING`; they are not compiled into the published
+artifact.
 
 ## Credits
 


### PR DESCRIPTION
Follow-up to #393 and #394. Those made the licensing internally consistent; this makes it *machine-detectable*.

## Why

GitHub reported this repo's license as `NOASSERTION` / "Other". That field feeds Dependabot, SBOM generators, Syft and most corporate scanners — so to automated tooling, the project appeared to have **no license at all**.

GitHub's detector (`licensee`) matches a *single* license file against known templates at ~98% similarity. `COPYING` holds two full license texts plus a third-party section, so it can never match any one template. A `LICENSE` file containing only the Apache-2.0 arm gives the detector something it can identify.

## The pristine-text constraint

`LICENSE` is **byte-for-byte identical** to the canonical text at `https://www.apache.org/licenses/LICENSE-2.0.txt` — verified by `diff` against the fetched original, not reproduced from memory.

Nothing is prepended to it, deliberately. Even a short "this project is dual licensed" preamble risks dropping similarity below the match threshold and defeating the entire purpose of adding the file. Since `LICENSE` therefore cannot explain itself, the cross-references live elsewhere:

- **`COPYING`** states that it remains authoritative, and that `LICENSE` carries only the Apache arm *without narrowing the choice offered*.
- **`README`** gains a real `## License` section. It previously had none — only a passing mention buried under Contributing — which was itself a gap. It documents the dual grant, the SPDX expression, and the third-party AntiSamy files, plus a table-of-contents entry.
- **`.gitattributes`** normalizes `LICENSE` line endings, as it already does for `COPYING`.

## This grants and removes nothing

Recipients may still take **either** license. Only the machine-readable presentation changes. The one honest tradeoff: someone who reads *only* `LICENSE` sees just the Apache arm — which is a valid license for this project, merely not the complete picture. `COPYING`, the README, the POM and all 77 SPDX tags carry the full dual grant.

## Verification

```
LICENSE vs canonical apache.org text : identical, byte for byte
build                                : green
tests                                : 341, 0 failures, 0 errors
```

Note that GitHub recomputes license detection asynchronously after merge, so the badge may take a few minutes to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iLZCxwbTLngwvBzNqKuVg