### PR TITLE
Remove the unbound Coveralls plugin and its committed repo token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OWASP Java HTML Sanitizer
 
-[![Build](https://github.com/OWASP/java-html-sanitizer/actions/workflows/build.yml/badge.svg)](https://github.com/OWASP/java-html-sanitizer/actions/workflows/build.yml) [![Coverage Status](https://coveralls.io/repos/github/OWASP/java-html-sanitizer/badge.svg?branch=main)](https://coveralls.io/github/OWASP/java-html-sanitizer?branch=main) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2602/badge)](https://bestpractices.coreinfrastructure.org/projects/2602) [![Maven Central](https://img.shields.io/maven-central/v/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer.svg)](https://search.maven.org/artifact/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer)
+[![Build](https://github.com/OWASP/java-html-sanitizer/actions/workflows/build.yml/badge.svg)](https://github.com/OWASP/java-html-sanitizer/actions/workflows/build.yml) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2602/badge)](https://bestpractices.coreinfrastructure.org/projects/2602) [![Maven Central](https://img.shields.io/maven-central/v/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer.svg)](https://search.maven.org/artifact/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer)
 
 
 A fast and easy to configure HTML Sanitizer written in Java which lets

--- a/change_log.md
+++ b/change_log.md
@@ -37,6 +37,9 @@ Most recent at top.
     * Build: `empiricism/rebuild.sh` regenerates `HtmlElementTablesCanned.java`
       again.  The 2024 Guava removal had turned the generator's array-length
       check into a literal `3`, so it rejected every `explicitClosers` entry.
+    * Build: Coveralls coverage reporting is removed.  The plugin had not run
+      since the Travis scripts were deleted in 2024, and the repo token that
+      was committed with it in 2019 has been revoked.
     * Docs: README examples compile again; Javadoc links point at `latest`.
     * Special thanks to (in lexicographic order):
       Alessandro Ruzzon, corebonts, Daham Chinthana, Domi, hwangjeyeon,

--- a/owasp-java-html-sanitizer/pom.xml
+++ b/owasp-java-html-sanitizer/pom.xml
@@ -55,13 +55,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <configuration>
-          <repoToken>TENYw0IKRulLOXgkyzjGqNi0hQyhBiSiU</repoToken>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -165,20 +165,6 @@ application while protecting against XSS.
           <version>0.8.3</version>
         </plugin>
         <plugin>
-          <groupId>org.eluder.coveralls</groupId>
-          <artifactId>coveralls-maven-plugin</artifactId>
-          <version>4.3.0</version>
-
-          <dependencies>
-            <dependency>
-              <!-- https://github.com/trautonen/coveralls-maven-plugin/issues/112#issuecomment-343114987 -->
-              <groupId>javax.xml.bind</groupId>
-              <artifactId>jaxb-api</artifactId>
-              <version>2.2.3</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <extensions>true</extensions>


### PR DESCRIPTION
## Summary

Closes #400.

`coveralls-maven-plugin` has not been invoked since the Travis build script was deleted in 65d48ea, but `owasp-java-html-sanitizer/pom.xml` still carried it with a hard-coded repo token, the root POM pinned it in `pluginManagement` together with the `jaxb-api` workaround it needed, and the README showed a Coverage badge for numbers nobody uploads.

The token has been revoked on coveralls.io. This removes the last references to it. `jacoco` stays for local coverage reports, and `change_log.md` records the removal.

Stacked on #399; the diff shrinks to this one commit once that merges.

## Verification

| Build | JDK | Result |
|---|---|---|
| `./mvnw -ntp -B clean verify` | 11.0.32.1 | PASS, 345 tests, 0 failures |
| `./mvnw -ntp -B clean verify -Ppublication` | 11.0.32.1 | PASS, javadoc and sources jars for all modules |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
