### PR TITLE
Allow headers and scope on table cells in Sanitizers.TABLES

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -25,6 +25,9 @@ Most recent at top.
     * HTML: Attribute names may begin with an underscore.
     * HTML: `Sanitizers.TABLES` allows integer `colspan` and `rowspan` on
       `td` and `th`; `Sanitizers.IMAGES` allows `loading="lazy|eager"`.
+    * HTML: `Sanitizers.TABLES` allows `headers` on `td` and `th`, limited to a
+      space-separated list of ID tokens, and `scope` on `th`, limited to `row`,
+      `col`, `rowgroup` and `colgroup` and canonicalized to lower case (PR #326).
     * CSS: `text-align` accepts `start`, `end`, `justify-all` and `match-parent`.
     * CSS: `calc()` is allowed in `width`, `min-width`, `max-width`, `height`,
       `min-height` and `max-height` (issue #361).  Operands are limited to
@@ -50,8 +53,8 @@ Most recent at top.
     * Docs: README examples compile again; Javadoc links point at `latest`.
     * Special thanks to (in lexicographic order):
       Alessandro Ruzzon, corebonts, Daham Chinthana, Domi, hwangjeyeon,
-      Martin Jackson, Raibipasha-24, strangelookingnerd, Sven Strickroth,
-      yangbongsoo
+      Martin Jackson, Raibipasha-24, strangelookingnerd, subbudvk,
+      Sven Strickroth, yangbongsoo
   * Release 20260313.1
     * Fix: Preserve the order of `rel` attribute values while still
       de-duplicating them.

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Sanitizers.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Sanitizers.java
@@ -97,6 +97,36 @@ public final class Sanitizers {
   };
 
   /**
+   * Accepts a space-separated list of ID references, as used by the
+   * {@code headers} attribute on table cells.  Each token is limited to ASCII
+   * letters, digits and {@code _ - . :}, and runs of white-space between
+   * tokens collapse to a single space.
+   */
+  private static final AttributePolicy ID_LIST = new AttributePolicy() {
+    public String apply(
+            String elementName, String attributeName, String value) {
+      int n = value.length();
+      StringBuilder sb = new StringBuilder(n);
+      for (int i = 0; i < n; ++i) {
+        char ch = value.charAt(i);
+        if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\f' || ch == '\r') {
+          int len = sb.length();
+          if (len != 0 && sb.charAt(len - 1) != ' ') { sb.append(' '); }
+        } else if (('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')
+                   || ('0' <= ch && ch <= '9')
+                   || ch == '_' || ch == '-' || ch == '.' || ch == ':') {
+          sb.append(ch);
+        } else {
+          return null;
+        }
+      }
+      int len = sb.length();
+      if (len != 0 && sb.charAt(len - 1) == ' ') { sb.setLength(--len); }
+      return len == 0 ? null : sb.toString();
+    }
+  };
+
+  /**
    * Allows common table elements.
    */
   public static final PolicyFactory TABLES = new HtmlPolicyBuilder()
@@ -111,6 +141,9 @@ public final class Sanitizers {
                 "colgroup", "col",
                 "thead", "tbody", "tfoot")
     .allowAttributes("colspan", "rowspan").matching(INTEGER).onElements("td", "th")
+    .allowAttributes("headers").matching(ID_LIST).onElements("td", "th")
+    .allowAttributes("scope").matching(true, "row", "col", "rowgroup", "colgroup")
+        .onElements("th")
     .allowTextIn("table")  // WIDGY
     .toFactory();
 

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
@@ -240,6 +240,62 @@ public class SanitizersTest extends TestCase {
   }
 
   @Test
+  public static final void testTableHeadersAndScope() {
+    PolicyFactory s = Sanitizers.TABLES;
+
+    // scope is limited to the four spec values and canonicalized to lower case.
+    assertEquals(
+        "<table><tbody><tr><th scope=\"col\">h</th></tr></tbody></table>",
+        s.sanitize("<table><tr><th scope=\"col\">h</th></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><th scope=\"rowgroup\">h</th></tr></tbody></table>",
+        s.sanitize("<table><tr><th scope=\"RowGroup\">h</th></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><th>h</th></tr></tbody></table>",
+        s.sanitize("<table><tr><th scope=\"random\">h</th></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><th>h</th></tr></tbody></table>",
+        s.sanitize("<table><tr><th scope=\"col row\">h</th></tr></table>"));
+    // scope is only meaningful on th.
+    assertEquals(
+        "<table><tbody><tr><td>c</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td scope=\"col\">c</td></tr></table>"));
+
+    // headers is a space-separated list of ids, on both td and th.
+    assertEquals(
+        "<table><tbody><tr><th headers=\"h1\">h</th>"
+        + "<td headers=\"h1 h2\">c</td></tr></tbody></table>",
+        s.sanitize(
+            "<table><tr><th headers=\"h1\">h</th>"
+            + "<td headers=\"h1 h2\">c</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td headers=\"h-1 h.2:x\">c</td></tr></tbody></table>",
+        s.sanitize(
+            "<table><tr><td headers=\"  h-1 \t h.2:x  \">c</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td>c</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td headers=\"\">c</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td>c</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td headers=\"   \">c</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td>c</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td headers=\"h1,h2\">c</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td>c</td></tr></tbody></table>",
+        s.sanitize(
+            "<table><tr><td headers=\"javascript:alert(1)\">c</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td>c</td></tr></tbody></table>",
+        s.sanitize(
+            "<table><tr><td headers=\"h1&quot; onmouseover=&quot;alert(1)\">"
+            + "c</td></tr></table>"));
+    assertEquals(
+        "<table><tbody><tr><td>c</td></tr></tbody></table>",
+        s.sanitize("<table><tr><td headers=\"hé\">c</td></tr></table>"));
+  }
+
+  @Test
   public static final void testLinks() {
     PolicyFactory s = Sanitizers.LINKS;
     assertEquals(


### PR DESCRIPTION
Salvages the two attributes from #326 that #378 did not already land, on a fresh branch against the current layout.

- `headers` on `td` and `th`: a space-separated list of ID tokens (ASCII letters, digits, `_ - . :`), white-space collapsed, anything else rejected.
- `scope` on `th`: `row`, `col`, `rowgroup`, `colgroup`, matched case-insensitively and emitted in canonical lower case. #326's custom policy compared the lowercased value but returned the original.

Positive and negative tests in `SanitizersTest`, changelog entry, credit to @subbudvk.

Supersedes #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
