### PR TITLE
Do not emit a dangling '-' as part of a CSS unicode-range token (#245)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 /COPYING text
 /LICENSE text
-/src/test/resources/org/owasp/html/* text eol=lf
+/owasp-java-html-sanitizer/src/test/resources/org/owasp/html/* text eol=lf
 .gitattributes text
 .gitignore text
 *.html text

--- a/change_log.md
+++ b/change_log.md
@@ -28,6 +28,15 @@ Most recent at top.
     * HTML: `Sanitizers.TABLES` allows `headers` on `td` and `th`, limited to a
       space-separated list of ID tokens, and `scope` on `th`, limited to `row`,
       `col`, `rowgroup` and `colgroup` and canonicalized to lower case (PR #326).
+    * CSS: A `-` after a unicode-range start that is not followed by hex
+      digits, as in `U+a-x` or `U+a-->`, is no longer emitted as part of the
+      range token.  It was written to the output and then lexed again as the
+      next token, so `U+a-x` normalized to `U+a- -x`, which did not survive a
+      second pass through the lexer (issue #245).
+    * Build: `.gitattributes` now forces LF line endings on the HTML lexer
+      golden files at their current path under `owasp-java-html-sanitizer/`,
+      so `HtmlLexerTest` passes on Windows checkouts with `core.autocrlf`
+      (also noted in issue #245).
     * CSS: `text-align` accepts `start`, `end`, `justify-all` and `match-parent`.
     * CSS: `calc()` is allowed in `width`, `min-width`, `max-width`, `height`,
       `min-height` and `max-height` (issue #361).  Operands are limited to

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssTokens.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssTokens.java
@@ -1206,6 +1206,7 @@ final class CssTokens implements Iterable<String> {
           if (!hasQmark) {
             // Look for end of range.
             ++pos;
+            int startOfDash = sb.length();
             sb.append('-');
             int numEndDigits = 0;
             while (pos < cssLimit && numEndDigits < 6) {
@@ -1220,8 +1221,14 @@ final class CssTokens implements Iterable<String> {
               }
             }
             if (numEndDigits == 0) {
-              // Back up over '-'
+              // Not a range after all.  Back up over the '-' so it is lexed
+              // as its own token, and drop it from the output as well, so
+              // that it is not emitted twice.  Emitting it as part of the
+              // range meant "U+a-x" normalized to "U+a- -x", which is not
+              // idempotent (issue #245).  A trailing space keeps the range
+              // from merging with whatever follows.
               --pos;
+              sb.setLength(startOfDash);
               sb.append(' ');
             }
           } else {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssTokensTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssTokensTest.java
@@ -379,6 +379,41 @@ public class CssTokensTest extends TestCase {
     // TODO: invalid code-units in unicode ranges, and out of order values.
   }
 
+  /**
+   * A '-' after the start of a unicode range that is not followed by hex
+   * digits does not begin a range end, and must not be emitted as part of
+   * the range token.  Issue #245 found the lexer producing "U+a- -x" for
+   * "U+a-x", which does not survive a second pass through the lexer.
+   */
+  @Test
+  public static final void testUnicodeRangeWithDanglingDash() {
+    assertTokens(
+        "U+a-x",
+        "U+a:UNICODE_RANGE", " ", "-x:IDENT");
+    assertTokens(
+        "u+ABCDEF-x",
+        "U+abcdef:UNICODE_RANGE", " ", "-x:IDENT");
+    // A lone '-' has always lexed as a (bogus) identifier.
+    assertTokens(
+        "U+a-",
+        "U+a:UNICODE_RANGE", " ", "-:IDENT");
+    assertTokens(
+        "U+a- *",
+        "U+a:UNICODE_RANGE", " ", "-:IDENT", " ", "*:DELIM");
+    assertTokens(
+        "U+a-.5",
+        "U+a:UNICODE_RANGE", " ", "-0.5:NUMBER");
+    // The CDC token "-->" is ignorable, so "U+a-->*" is the range U+a
+    // followed by the delimiter '*'.  This is the shape that issue #245 hit.
+    assertTokens(
+        "U+a-->*",
+        "U+a:UNICODE_RANGE", " ", "*:DELIM");
+    // A real range end is still consumed.
+    assertTokens(
+        "U+a-b-x",
+        "U+a-b:UNICODE_RANGE", "-x:IDENT");
+  }
+
   public static final void testTokenMerging() {
     assertTokens(
         "/\\* */", "/:DELIM", " ", "*:DELIM", " ", "*:DELIM", "/:DELIM");


### PR DESCRIPTION
Fixes #245.

## Problem

`CssFuzzerTest.testUnderStress` fails at seed `1641590962954` with a "not idempotent" assertion. The reduced input is `U+a-->*`:

- `consumeUnicodeRange` lexes `U+a`, sees `-`, appends it to the output, then finds no hex digits after it.
- It backs `pos` up so the `-` is lexed again as the next token, but leaves the `-` in the output.
- So `U+a-->*` normalizes to `U+a- *` (the `-->` CDC is ignorable), and a second pass turns `U+a- *` into `U+a- - *`.

The same thing happens for `U+a-x` (`U+a- -x`) and any other `-` that does not begin a range end.

## Fix

Drop the `-` from the output when it turns out not to begin a range end, keeping the trailing space that separates the range from whatever follows. This matches what the `U+a??-` branch already did.

## Tests

- New `CssTokensTest.testUnicodeRangeWithDanglingDash` covers `U+a-x`, `u+ABCDEF-x`, `U+a-`, `U+a- *`, `U+a-.5`, `U+a-->*`, and confirms a real range end like `U+a-b-x` is still consumed. The shared `lex` helper asserts idempotency for each.
- `CssFuzzerTest` passes at the reported seed and at five other seeds.
- Full `./mvnw verify` passes on JDK 11, 17, 21 and 25 (351 tests).

## Also

The issue reporter noted having to convert the HTML lexer golden files from CRLF to LF by hand on Windows. The `.gitattributes` `eol=lf` rule for those files was written for the pre-module layout (`/src/test/resources/...`) and stopped matching after the move under `owasp-java-html-sanitizer/`. This PR points it at the current path, which `git ls-files --eol` confirms now applies `eol=lf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
