### PR TITLE
Fix stale SECURITY.md version, JReleaser previous tag, and deprecated CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -71,6 +71,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,33 @@ jobs:
             echo "Version is already set to ${{ github.event.inputs.version }}"
           fi
 
+      - name: Resolve previous release tag
+        id: previous_tag
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          # Hand JReleaser the previous dated release tag explicitly so the
+          # generated release notes cover only the commits since that release.
+          # Only release-YYYYMMDD[.N] tags count, which skips the legacy release-223
+          # tag. The previous tag is the newest one that sorts below this version.
+          previous=$( { git tag --list 'release-*'; echo "release-${VERSION}"; } \
+            | grep -E '^release-[0-9]{8}(\.[0-9]+)?$' \
+            | sort -uV \
+            | awk -v current="release-${VERSION}" '$0 == current { print prev; exit } { prev = $0 }')
+          if [ -z "$previous" ]; then
+            echo "::error::Could not resolve the previous release tag from git tags"
+            exit 1
+          fi
+          echo "Previous release tag: $previous"
+          echo "tag=$previous" >> "$GITHUB_OUTPUT"
+
       - name: Build
         run: ./mvnw -ntp -B -Ppublication
 
       - name: Release
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_PREVIOUS_TAG_NAME: ${{ steps.previous_tag.outputs.tag }}
           JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-Only the lastest version are supported with updates.
+Only the latest version is supported with updates.
 
 | Version    | Supported          |
 | ---------- | ------------------ |
-| 20260103.1 | :white_check_mark: |
+| 20260313.1 | :white_check_mark: |
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,6 @@ application while protecting against XSS.
                 <release>
                   <github>
                     <tagName>release-{{projectVersion}}</tagName>
-                    <previousTagName>release-20260101.1</previousTagName>
                     <releaseName>Release {{projectVersion}}</releaseName>
                     <changelog>
                       <formatted>ALWAYS</formatted>


### PR DESCRIPTION
## Summary

- **SECURITY.md** listed `20260103.1` as the supported version, which was never released (tags are `20260102.1` and `20260313.1`). It now lists `20260313.1`. The typo in the sentence above the table is fixed too.
- **JReleaser `previousTagName`** was pinned to `release-20260101.1`, so the 20260313.1 release notes replayed everything since January. The pin is removed from `pom.xml`, and `release.yml` now resolves the previous dated release tag with git and passes it via `JRELEASER_PREVIOUS_TAG_NAME`, so it cannot go stale again.
- **CodeQL** used `github/codeql-action@v2`, which is deprecated. Bumped to **v4** rather than v3: the upstream changelog states v3 is deprecated in December 2026, so v3 would have bought three months.

## Previous-tag resolution

- JReleaser's built-in lookup matches every `release-*` tag, including the legacy `release-223` tag from 2014. The new step only considers `release-YYYYMMDD[.N]` tags, picks the newest one that version-sorts below the version being released, and fails the job before any publishing if nothing matches.
- A non-blank pom value takes precedence over the env var, so removing the pin is what makes the env var apply.

## Verification

- Local JReleaser 1.22.0 dry-run (`jreleaser:changelog` with the pom temporarily set to 20260907.1) and `JRELEASER_PREVIOUS_TAG_NAME=release-20260313.1` logged `looking for previous tag 'release-20260313.1'` then `found tag release-20260313.1`.
- The step script, run locally under the runner's `bash -eo pipefail`, resolves 20260907.1 → release-20260313.1, 20260313.1 → release-20260102.1, 20260102.1 → release-20260101.1, and exits 1 for a version with no older dated tag.
- Both workflow files parse as YAML and `pom.xml` parses as XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
