### PR TITLE
Follow the WHATWG tokenizer for degenerate HTML comments

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -17,9 +17,11 @@ Most recent at top.
       artifacts are no longer published separately. If you added an explicit
       dependency on `java8-shim` or `java10-shim` as a workaround, remove it.
     * HTML: Follow the WHATWG tokenizer for degenerate comments. `<!>`,
-      `<!-->` and `<!--->` are complete empty comments, and `--!>` closes a
-      comment, matching browser behaviour instead of swallowing the content
-      that followed.
+      `<!-->`, `<!--->` and `<!->` are complete empty comments, and `--!>`
+      closes a comment even when only dashes precede it (`<!----!>`),
+      matching browser behaviour instead of swallowing the content that
+      followed (issue #258).  Conversely, only a contiguous `-->` or `--!>`
+      closes a comment: `<!-- a -x->` no longer ends it early.
     * HTML: Attribute names may begin with an underscore.
     * HTML: `Sanitizers.TABLES` allows integer `colspan` and `rowspan` on
       `td` and `th`; `Sanitizers.IMAGES` allows `loading="lazy|eager"`.

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
@@ -476,6 +476,7 @@ final class HtmlInputSplitter extends AbstractTokenStream {
     COMMENT_DASH_DASH,
     COMMENT_DASH_DASH_BANG,
     COMMENT_DASH_AFTER_BANG,
+    COMMENT_START_DASH,
     DIRECTIVE,
     DONE,
     BOGUS_COMMENT,
@@ -650,16 +651,32 @@ final class HtmlInputSplitter extends AbstractTokenStream {
                 case BANG_DASH:
                   if ('-' == ch) {
                     state = State.COMMENT_DASH_AFTER_BANG;
+                  } else if ('>' == ch) {
+                    // <!-> is a bogus comment that ends at the first '>'
+                    state = State.DONE;
+                    type = HtmlTokenType.COMMENT;
                   } else {
                     state = State.DIRECTIVE;
                   }
                   break;
-                case COMMENT_DASH_AFTER_BANG:
+                case COMMENT_DASH_AFTER_BANG:  // Just after "<!--"
                   if ('>' == ch) { // <!--> is a valid html comment
                     state = State.DONE;
                     type = HtmlTokenType.COMMENT;
-                  } else if ('-' == ch) { // <!---> is a valid html comment
-                    state = State.COMMENT_DASH_AFTER_BANG;
+                  } else if ('-' == ch) {
+                    state = State.COMMENT_START_DASH;
+                  } else {
+                    state = State.COMMENT;
+                  }
+                  break;
+                case COMMENT_START_DASH:  // Just after "<!---"
+                  if ('>' == ch) { // <!---> is a valid html comment
+                    state = State.DONE;
+                    type = HtmlTokenType.COMMENT;
+                  } else if ('-' == ch) {
+                    // <!---- is in the comment end state, so --!> or more
+                    // dashes followed by > will close the comment.
+                    state = State.COMMENT_DASH_DASH;
                   } else {
                     state = State.COMMENT;
                   }
@@ -672,9 +689,11 @@ final class HtmlInputSplitter extends AbstractTokenStream {
                   }
                   break;
                 case COMMENT_DASH:
+                  // Anything but a second dash is ordinary comment content,
+                  // so "-x->" must not close the comment.
                   state = ('-' == ch)
                       ? State.COMMENT_DASH_DASH
-                      : State.COMMENT_DASH;
+                      : State.COMMENT;
                   break;
                 case COMMENT_DASH_DASH:
                   if ('>' == ch) {
@@ -685,7 +704,7 @@ final class HtmlInputSplitter extends AbstractTokenStream {
                   } else if ('-' == ch) {
                     state = State.COMMENT_DASH_DASH;
                   } else {
-                    state = State.COMMENT_DASH;
+                    state = State.COMMENT;
                   }
                   break;
                 case COMMENT_DASH_DASH_BANG:

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
@@ -166,7 +166,98 @@ public class HtmlLexerTest extends TestCase {
             "TEXT: a",
             "COMMENT: <!--->",
             "TEXT: b",
-            "SERVERCODE: <!->c"
+            "COMMENT: <!->",
+            "TEXT: c"
+    );
+  }
+
+  @Test
+  public static final void testBangDashIsABogusComment() throws Exception
+  {
+    // <!- followed by anything but a dash is a bogus comment that ends at
+    // the first '>', so <!-> must not swallow the following tag.
+    assertTokens("<!->c<b>after</b>",
+            "COMMENT: <!->",
+            "TEXT: c",
+            "TAGBEGIN: <b",
+            "TAGEND: >",
+            "TEXT: after",
+            "TAGBEGIN: </b",
+            "TAGEND: >"
+    );
+    assertTokens("<!-x>c<b>after</b>",
+            "DIRECTIVE: <!-x>",
+            "TEXT: c",
+            "TAGBEGIN: <b",
+            "TAGEND: >",
+            "TEXT: after",
+            "TAGBEGIN: </b",
+            "TAGEND: >"
+    );
+  }
+
+  @Test
+  public static final void testDashDashBangClosesCommentAfterLeadingDashes() throws Exception
+  {
+    // Issue #258: <!-- followed only by dashes and then --!> must terminate
+    // rather than swallowing the rest of the document.
+    assertTokens("<!----!><b>after</b>",
+            "COMMENT: <!----!>",
+            "TAGBEGIN: <b",
+            "TAGEND: >",
+            "TEXT: after",
+            "TAGBEGIN: </b",
+            "TAGEND: >"
+    );
+    assertTokens("<!-----!><b>after</b>",
+            "COMMENT: <!-----!>",
+            "TAGBEGIN: <b",
+            "TAGEND: >",
+            "TEXT: after",
+            "TAGBEGIN: </b",
+            "TAGEND: >"
+    );
+    // Fewer than two dashes after <!-- do not reach the comment end state,
+    // so !> is ordinary comment content and the comment runs to the end.
+    assertTokens("<!--!><b>after</b>",
+            "COMMENT: <!--!><b>after</b>"
+    );
+    assertTokens("<!---!><b>after</b>",
+            "COMMENT: <!---!><b>after</b>"
+    );
+  }
+
+  @Test
+  public static final void testCommentCloseRequiresAdjacentDashes() throws Exception
+  {
+    // A dash followed by other content is ordinary comment text; only a
+    // contiguous "-->" (or "--!>") closes the comment, as in a browser.
+    assertTokens("<!-- a -x-><b>after</b>",
+            "COMMENT: <!-- a -x-><b>after</b>"
+    );
+    assertTokens("<!-- a --b-><b>after</b>",
+            "COMMENT: <!-- a --b-><b>after</b>"
+    );
+    assertTokens("<!-- a -x--><b>after</b>",
+            "COMMENT: <!-- a -x-->",
+            "TAGBEGIN: <b",
+            "TAGEND: >",
+            "TEXT: after",
+            "TAGBEGIN: </b",
+            "TAGEND: >"
+    );
+    assertTokens("<!-- a --b--><b>after</b>",
+            "COMMENT: <!-- a --b-->",
+            "TAGBEGIN: <b",
+            "TAGEND: >",
+            "TEXT: after",
+            "TAGBEGIN: </b",
+            "TAGEND: >"
+    );
+    // Issue #231: the comment used to end at "->" before "I'M".
+    assertTokens("<!-- COMMENT -- ME -> I'M ALONE --> MY CODE",
+            "COMMENT: <!-- COMMENT -- ME -> I'M ALONE -->",
+            "TEXT:  MY CODE"
     );
   }
 

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -321,6 +321,30 @@ public class HtmlSanitizerTest extends TestCase {
   }
 
   @Test
+  public static final void testDegenerateComments() {
+    // Issue #258: a comment opened by <!-- and closed by --!> after nothing
+    // but dashes must not swallow the rest of the document.
+    assertEquals("<b>after</b>", sanitize("<!----!><b>after</b>"));
+    assertEquals("<b>after</b>", sanitize("<!-----!><b>after</b>"));
+    // <!-> is an empty bogus comment, not a directive that runs to the
+    // next '>' and eats the following tag.
+    assertEquals("c<b>after</b>", sanitize("<!->c<b>after</b>"));
+    // Other complete empty comments.
+    assertEquals("x", sanitize("<!>x"));
+    assertEquals("x", sanitize("<!-->x"));
+    assertEquals("x", sanitize("<!--->x"));
+    // Fewer than two dashes after <!-- leave !> as comment content, so the
+    // comment runs to the end of input, as it does in a browser.
+    assertEquals("", sanitize("<!--!><b>after</b>"));
+    assertEquals("", sanitize("<!---!><b>after</b>"));
+    // Only a contiguous --> or --!> closes a comment; a lone dash followed
+    // later by -> does not, so these comments also run to end of input.
+    assertEquals("", sanitize("<!-- a -x-><b>after</b>"));
+    assertEquals("", sanitize("<!-- a --b-><b>after</b>"));
+    assertEquals("<b>after</b>", sanitize("<!-- a -x--><b>after</b>"));
+  }
+
+  @Test
   public static final void testQMarkMeta() {
     assertEquals(
         "Hello, <b>World</b>!",


### PR DESCRIPTION
Fixes #258, fixes #231, fixes #396.

Three deviations in `HtmlLexer`'s `<!` state machine let a comment swallow more, or less, of the document than a browser would. All three are fidelity bugs rather than security bugs (comments are dropped from the output either way), but each can silently erase or expose content that follows a comment in a rich-text field.

## `<!----!>` never terminates a comment (#258)

`COMMENT_DASH_AFTER_BANG` lumped `<!--`, `<!---` and `<!----` into a single state and sent `!` to plain `COMMENT` instead of the comment-end-bang state, so `<!----!><b>after</b>` sanitized to the empty string. The state is now split: `COMMENT_DASH_AFTER_BANG` is "just after `<!--`", the new `COMMENT_START_DASH` is "just after `<!---`", and a further dash lands in `COMMENT_DASH_DASH`, which already handles `-->` and `--!>`.

## `<!->` swallows the following tag (#396)

`BANG_DASH` moved `>` into `DIRECTIVE` after consuming it, so the directive ran to the *next* `>`: `<!->c<b>after</b>` yielded `after`. `BANG_DASH` now ends the token on `>` as an empty comment, matching how `BANG` already handles `<!>`. `testAbruptClosingOfEmptyComment` asserted the old behaviour and is corrected.

## A lone `-` followed later by `->` closes a comment (#231)

Once a comment contained a single dash, `COMMENT_DASH` never returned to `COMMENT`, so `<!-- COMMENT -- ME -> I'M ALONE --> MY CODE` ended at `->`. The "anything else" branches of `COMMENT_DASH` and `COMMENT_DASH_DASH` now fall back to `COMMENT`, so only a contiguous `-->` or `--!>` closes a comment.

## Verification

Every asserted case, including the negative ones, was checked against Chrome's tokenizer via `innerHTML`: `<!----!>` and `<!-----!>` close; `<!--!>` and `<!---!>` do **not** (the `!>` is comment content and the comment runs to end of input); `<!->` and `<!-x>` are bogus comments ending at the first `>`; `<!-- a -x->` and `<!-- a --b->` do not close.

New tests: `HtmlLexerTest.testBangDashIsABogusComment`, `testDashDashBangClosesCommentAfterLeadingDashes`, `testCommentCloseRequiresAdjacentDashes` (includes the exact #231 input), and end-to-end `HtmlSanitizerTest.testDegenerateComments`. Full module suite: 345 tests, 0 failures. `change_log.md`'s existing unreleased "degenerate comments" entry is extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
