### PR TITLE
Decode character references before escaping raw text inside svg/math

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -70,6 +70,11 @@ Most recent at top.
       Alessandro Ruzzon, corebonts, Daham Chinthana, Domi, hwangjeyeon,
       Martin Jackson, Raibipasha-24, strangelookingnerd, subbudvk,
       Sven Strickroth, yangbongsoo
+    * HTML: Inside `<svg>` / `<math>`, the content of raw text elements such
+      as `<style>` is escaped rather than emitted verbatim (since 20240325.1),
+      but it was escaped without first decoding character references, so
+      `&amp;` came out as `&amp;amp;`.  References are now decoded once
+      before re-encoding (issue #411).
   * Release 20260313.1
     * Fix: Preserve the order of `rel` attribute values while still
       de-duplicating them.

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -61,6 +61,14 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   private boolean open;
   /** The count of {@link #foreignContentRootElementNames} opened and not subsequently closed. */
   private int foreignContentDepth = 0;
+  /**
+   * True when the current element is one whose content the HTML lexer treats
+   * as raw text, so its text arrives with character references undecoded, but
+   * it is inside foreign content where browsers parse that content as markup.
+   * Such text must be decoded before it is escaped, otherwise character
+   * references would be encoded twice.
+   */
+  private boolean decodeTextBeforeEscaping = false;
 
   /**
    * Factory.
@@ -177,6 +185,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     }
 
     HtmlTextEscapingMode tentativeEscapingMode = HtmlTextEscapingMode.getModeForTag(elementName);
+    decodeTextBeforeEscaping = false;
     if (foreignContentDepth == 0) {
       escapingMode = tentativeEscapingMode;
     } else {
@@ -184,6 +193,15 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
         case PCDATA:
         case VOID:
           escapingMode = tentativeEscapingMode;
+          break;
+        case CDATA:
+        case CDATA_SOMETIMES:
+        case PLAIN_TEXT:
+          // The lexer delivers the content of these elements as raw text
+          // without decoding character references, but browsers parse it as
+          // markup inside foreign content, so decode before re-encoding.
+          decodeTextBeforeEscaping = true;
+          escapingMode = HtmlTextEscapingMode.RCDATA;
           break;
         default: // escape special characters but do not allow tags
           escapingMode = HtmlTextEscapingMode.RCDATA;
@@ -265,6 +283,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     if (foreignContentDepth != 0 && foreignContentRootElementNames.contains(elementName)) {
       foreignContentDepth -= 1;
     }
+    decodeTextBeforeEscaping = false;
 
     if (pendingUnescaped != null) {
       if (!lastTagOpened.equals(elementName)) {
@@ -306,7 +325,9 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
       pendingUnescaped.append(text);
     } else {
       if (this.escapingMode == HtmlTextEscapingMode.RCDATA) {
-        Encoding.encodeRcdataOnto(text, output);
+        Encoding.encodeRcdataOnto(
+            decodeTextBeforeEscaping ? Encoding.decodeHtml(text, false) : text,
+            output);
       } else {
         Encoding.encodePcdataOnto(text, output);
       }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -1302,6 +1302,30 @@ public class HtmlPolicyBuilderTest extends TestCase {
   }
 
   @Test
+  public final void testRawTextElementsInsideForeignContent() {
+    PolicyFactory policyFactory = new HtmlPolicyBuilder()
+            .allowElements("svg", "math", "style")
+            .allowTextIn("style")
+            .toFactory();
+    // Outside svg/math, style content is raw text and is emitted verbatim.
+    assertEquals(
+        "<style>a &amp; b</style>",
+        policyFactory.sanitize("<style>a &amp; b</style>"));
+    // Inside svg/math, browsers decode character references in style content,
+    // so it is escaped once, not twice.
+    assertEquals(
+        "<svg><style>a &amp; b &lt;c&gt;</style></svg>",
+        policyFactory.sanitize("<svg><style>a &amp; b &lt;c&gt;</style></svg>"));
+    assertEquals(
+        "<math><style>a &amp; b</style></math>",
+        policyFactory.sanitize("<math><style>a &amp; b</style></math>"));
+    assertEquals(
+        "<svg><style>a &amp; b</style></svg><style>c &amp; d</style>",
+        policyFactory.sanitize(
+            "<svg><style>a &amp; b</style></svg><style>c &amp; d</style>"));
+  }
+
+  @Test
   public final void testTextareaIsNotTextArea() {
     String input = "<textarea>x</textarea><textArea>y</textArea>";
     PolicyFactory textareaPolicy = new HtmlPolicyBuilder().allowElements("textarea").toFactory();

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlStreamRendererTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlStreamRendererTest.java
@@ -504,4 +504,33 @@ public class HtmlStreamRendererTest extends TestCase {
     rendered.setLength(0);
     return result;
   }
+
+  public final void testRawTextElementInsideForeignContentIsDecodedBeforeEscaping()
+      throws Exception {
+    renderer.openDocument();
+    renderer.openTag("svg", j8().listOf());
+    renderer.openTag("style", j8().listOf());
+    // The lexer does not decode character references in raw text elements.
+    renderer.text("a &amp; b &lt;c&gt; &#x3c;d>");
+    renderer.closeTag("style");
+    // Text outside the raw text element arrives decoded as usual.
+    renderer.text("x &amp; y");
+    renderer.closeTag("svg");
+    renderer.closeDocument();
+
+    assertEquals(
+        "<svg><style>a &amp; b &lt;c&gt; &lt;d&gt;</style>x &amp;amp; y</svg>",
+        rendered.toString());
+  }
+
+  public final void testRawTextElementOutsideForeignContentIsNotDecoded()
+      throws Exception {
+    renderer.openDocument();
+    renderer.openTag("style", j8().listOf());
+    renderer.text("a &amp; b");
+    renderer.closeTag("style");
+    renderer.closeDocument();
+
+    assertEquals("<style>a &amp; b</style>", rendered.toString());
+  }
 }


### PR DESCRIPTION
Inside `<svg>` / `<math>` the renderer escapes the content of raw text elements such as `style` and `script`, because browsers parse it as markup there. The lexer, however, delivers that content undecoded, so escaping it again turned `&amp;` into `&amp;amp;`.

The renderer now decodes character references in that one case before re-encoding. Content outside foreign content is unchanged, and tags still cannot appear inside these elements. Tests cover the renderer directly and end to end through `HtmlPolicyBuilder`; the full suite passes on JDK 11 and 21.

Fixes #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
