### PR TITLE
Elide forbidden code points and normalize newlines in sanitized output (#223, carries #225)

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -28,6 +28,29 @@ Most recent at top.
       `<p class="test" "="">bar</p> <p>baz</p>` now keeps `bar` and `baz`
       instead of pairing the stray quote with the next one and swallowing the
       rest of the document (issue #189).
+    * HTML: Sanitized output no longer contains code points that HTML
+      forbids (issue #223, from PR #225 by Simon Greatrix).  The 66 Unicode
+      noncharacters, U+007F and the C1 controls U+0080..U+009F are removed
+      from text and attribute values, as the C0 controls already were,
+      instead of being passed through raw or written as `&#x5fffe;`-style
+      references, which browsers treat as parse errors.  CR and CRLF in
+      text and attribute values are normalized to LF as the HTML input
+      stream preprocessor does, so rendering is unchanged but the output
+      never contains a raw carriage return.  Characters whose compatibility
+      decomposition contains ASCII punctuation, such as U+FE64 SMALL
+      LESS-THAN SIGN, are written as numeric references so that a later
+      normalization of the output cannot produce an HTML special character;
+      everything from U+FE60 up is still written as a reference, as before.
+      Stripping happens after character references are decoded, so a
+      forbidden code point can neither hide a `javascript:` protocol from a
+      URL policy nor turn `&l?t;` into `&lt;`.  The February 2018 iOS
+      "query of death" workaround, which dropped U+200C before some
+      Devanagari, Bengali and Telugu vowels, is removed.
+    * HTML: Only the five ASCII whitespace characters separate tokens inside
+      a tag, as in the WHATWG tokenizer.  `Character.isWhitespace` also
+      accepted U+000B, U+001C..U+001F and Unicode space separators such as
+      U+3000, so `<b\u3000onclick=x>` was read as `<b onclick=x>` where a
+      browser sees an unknown element named `b\u3000onclick=x`.
     * HTML: Attribute names may begin with an underscore.
     * HTML: `Sanitizers.TABLES` allows integer `colspan` and `rowspan` on
       `td` and `th`; `Sanitizers.IMAGES` allows `loading="lazy|eager"`.
@@ -68,8 +91,8 @@ Most recent at top.
     * Docs: README examples compile again; Javadoc links point at `latest`.
     * Special thanks to (in lexicographic order):
       Alessandro Ruzzon, corebonts, Daham Chinthana, Domi, hwangjeyeon,
-      Martin Jackson, Raibipasha-24, strangelookingnerd, subbudvk,
-      Sven Strickroth, yangbongsoo
+      Martin Jackson, Raibipasha-24, Simon Greatrix, strangelookingnerd,
+      subbudvk, Sven Strickroth, yangbongsoo
     * HTML: Inside `<svg>` / `<math>`, the content of raw text elements such
       as `<style>` is escaped rather than emitted verbatim (since 20240325.1),
       but it was escaped without first decoding character references, so

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
@@ -28,7 +28,9 @@
 package org.owasp.html;
 
 import java.io.IOException;
-
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Encoders and decoders for HTML. */
@@ -107,6 +109,7 @@ public final class Encoding {
     stripBannedCodeunits(sb, 0);
   }
 
+
   @TCB
   private static void stripBannedCodeunits(StringBuilder sb, int start) {
     int k = start;
@@ -121,13 +124,16 @@ public final class Encoding {
           if (i+1 < n) {
             char next = sb.charAt(i+1);
             if (Character.isSurrogatePair(ch, next)) {
-              sb.setCharAt(k++, ch);
-              sb.setCharAt(k++, next);
+              // The last two code points in each plane are non-characters that should be elided.
+              if ((ch & 0xfc3f) != 0xd83f || (next & 0xfffe) != 0xdffe) {
+                sb.setCharAt(k++, ch);
+                sb.setCharAt(k++, next);
+              }
               ++i;
             }
           }
           continue;
-        } else if ((ch & 0xfffe) == 0xfffe) {
+        } else if ((ch & 0xfffe) == 0xfffe || (0xfdd0 <= ch && ch <= 0xfdef)) {
           continue;
         }
       }
@@ -152,19 +158,34 @@ public final class Encoding {
         }
       } else if (0xd800 <= ch) {
         if (ch <= 0xdfff) {
-          if (i+1 < n && Character.isSurrogatePair(ch, s.charAt(i+1))) {
-            ++i;  // Skip over low surrogate since we know it's ok.
+          if (i + 1 < n ) {
+            // could be a surrogate pair
+            char cn = s.charAt(i+1);
+            if( Character.isSurrogatePair(ch,cn) ) {
+              int cp = Character.toCodePoint(ch, cn);
+              // Could be a non-character
+              if ((cp & 0xfffe) == 0xfffe) {
+                // not valid
+                return i;
+              }
+
+              // skip over trailing surrogate since we know it is OK
+              i++;
+            } else {
+              // not a surrogate pair
+              return i;
+            }
           } else {
+            // isolated surrogate at end of string
             return i;
           }
-        } else if ((ch & 0xfffe) == 0xfffe) {
+        } else if ((ch & 0xfffe) == 0xfffe || (0xfdd0 <= ch && ch <= 0xfdef)) {
           return i;
         }
       }
     }
     return -1;
   }
-
   /**
    * Appends an encoded form of plainText to output where the encoding is
    * sufficient to prevent an HTML parser from interpreting any characters in
@@ -208,6 +229,7 @@ public final class Encoding {
     // executing expressions in sanitized text.
     encodeHtmlOnto(plainText, output, "{<!-- -->");
   }
+
 
   /**
    * Appends an encoded form of plainText to putput where the encoding is
@@ -253,126 +275,93 @@ public final class Encoding {
       char ch = plainText.charAt(i);
       if (ch < REPLACEMENTS.length) {  // Handles all ASCII.
         String repl = REPLACEMENTS[ch];
-        if (ch == '{' && repl == null) {
-          if (i + 1 == n || plainText.charAt(i + 1) == '{') {
-            repl = braceReplacement;
+        if( repl==null ) {
+          if (ch == '{') {
+            if (i + 1 == n || plainText.charAt(i + 1) == '{') {
+              // "{{" detected, so use the brace replacement
+              repl = braceReplacement;
+            }
+          }
+          if (ch == '\r') {
+            // If this CR is followed by a LF, just remove it. Otherwise replace it with a LF.
+            if (i + 1 == n || plainText.charAt(i + 1) != '\n' ) {
+              // CR not followed by LF, so turn into LF
+              repl = "\n";
+            } else {
+              // CRLF, so remove CR
+              repl = "";
+            }
           }
         }
         if (repl != null) {
           output.append(plainText, pos, i).append(repl);
           pos = i + 1;
         }
-      } else if ((0x93A <= ch && ch <= 0xC4C)
-          && (
-              // Devanagari vowel
-              ch <= 0x94F
-              // Benagli vowels
-              || 0x985 <= ch && ch <= 0x994
-              || 0x9BE <= ch && ch < 0x9CC  // 0x9CC (Bengali AU) is ok
-              || 0x9E0 <= ch && ch <= 0x9E3
-              // Telugu vowels
-              || 0xC05 <= ch && ch <= 0xC14
-              || 0xC3E <= ch && ch != 0xC48 /* 0xC48 (Telugu AI) is ok */)) {
-        // https://manishearth.github.io/blog/2018/02/15/picking-apart-the-crashing-ios-string/
-        // > So, ultimately, the full set of cases that cause the crash are:
-        // >   Any sequence <consonant1, virama, consonant2, ZWNJ, vowel>
-        // > in Devanagari, Bengali, and Telugu, where: ...
-
-        // TODO: This is needed as of February 2018, but hopefully not long after that.
-        // We eliminate the ZWNJ which seems the minimally damaging thing to do to
-        // Telugu rendering per the article above:
-        // > a ZWNJ before a vowel doesn’t really do anything for most Indic scripts.
-
-        if (pos < i) {
-          if (plainText.charAt(i - 1) == 0x200C /* ZWNJ */) {
-            output.append(plainText, pos, i - 1);
-            // Drop the ZWNJ on the floor.
-            pos = i;
-          }
-        } else if (output instanceof StringBuilder) {
-          StringBuilder sb = (StringBuilder) output;
-          int len = sb.length();
-          if (len != 0) {
-            if (sb.charAt(len - 1) == 0x200C /* ZWNJ */) {
-              sb.setLength(len - 1);
-            }
-          }
-        }
-      } else if (((char) 0xd800) <= ch) {
-        if (ch <= ((char) 0xdfff)) {
-          char next;
-          if (i + 1 < n
-              && Character.isSurrogatePair(
-                  ch, next = plainText.charAt(i + 1))) {
-            // Emit supplemental codepoints as entity so that they cannot
-            // be mis-encoded as UTF-8 of surrogates instead of UTF-8 proper
-            // and get involved in UTF-16/UCS-2 confusion.
-            int codepoint = Character.toCodePoint(ch, next);
-            output.append(plainText, pos, i);
-            appendNumericEntity(codepoint, output);
-            ++i;
-            pos = i + 1;
-          } else {
-            output.append(plainText, pos, i);
-            // Elide the orphaned surrogate.
-            pos = i + 1;
-          }
-        } else if (0xfe60 <= ch) {
-          // Is a control character or possible full-width version of a
-          // special character, a BOM, or one of the FE60 block that might
-          // be elided or normalized to an HTML special character.
-          // Running
-          //   cat NormalizationText.txt \
-          //     | perl -pe 's/ ?#.*//' \
-          //     | egrep '(;003C(;|$)|003E|0026|0022|0027|0060)'
-          // dumps a list of code-points that can normalize to HTML special
-          // characters.
-          output.append(plainText, pos, i);
-          pos = i + 1;
-          if ((ch & 0xfffe) == 0xfffe) {
-            // Elide since not an the XML Character.
-          } else {
-            appendNumericEntity(ch, output);
-          }
-        }
-      } else if (ch == '\u1FEF') {  // Normalizes to backtick.
-        output.append(plainText, pos, i).append("&#8175;");
+      } else if (RISKY_NORMALIZATION.contains(ch)) {
+        // Application of unicode compatibility normalization produces a risky character.
+        output.append(plainText, pos, i);
         pos = i + 1;
+        appendNumericEntity(ch,output);
+      } else if ((ch <= 0x9f) || (0xfdd0 <= ch && ch <= 0xfdef) || ((ch & 0xfffe) == 0xfffe)) {
+        // Elide C1 escapes and BMP non-characters.
+        output.append(plainText, pos, i);
+        pos = i + 1;
+      } else if (0xd800 <= ch && ch <= 0xdfff) {
+        // handle surrogates
+        char next;
+        if (i + 1 < n && Character.isSurrogatePair(ch, next = plainText.charAt(i + 1))) {
+          // Emit supplemental codepoints as entity so that they cannot
+          // be mis-encoded as UTF-8 of surrogates instead of UTF-8 proper
+          // and get involved in UTF-16/UCS-2 confusion.
+          int codepoint = Character.toCodePoint(ch, next);
+          output.append(plainText, pos, i);
+          // do not append 0xfffe and 0xffff from any plane
+          if( (codepoint & 0xfffe) != 0xfffe ) {
+            appendNumericEntity(codepoint, output);
+          }
+          ++i;
+          pos = i + 1;
+        } else {
+          output.append(plainText, pos, i);
+          // Elide the orphaned surrogate.
+          pos = i + 1;
+        }
       }
     }
     output.append(plainText, pos, n);
   }
 
+
+  /**
+   * Append a codepoint to the output as a numeric entity.
+   *
+   * @param codepoint the codepoint
+   * @param output    the output
+   *
+   * @throws IOException              if the output cannot be written to
+   * @throws IllegalArgumentException if the codepoint cannot be represented as a numeric escape.
+   */
   @TCB
   static void appendNumericEntity(int codepoint, Appendable output)
       throws IOException {
+    if (((codepoint <= 0x1f) && (codepoint != 9 && codepoint != 0xa)) || (0x7f <= codepoint && codepoint <= 0x9f)) {
+      throw new IllegalArgumentException("Illegal numeric escape. Cannot represent control code: " + codepoint);
+    }
+    if ((0xfdd0 <= codepoint && codepoint <= 0xfdef) || ((codepoint & 0xfffe) == 0xfffe)) {
+      throw new IllegalArgumentException("Illegal numeric escape. Cannot represent non-character: " + codepoint);
+    }
+
     output.append("&#");
     if (codepoint < 100) {
-      // TODO: is this dead code due to REPLACEMENTS above.
-      if (codepoint < 10) {
-        output.append((char) ('0' + codepoint));
-      } else {
-        output.append((char) ('0' + (codepoint / 10)));
-        output.append((char) ('0' + (codepoint % 10)));
-      }
+      // Below 100, a decimal representation is shortest
+      output.append(Integer.toString(codepoint));
     } else {
-      int nDigits = (codepoint < 0x1000
-                     ? codepoint < 0x100 ? 2 : 3
-                     : (codepoint < 0x10000 ? 4
-                        : codepoint < 0x100000 ? 5 : 6));
+      // Append a hexadecimal value
       output.append('x');
-      for (int digit = nDigits; --digit >= 0;) {
-        int hexDigit = (codepoint >>> (digit << 2)) & 0xf;
-        output.append(HEX_NUMERAL[hexDigit]);
-      }
+      output.append(Integer.toHexString(codepoint));
     }
     output.append(";");
   }
-
-  private static final char[] HEX_NUMERAL = {
-   '0', '1', '2', '3', '4', '5', '6', '7',
-   '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
-  };
 
   /** Maps ASCII chars that need to be encoded to an equivalent HTML entity. */
   private static final String[] REPLACEMENTS = new String[0x80];
@@ -398,17 +387,41 @@ public final class Encoding {
     REPLACEMENTS['>']  = "&gt;";                     // HTML special.
     REPLACEMENTS['@']  = "&#" + ((int) '@')  + ";";  // Conditional compilation.
     REPLACEMENTS['`']  = "&#" + ((int) '`')  + ";";  // Attribute delimiter.
+    REPLACEMENTS['\u007f']  = "";                    // Elide delete
   }
 
   /**
    * IS_BANNED_ASCII[i] where is an ASCII control character codepoint (&lt; 0x20)
    * is true for control characters that are not allowed in an XML source text.
    */
-  private static boolean[] IS_BANNED_ASCII = new boolean[0x20];
+  private static final boolean[] IS_BANNED_ASCII = new boolean[0x20];
   static {
     for (int i = 0; i < IS_BANNED_ASCII.length; ++i) {
       IS_BANNED_ASCII[i] = !(i == '\t' || i == '\n' || i == '\r');
     }
   }
 
+  /** Set of all Unicode characters which when processed with unicode compatibility decomposition will include a non-alphanumeric ascii character. */
+  static final Set<Character> RISKY_NORMALIZATION;
+  static {
+    HashSet<Character> set = new HashSet<Character>();
+
+    // These characters all decompose riskily
+    String singles = "\u037e\u1fef\u203c\u207a\u208a\u2100\u2101\u2105\u2106\u2260\u226e\u226f\u33c2\u33c7\u33d8\ufb29\ufe10\ufe19\ufe30\ufe47\ufe48\ufe52";
+    for(char ch : singles.toCharArray()) {
+      set.add(ch);
+    }
+
+    // This string is composed of pairs of characters defining inclusive start and end ranges.
+    String pairs =
+              "\u2024\u2026\u2047\u2049\u207c\u207e\u208c\u208e\u2474\u24b5\u2a74\u2a76\u3200\u321e\u3220\u3243\ufe13\ufe16\ufe33"
+            + "\ufe38\ufe4d\ufe50\ufe54\ufe57\ufe59\ufe5c\ufe5f\ufe66\ufe68\ufe6b\uff01\uff0f\uff1a\uff20\uff3b\uff40\uff5b\uff5e";
+    for(int i=0;i<pairs.length();i+=2) {
+      for(char ch=pairs.charAt(i);ch<=pairs.charAt(i+1);ch++) {
+        set.add(ch);
+      }
+    }
+
+    RISKY_NORMALIZATION = Collections.unmodifiableSet(set);
+  }
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
@@ -28,9 +28,8 @@
 package org.owasp.html;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.BitSet;
+
 import javax.annotation.Nullable;
 
 /** Encoders and decoders for HTML. */
@@ -87,8 +86,11 @@ public final class Encoding {
   }
 
   /**
-   * Returns the portion of its input that consists of XML safe chars.
+   * Returns the portion of its input that consists of chars that are safe in
+   * both XML and HTML: the XML Character production without the
+   * noncharacters, DEL and the C1 controls that HTML treats as parse errors.
    * @see <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#charsets">XML Ch. 2.2 - Characters</a>
+   * @see <a href="https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream">HTML 13.2.3.5 - Preprocessing the input stream</a>
    */
   @TCB
   static String stripBannedCodeunits(String s) {
@@ -101,14 +103,14 @@ public final class Encoding {
   }
 
   /**
-   * Leaves in the input buffer only code-units that comprise XML safe chars.
-   * @see <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#charsets">XML Ch. 2.2 - Characters</a>
+   * Leaves in the input buffer only code-units that comprise chars that are
+   * safe in both XML and HTML.
+   * @see #stripBannedCodeunits(String)
    */
   @TCB
   static void stripBannedCodeunits(StringBuilder sb) {
     stripBannedCodeunits(sb, 0);
   }
-
 
   @TCB
   private static void stripBannedCodeunits(StringBuilder sb, int start) {
@@ -119,13 +121,18 @@ public final class Encoding {
         if (IS_BANNED_ASCII[ch]) {
           continue;
         }
+      } else if (0x7f <= ch && ch <= 0x9f) {
+        // DEL and the C1 controls.  encodeHtmlOnto elides them, so they are
+        // stripped here too: policies must judge the text that will be
+        // emitted, not text that a later elision would join up differently.
+        continue;
       } else if (0xd800 <= ch) {
         if (ch <= 0xdfff) {
           if (i+1 < n) {
             char next = sb.charAt(i+1);
             if (Character.isSurrogatePair(ch, next)) {
-              // The last two code points in each plane are non-characters that should be elided.
-              if ((ch & 0xfc3f) != 0xd83f || (next & 0xfffe) != 0xdffe) {
+              // The last two code points of each plane are noncharacters.
+              if (!isNoncharacter(Character.toCodePoint(ch, next))) {
                 sb.setCharAt(k++, ch);
                 sb.setCharAt(k++, next);
               }
@@ -133,7 +140,7 @@ public final class Encoding {
             }
           }
           continue;
-        } else if ((ch & 0xfffe) == 0xfffe || (0xfdd0 <= ch && ch <= 0xfdef)) {
+        } else if (isNoncharacter(ch)) {
           continue;
         }
       }
@@ -143,9 +150,9 @@ public final class Encoding {
   }
 
   /**
-   * The number of code-units at the front of s that form code-points in the
-   * XML Character production.
-   * @return -1 if all of s is in the XML Character production.
+   * The number of code-units at the front of s that form code-points that
+   * {@link #stripBannedCodeunits(String)} keeps.
+   * @return -1 if all of s is kept.
    */
   @TCB
   private static int longestPrefixOfGoodCodeunits(String s) {
@@ -156,36 +163,40 @@ public final class Encoding {
         if (IS_BANNED_ASCII[ch]) {
           return i;
         }
+      } else if (0x7f <= ch && ch <= 0x9f) {
+        return i;
       } else if (0xd800 <= ch) {
         if (ch <= 0xdfff) {
-          if (i + 1 < n ) {
-            // could be a surrogate pair
-            char cn = s.charAt(i+1);
-            if( Character.isSurrogatePair(ch,cn) ) {
-              int cp = Character.toCodePoint(ch, cn);
-              // Could be a non-character
-              if ((cp & 0xfffe) == 0xfffe) {
-                // not valid
-                return i;
-              }
-
-              // skip over trailing surrogate since we know it is OK
-              i++;
+          if (i + 1 < n) {
+            char next = s.charAt(i + 1);
+            if (Character.isSurrogatePair(ch, next)
+                && !isNoncharacter(Character.toCodePoint(ch, next))) {
+              ++i;  // Skip over low surrogate since we know it's ok.
             } else {
-              // not a surrogate pair
               return i;
             }
           } else {
-            // isolated surrogate at end of string
-            return i;
+            return i;  // Orphaned surrogate at the end of the string.
           }
-        } else if ((ch & 0xfffe) == 0xfffe || (0xfdd0 <= ch && ch <= 0xfdef)) {
+        } else if (isNoncharacter(ch)) {
           return i;
         }
       }
     }
     return -1;
   }
+
+  /**
+   * True for the 66 Unicode noncharacters: U+FDD0..U+FDEF and the last two
+   * code points of every plane.  HTML treats them as parse errors and forbids
+   * numeric character references to them.
+   * @see <a href="https://infra.spec.whatwg.org/#noncharacter">Infra - noncharacter</a>
+   */
+  static boolean isNoncharacter(int codepoint) {
+    return (codepoint & 0xfffe) == 0xfffe
+        || (0xfdd0 <= codepoint && codepoint <= 0xfdef);
+  }
+
   /**
    * Appends an encoded form of plainText to output where the encoding is
    * sufficient to prevent an HTML parser from interpreting any characters in
@@ -230,7 +241,6 @@ public final class Encoding {
     encodeHtmlOnto(plainText, output, "{<!-- -->");
   }
 
-
   /**
    * Appends an encoded form of plainText to putput where the encoding is
    * sufficient to prevent an HTML parser from transitioning out of the
@@ -262,8 +272,15 @@ public final class Encoding {
    * For example, {@code escapeHtmlOnto("1 < 2", w)},
    * is equivalent to {@code w.append("1 &lt; 2")} but possibly with fewer
    * smaller appends.
-   * Elides code-units that are not valid XML Characters.
+   *
+   * <p>Elides code-units that are not valid XML Characters, and the
+   * noncharacters, DEL and C1 controls that HTML forbids in character
+   * references and treats as parse errors in the input stream.  Normalizes
+   * CR and CRLF to LF as the HTML input stream preprocessor does, so the
+   * output never contains a raw carriage return.
    * @see <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#charsets">XML Ch. 2.2 - Characters</a>
+   * @see <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML 13.1.4 - Character references</a>
+   * @see <a href="https://infra.spec.whatwg.org/#normalize-newlines">Infra - normalize newlines</a>
    */
   @TCB
   private static void encodeHtmlOnto(
@@ -275,48 +292,34 @@ public final class Encoding {
       char ch = plainText.charAt(i);
       if (ch < REPLACEMENTS.length) {  // Handles all ASCII.
         String repl = REPLACEMENTS[ch];
-        if( repl==null ) {
+        if (repl == null) {
           if (ch == '{') {
             if (i + 1 == n || plainText.charAt(i + 1) == '{') {
-              // "{{" detected, so use the brace replacement
               repl = braceReplacement;
             }
-          }
-          if (ch == '\r') {
-            // If this CR is followed by a LF, just remove it. Otherwise replace it with a LF.
-            if (i + 1 == n || plainText.charAt(i + 1) != '\n' ) {
-              // CR not followed by LF, so turn into LF
-              repl = "\n";
-            } else {
-              // CRLF, so remove CR
-              repl = "";
-            }
+          } else if (ch == '\r') {
+            // CRLF becomes LF by dropping the CR; a lone CR becomes LF.
+            repl = (i + 1 < n && plainText.charAt(i + 1) == '\n') ? "" : "\n";
           }
         }
         if (repl != null) {
           output.append(plainText, pos, i).append(repl);
           pos = i + 1;
         }
-      } else if (RISKY_NORMALIZATION.contains(ch)) {
-        // Application of unicode compatibility normalization produces a risky character.
-        output.append(plainText, pos, i);
-        pos = i + 1;
-        appendNumericEntity(ch,output);
-      } else if ((ch <= 0x9f) || (0xfdd0 <= ch && ch <= 0xfdef) || ((ch & 0xfffe) == 0xfffe)) {
-        // Elide C1 escapes and BMP non-characters.
+      } else if (ch <= 0x9f || isNoncharacter(ch)) {
+        // Elide the C1 controls and the BMP noncharacters.
         output.append(plainText, pos, i);
         pos = i + 1;
       } else if (0xd800 <= ch && ch <= 0xdfff) {
-        // handle surrogates
         char next;
-        if (i + 1 < n && Character.isSurrogatePair(ch, next = plainText.charAt(i + 1))) {
-          // Emit supplemental codepoints as entity so that they cannot
-          // be mis-encoded as UTF-8 of surrogates instead of UTF-8 proper
-          // and get involved in UTF-16/UCS-2 confusion.
+        if (i + 1 < n
+            && Character.isSurrogatePair(ch, next = plainText.charAt(i + 1))) {
           int codepoint = Character.toCodePoint(ch, next);
           output.append(plainText, pos, i);
-          // do not append 0xfffe and 0xffff from any plane
-          if( (codepoint & 0xfffe) != 0xfffe ) {
+          if (!isNoncharacter(codepoint)) {
+            // Emit supplemental codepoints as entity so that they cannot
+            // be mis-encoded as UTF-8 of surrogates instead of UTF-8 proper
+            // and get involved in UTF-16/UCS-2 confusion.
             appendNumericEntity(codepoint, output);
           }
           ++i;
@@ -326,41 +329,52 @@ public final class Encoding {
           // Elide the orphaned surrogate.
           pos = i + 1;
         }
+      } else if (0xfe60 <= ch || isRiskyNormalization(ch)) {
+        // Above U+FE60 lie the small form variants, Arabic presentation
+        // forms, the halfwidth and fullwidth forms, the byte order mark and
+        // the specials block: full-width versions of HTML special characters
+        // and code points that an encoding conversion may drop or mangle.
+        // Elsewhere in the BMP, isRiskyNormalization picks out characters
+        // whose compatibility decomposition contains ASCII punctuation, such
+        // as U+1FEF GREEK VARIA which normalizes to a backtick.
+        // Either way, a numeric reference survives any later normalization
+        // of the output unchanged.
+        output.append(plainText, pos, i);
+        pos = i + 1;
+        appendNumericEntity(ch, output);
       }
     }
     output.append(plainText, pos, n);
   }
 
-
   /**
-   * Append a codepoint to the output as a numeric entity.
+   * Appends a numeric character reference for the code point to the output.
    *
-   * @param codepoint the codepoint
-   * @param output    the output
-   *
-   * @throws IOException              if the output cannot be written to
-   * @throws IllegalArgumentException if the codepoint cannot be represented as a numeric escape.
+   * @throws IllegalArgumentException if HTML forbids a numeric character
+   *     reference to the code point: controls other than TAB and LF,
+   *     surrogates, noncharacters and values above U+10FFFF.
+   * @see <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML 13.1.4 - Character references</a>
    */
   @TCB
   static void appendNumericEntity(int codepoint, Appendable output)
       throws IOException {
-    if (((codepoint <= 0x1f) && (codepoint != 9 && codepoint != 0xa)) || (0x7f <= codepoint && codepoint <= 0x9f)) {
-      throw new IllegalArgumentException("Illegal numeric escape. Cannot represent control code: " + codepoint);
+    if ((codepoint < 0x20 && codepoint != '\t' && codepoint != '\n')
+        || (0x7f <= codepoint && codepoint <= 0x9f)
+        || (0xd800 <= codepoint && codepoint <= 0xdfff)
+        || codepoint > Character.MAX_CODE_POINT
+        || isNoncharacter(codepoint)) {
+      throw new IllegalArgumentException(
+          "Cannot write a character reference to U+"
+          + Integer.toHexString(codepoint));
     }
-    if ((0xfdd0 <= codepoint && codepoint <= 0xfdef) || ((codepoint & 0xfffe) == 0xfffe)) {
-      throw new IllegalArgumentException("Illegal numeric escape. Cannot represent non-character: " + codepoint);
-    }
-
     output.append("&#");
     if (codepoint < 100) {
-      // Below 100, a decimal representation is shortest
+      // Below 100 the decimal form is shortest.
       output.append(Integer.toString(codepoint));
     } else {
-      // Append a hexadecimal value
-      output.append('x');
-      output.append(Integer.toHexString(codepoint));
+      output.append('x').append(Integer.toHexString(codepoint));
     }
-    output.append(";");
+    output.append(';');
   }
 
   /** Maps ASCII chars that need to be encoded to an equivalent HTML entity. */
@@ -387,7 +401,7 @@ public final class Encoding {
     REPLACEMENTS['>']  = "&gt;";                     // HTML special.
     REPLACEMENTS['@']  = "&#" + ((int) '@')  + ";";  // Conditional compilation.
     REPLACEMENTS['`']  = "&#" + ((int) '`')  + ";";  // Attribute delimiter.
-    REPLACEMENTS['\u007f']  = "";                    // Elide delete
+    REPLACEMENTS[0x7f] = "";                         // DEL is a control; elide.
   }
 
   /**
@@ -401,27 +415,42 @@ public final class Encoding {
     }
   }
 
-  /** Set of all Unicode characters which when processed with unicode compatibility decomposition will include a non-alphanumeric ascii character. */
-  static final Set<Character> RISKY_NORMALIZATION;
+  /**
+   * Bit {@code c} is set when the BMP character U+c has a compatibility
+   * decomposition (NFKD) that contains a printable, non-alphanumeric ASCII
+   * character, so that a downstream normalization could turn it into an HTML
+   * special character: U+FE64 SMALL LESS-THAN SIGN normalizes to {@code <}.
+   *
+   * <p>The table is spelled out rather than derived from
+   * {@code java.text.Normalizer} at class load so that output does not vary
+   * with the JDK's Unicode version; {@code EncodingTest} checks it against
+   * the running JDK's tables and says which characters to add if they drift.
+   */
+  private static final BitSet RISKY_NORMALIZATION = new BitSet(0x10000);
   static {
-    HashSet<Character> set = new HashSet<Character>();
-
-    // These characters all decompose riskily
-    String singles = "\u037e\u1fef\u203c\u207a\u208a\u2100\u2101\u2105\u2106\u2260\u226e\u226f\u33c2\u33c7\u33d8\ufb29\ufe10\ufe19\ufe30\ufe47\ufe48\ufe52";
-    for(char ch : singles.toCharArray()) {
-      set.add(ch);
+    // Single characters.
+    String singles = "\u037e\u1fef\u203c\u207a\u208a\u2100\u2101\u2105\u2106"
+        + "\u2260\u226e\u226f\u33c2\u33c7\u33d8\ufb29\ufe10\ufe19\ufe30\ufe47"
+        + "\ufe48\ufe52";
+    for (int i = 0, n = singles.length(); i < n; ++i) {
+      RISKY_NORMALIZATION.set(singles.charAt(i));
     }
-
-    // This string is composed of pairs of characters defining inclusive start and end ranges.
-    String pairs =
-              "\u2024\u2026\u2047\u2049\u207c\u207e\u208c\u208e\u2474\u24b5\u2a74\u2a76\u3200\u321e\u3220\u3243\ufe13\ufe16\ufe33"
-            + "\ufe38\ufe4d\ufe50\ufe54\ufe57\ufe59\ufe5c\ufe5f\ufe66\ufe68\ufe6b\uff01\uff0f\uff1a\uff20\uff3b\uff40\uff5b\uff5e";
-    for(int i=0;i<pairs.length();i+=2) {
-      for(char ch=pairs.charAt(i);ch<=pairs.charAt(i+1);ch++) {
-        set.add(ch);
-      }
+    // Pairs of characters bounding inclusive ranges.
+    String ranges = "\u2024\u2026\u2047\u2049\u207c\u207e\u208c\u208e\u2474"
+        + "\u24b5\u2a74\u2a76\u3200\u321e\u3220\u3243\ufe13\ufe16\ufe33\ufe38"
+        + "\ufe4d\ufe50\ufe54\ufe57\ufe59\ufe5c\ufe5f\ufe66\ufe68\ufe6b\uff01"
+        + "\uff0f\uff1a\uff20\uff3b\uff40\uff5b\uff5e";
+    for (int i = 0, n = ranges.length(); i < n; i += 2) {
+      RISKY_NORMALIZATION.set(ranges.charAt(i), ranges.charAt(i + 1) + 1);
     }
+  }
 
-    RISKY_NORMALIZATION = Collections.unmodifiableSet(set);
+  /**
+   * True if a compatibility normalization of ch could produce an ASCII
+   * punctuation character.
+   * @see #RISKY_NORMALIZATION
+   */
+  static boolean isRiskyNormalization(char ch) {
+    return RISKY_NORMALIZATION.get(ch);
   }
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
@@ -552,7 +552,7 @@ final class HtmlInputSplitter extends AbstractTokenStream {
             break;
           }
         }
-      } else if (!Character.isWhitespace(ch)) {
+      } else if (!Strings.isHtmlSpace(ch)) {
         type = HtmlTokenType.TEXT;
         for (; end < limit; ++end) {
           ch = input.charAt(end);
@@ -563,12 +563,12 @@ final class HtmlInputSplitter extends AbstractTokenStream {
               && '>' == input.charAt(end + 1)) {
             break;
           } else if ('>' == ch || '=' == ch
-                     || Character.isWhitespace(ch)) {
+                     || Strings.isHtmlSpace(ch)) {
             break;
           } else if ('"' == ch || '\'' == ch) {
             if (end + 1 < limit) {
               char ch2 = input.charAt(end + 1);
-              if (Character.isWhitespace(ch2)
+              if (Strings.isHtmlSpace(ch2)
                   || ch2 == '>' || ch2 == '/') {
                 ++end;
                 break;
@@ -579,7 +579,7 @@ final class HtmlInputSplitter extends AbstractTokenStream {
       } else {
         // We skip whitespace tokens inside tag bodies.
         type = HtmlTokenType.IGNORABLE;
-        while (end < limit && Character.isWhitespace(input.charAt(end))) {
+        while (end < limit && Strings.isHtmlSpace(input.charAt(end))) {
           ++end;
         }
       }
@@ -629,7 +629,7 @@ final class HtmlInputSplitter extends AbstractTokenStream {
               ch = input.charAt(end);
               switch (state) {
                 case TAGNAME:
-                  if (Character.isWhitespace(ch)
+                  if (Strings.isHtmlSpace(ch)
                       || '>' == ch || '/' == ch || '<' == ch) {
                     // End processing of an escape exempt block when we see
                     // a corresponding end tag.

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/ElidedCharactersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/ElidedCharactersTest.java
@@ -1,0 +1,143 @@
+package org.owasp.html;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+/**
+ * Some characters should not appear in HTML documents, present risks for log-file injection, or are otherwise discouraged from sanitized HTML. This set of
+ * unit tests verifies that the inclusion of such characters does not allow dangerous code to slip through.
+ * <p>
+ * There are two requirements:
+ * <p>
+ * 1) The Encoding.encodeRcdataOnto method should remove discouraged characters.
+ * 2) Sanitized HTML should not change
+ *
+ * @author Simon Greatrix on 25/01/2021.
+ */
+public class ElidedCharactersTest extends TestCase {
+
+  /** List of all characters that are discouraged in HTML. */
+  static List<String> DISCOURAGED;
+
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromTagStart() throws IOException {
+    // <Xp></p> is an unrecognised tag and an unmatched end tag
+    for (String d : DISCOURAGED) {
+      String test = "<" + d+"h1></h1>";
+      String html = Sanitizers.BLOCKS.sanitize(test);
+      String m = String.format("Use in <h1> of U+%06x", d.codePointAt(0));
+      assertEquals(m, "&lt;h1&gt;", html);
+    }
+
+    String html = Sanitizers.BLOCKS.sanitize("<h1></h1>");
+    assertEquals("<h1></h1>",html);
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromInsideTag() throws IOException {
+    // <h1X></h1> is an unrecognised tag and an unmatched end tag
+    for (String d : DISCOURAGED) {
+      String test = "<h"+d+"1></h1>";
+      String html = Sanitizers.BLOCKS.sanitize(test);
+      String m = String.format("Use in <h1> of U+%06x", d.codePointAt(0));
+      assertEquals(m, "", html);
+    }
+
+    String html = Sanitizers.BLOCKS.sanitize("<h1></h1>");
+    assertEquals("<h1></h1>",html);
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromTagEnd() throws IOException {
+    // <h1X></h1> is an unrecognised tag and an unmatched end tag
+    for (String d : DISCOURAGED) {
+      String test = "<h1"+ d+"></h1>";
+      String html = Sanitizers.BLOCKS.sanitize(test);
+      String m = String.format("Use in <h1> of U+%06x", d.codePointAt(0));
+      assertEquals(m, "", html);
+    }
+
+    String html = Sanitizers.BLOCKS.sanitize("<h1></h1>");
+    assertEquals("<h1></h1>",html);
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromEndWhenEncoding() throws IOException {
+    for (String d : DISCOURAGED) {
+      String test = "Hello" + d;
+      StringBuilder builder = new StringBuilder();
+      Encoding.encodePcdataOnto(test, builder);
+      String m = String.format("Elision of U+%06x", d.codePointAt(0));
+      assertEquals(m, "Hello", builder.toString());
+    }
+  }
+
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromMiddleWhenEncoding() throws IOException {
+    for (String d : DISCOURAGED) {
+      String test = "Hel" + d + "lo";
+      StringBuilder builder = new StringBuilder();
+      Encoding.encodePcdataOnto(test, builder);
+      String m = String.format("Elision of U+%06x", d.codePointAt(0));
+      assertEquals(m, "Hello", builder.toString());
+    }
+  }
+
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromStartWhenEncoding() throws IOException {
+    for (String d : DISCOURAGED) {
+      String test = d + "Hello";
+      StringBuilder builder = new StringBuilder();
+      Encoding.encodePcdataOnto(test, builder);
+      String m = String.format("Elision of U+%06x", d.codePointAt(0));
+      assertEquals(m, "Hello", builder.toString());
+    }
+  }
+
+
+  static {
+    ArrayList<String> list = new ArrayList<String>();
+
+    // C0 characters banned by XML, except for the three official whitespace characters
+    for (char i = 0; i <= 0x1f; i++) {
+      if (i != 0x9 && i != 0xa && i != 0xd && i!=0xc) {
+        list.add(Character.toString(i));
+      }
+    }
+
+    // Delete character and C1 escapes which are discouraged by XML and banned as HTML numeric escapes. Also discouraging the U+0085 NEL characters.
+    for (char i = 0x7f; i <= 0x9f; i++) {
+      list.add(Character.toString(i));
+    }
+
+    // Isolated surrogates. NB Must also test that valid non-isolated surrogates are retained.
+    for (char i = 0xd800; i <= 0xdfff; i++) {
+      list.add(Character.toString(i));
+    }
+
+    // Isolated surrogates. NB Must also test that valid non-isolated surrogates are retained.
+    for (char i = 0xfdd0; i <= 0xfdef; i++) {
+      list.add(Character.toString(i));
+    }
+
+    list.add(Character.toString((char) 0xfffe));
+    list.add(Character.toString((char) 0xffff));
+
+    // Non-characters from the supplemental planes
+    for (int i = 1; i <= 16; i++) {
+      list.add(new String(Character.toChars(0x10000 * i + 0xfffe)));
+      list.add(new String(Character.toChars(0x10000 * i + 0xffff)));
+    }
+
+    DISCOURAGED = Collections.unmodifiableList(list);
+  }
+
+}

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/ElidedCharactersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/ElidedCharactersTest.java
@@ -1,3 +1,30 @@
+// Copyright (c) 2021, Simon Greatrix
+// All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 package org.owasp.html;
 
 import java.io.IOException;
@@ -5,139 +32,244 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import junit.framework.TestCase;
 import org.junit.Test;
 
+import junit.framework.TestCase;
+
 /**
- * Some characters should not appear in HTML documents, present risks for log-file injection, or are otherwise discouraged from sanitized HTML. This set of
- * unit tests verifies that the inclusion of such characters does not allow dangerous code to slip through.
- * <p>
- * There are two requirements:
- * <p>
- * 1) The Encoding.encodeRcdataOnto method should remove discouraged characters.
- * 2) Sanitized HTML should not change
+ * Some characters must not appear in HTML documents: the standard treats them
+ * as parse errors in the input stream and forbids character references to
+ * them.  Others, such as a raw U+000D, are a log injection risk.  These tests
+ * check that the sanitizer does not emit such characters, and that dropping
+ * one never joins the text around it into a tag, attribute or URL protocol
+ * that a policy would have rejected had it seen the joined form.
  *
  * @author Simon Greatrix on 25/01/2021.
+ * @see <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML 13.1.4 - Character references</a>
  */
+@SuppressWarnings("javadoc")
 public class ElidedCharactersTest extends TestCase {
 
-  /** List of all characters that are discouraged in HTML. */
-  static List<String> DISCOURAGED;
-
-
-  @Test
-  public static final void testRemoveDiscouragedCharacterFromTagStart() throws IOException {
-    // <Xp></p> is an unrecognised tag and an unmatched end tag
-    for (String d : DISCOURAGED) {
-      String test = "<" + d+"h1></h1>";
-      String html = Sanitizers.BLOCKS.sanitize(test);
-      String m = String.format("Use in <h1> of U+%06x", d.codePointAt(0));
-      assertEquals(m, "&lt;h1&gt;", html);
-    }
-
-    String html = Sanitizers.BLOCKS.sanitize("<h1></h1>");
-    assertEquals("<h1></h1>",html);
-  }
-
-  @Test
-  public static final void testRemoveDiscouragedCharacterFromInsideTag() throws IOException {
-    // <h1X></h1> is an unrecognised tag and an unmatched end tag
-    for (String d : DISCOURAGED) {
-      String test = "<h"+d+"1></h1>";
-      String html = Sanitizers.BLOCKS.sanitize(test);
-      String m = String.format("Use in <h1> of U+%06x", d.codePointAt(0));
-      assertEquals(m, "", html);
-    }
-
-    String html = Sanitizers.BLOCKS.sanitize("<h1></h1>");
-    assertEquals("<h1></h1>",html);
-  }
-
-  @Test
-  public static final void testRemoveDiscouragedCharacterFromTagEnd() throws IOException {
-    // <h1X></h1> is an unrecognised tag and an unmatched end tag
-    for (String d : DISCOURAGED) {
-      String test = "<h1"+ d+"></h1>";
-      String html = Sanitizers.BLOCKS.sanitize(test);
-      String m = String.format("Use in <h1> of U+%06x", d.codePointAt(0));
-      assertEquals(m, "", html);
-    }
-
-    String html = Sanitizers.BLOCKS.sanitize("<h1></h1>");
-    assertEquals("<h1></h1>",html);
-  }
-
-  @Test
-  public static final void testRemoveDiscouragedCharacterFromEndWhenEncoding() throws IOException {
-    for (String d : DISCOURAGED) {
-      String test = "Hello" + d;
-      StringBuilder builder = new StringBuilder();
-      Encoding.encodePcdataOnto(test, builder);
-      String m = String.format("Elision of U+%06x", d.codePointAt(0));
-      assertEquals(m, "Hello", builder.toString());
-    }
-  }
-
-
-  @Test
-  public static final void testRemoveDiscouragedCharacterFromMiddleWhenEncoding() throws IOException {
-    for (String d : DISCOURAGED) {
-      String test = "Hel" + d + "lo";
-      StringBuilder builder = new StringBuilder();
-      Encoding.encodePcdataOnto(test, builder);
-      String m = String.format("Elision of U+%06x", d.codePointAt(0));
-      assertEquals(m, "Hello", builder.toString());
-    }
-  }
-
-
-  @Test
-  public static final void testRemoveDiscouragedCharacterFromStartWhenEncoding() throws IOException {
-    for (String d : DISCOURAGED) {
-      String test = d + "Hello";
-      StringBuilder builder = new StringBuilder();
-      Encoding.encodePcdataOnto(test, builder);
-      String m = String.format("Elision of U+%06x", d.codePointAt(0));
-      assertEquals(m, "Hello", builder.toString());
-    }
-  }
-
+  /** Every code point that must not appear in sanitized output. */
+  static final List<String> DISCOURAGED;
 
   static {
-    ArrayList<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<String>();
 
-    // C0 characters banned by XML, except for the three official whitespace characters
+    // C0 controls, except the whitespace characters that XML allows.
+    // U+000C FORM FEED is elided from text too, but it is ASCII whitespace
+    // inside a tag, so it separates tag tokens like a space does; see
+    // testFormFeedIsTagWhitespaceButElidedFromText.
     for (char i = 0; i <= 0x1f; i++) {
-      if (i != 0x9 && i != 0xa && i != 0xd && i!=0xc) {
+      if (i != '\t' && i != '\n' && i != '\r' && i != '\f') {
         list.add(Character.toString(i));
       }
     }
 
-    // Delete character and C1 escapes which are discouraged by XML and banned as HTML numeric escapes. Also discouraging the U+0085 NEL characters.
+    // DEL and the C1 controls, which HTML forbids as character references
+    // and XML discourages.  U+0085 NEL is among them: some systems read it
+    // as a line break and others as an ellipsis, so it has no safe meaning.
     for (char i = 0x7f; i <= 0x9f; i++) {
       list.add(Character.toString(i));
     }
 
-    // Isolated surrogates. NB Must also test that valid non-isolated surrogates are retained.
+    // Isolated surrogates.  testSurrogatePairsAreKept checks that a valid
+    // pair survives.
     for (char i = 0xd800; i <= 0xdfff; i++) {
       list.add(Character.toString(i));
     }
 
-    // Isolated surrogates. NB Must also test that valid non-isolated surrogates are retained.
+    // The noncharacters in Arabic Presentation Forms-A.
     for (char i = 0xfdd0; i <= 0xfdef; i++) {
       list.add(Character.toString(i));
     }
 
+    // The last two code points of the BMP and of every supplementary plane.
     list.add(Character.toString((char) 0xfffe));
     list.add(Character.toString((char) 0xffff));
-
-    // Non-characters from the supplemental planes
-    for (int i = 1; i <= 16; i++) {
-      list.add(new String(Character.toChars(0x10000 * i + 0xfffe)));
-      list.add(new String(Character.toChars(0x10000 * i + 0xffff)));
+    for (int plane = 1; plane <= 16; plane++) {
+      list.add(new String(Character.toChars(0x10000 * plane + 0xfffe)));
+      list.add(new String(Character.toChars(0x10000 * plane + 0xffff)));
     }
 
     DISCOURAGED = Collections.unmodifiableList(list);
   }
 
+  /** Lets through the attributes that the token merging cases aim at. */
+  private static final PolicyFactory LINKS_WITH_TITLES = new HtmlPolicyBuilder()
+      .allowElements("a", "b")
+      .allowAttributes("href", "title").onElements("a")
+      .allowStandardUrlProtocols()
+      .toFactory();
+
+  private static String describe(String d) {
+    return String.format("U+%04X", d.codePointAt(0));
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromTagStart() {
+    // "<?h1>" is text, since '<' is not followed by a letter.
+    for (String d : DISCOURAGED) {
+      String html = Sanitizers.BLOCKS.sanitize("<" + d + "h1></h1>");
+      assertEquals(describe(d), "&lt;h1&gt;", html);
+    }
+    assertEquals("<h1></h1>", Sanitizers.BLOCKS.sanitize("<h1></h1>"));
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromInsideTag() {
+    // "<h?1>" is an unrecognised element and "</h1>" an unmatched end tag.
+    for (String d : DISCOURAGED) {
+      String html = Sanitizers.BLOCKS.sanitize("<h" + d + "1></h1>");
+      assertEquals(describe(d), "", html);
+    }
+    assertEquals("<h1></h1>", Sanitizers.BLOCKS.sanitize("<h1></h1>"));
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromTagEnd() {
+    // "<h1?>" is an unrecognised element: the character is not whitespace,
+    // so it does not end the tag name.
+    for (String d : DISCOURAGED) {
+      String html = Sanitizers.BLOCKS.sanitize("<h1" + d + "></h1>");
+      assertEquals(describe(d), "", html);
+    }
+    assertEquals("<h1></h1>", Sanitizers.BLOCKS.sanitize("<h1></h1>"));
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromEndWhenEncoding()
+      throws IOException {
+    for (String d : DISCOURAGED) {
+      StringBuilder builder = new StringBuilder();
+      Encoding.encodePcdataOnto("Hello" + d, builder);
+      assertEquals(describe(d), "Hello", builder.toString());
+    }
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromMiddleWhenEncoding()
+      throws IOException {
+    for (String d : DISCOURAGED) {
+      StringBuilder builder = new StringBuilder();
+      Encoding.encodePcdataOnto("Hel" + d + "lo", builder);
+      assertEquals(describe(d), "Hello", builder.toString());
+    }
+  }
+
+  @Test
+  public static final void testRemoveDiscouragedCharacterFromStartWhenEncoding()
+      throws IOException {
+    for (String d : DISCOURAGED) {
+      StringBuilder builder = new StringBuilder();
+      Encoding.encodePcdataOnto(d + "Hello", builder);
+      assertEquals(describe(d), "Hello", builder.toString());
+    }
+  }
+
+  @Test
+  public static final void testDiscouragedCharacterIsStrippedWhenDecoding() {
+    for (String d : DISCOURAGED) {
+      String m = describe(d);
+      assertEquals(m, "Hello", Encoding.decodeHtml("Hel" + d + "lo", false));
+      assertEquals(m, "Hello", Encoding.decodeHtml("Hel" + d + "lo", true));
+      // Stripping happens after references are decoded, so a stripped
+      // character cannot turn the text around it into a reference.
+      assertEquals(m, "&lt;", Encoding.decodeHtml("&l" + d + "t;", false));
+    }
+  }
+
+  @Test
+  public static final void testDiscouragedCharacterDoesNotHideAScriptTag() {
+    for (String d : DISCOURAGED) {
+      String m = describe(d);
+      // '<' followed by a non-letter is text.
+      assertEquals(m, "&lt;script&gt;alert(1)",
+          LINKS_WITH_TITLES.sanitize("<" + d + "script>alert(1)</script>"));
+      // "<s?cript>" is an unknown element, so its content is ordinary text
+      // and the end tag matches nothing.  It must not become <script>.
+      assertEquals(m, "alert(1)",
+          LINKS_WITH_TITLES.sanitize("<s" + d + "cript>alert(1)</script>"));
+      assertEquals(m, "x",
+          LINKS_WITH_TITLES.sanitize("<b" + d + ">x</b>"));
+    }
+  }
+
+  @Test
+  public static final void testDiscouragedCharacterDoesNotSplitAnAttribute() {
+    for (String d : DISCOURAGED) {
+      String m = describe(d);
+      // Inside a tag the character is not whitespace, so "a?href=..." is one
+      // unknown element name rather than an <a> with an href.
+      assertEquals(m, "x",
+          LINKS_WITH_TITLES.sanitize(
+              "<a" + d + "href=\"javascript:alert(1)\">x</a>"));
+      // An unquoted value runs on past the character, so "onclick=alert(1)"
+      // stays inside the title value and never becomes an attribute.
+      assertEquals(m, "<a href=\"/\" title=\"onclick&#61;alert(1)\">x</a>",
+          LINKS_WITH_TITLES.sanitize(
+              "<a href=\"/\" title=" + d + "onclick=alert(1)>x</a>"));
+      assertEquals(m, "<a href=\"/\" title=\"onclick&#61;alert(1)\">x</a>",
+          LINKS_WITH_TITLES.sanitize(
+              "<a href=\"/\" title=\"" + d + "onclick=alert(1)\">x</a>"));
+    }
+  }
+
+  @Test
+  public static final void testDiscouragedCharacterDoesNotHideAUrlProtocol() {
+    for (String d : DISCOURAGED) {
+      String m = describe(d);
+      // The character is stripped before the URL policy runs, so the policy
+      // sees "javascript:" and rejects it.  Stripping it only on output
+      // would let "java?script:" through as an unknown protocol and then
+      // emit "javascript:".
+      assertEquals(m, "x",
+          LINKS_WITH_TITLES.sanitize(
+              "<a href=\"java" + d + "script:alert(1)\">x</a>"));
+      // Nor can it hide a character reference from the decoder: "&?#58;"
+      // stays a literal ampersand, which the encoder escapes.
+      assertEquals(m, "<a href=\"javascript&amp;#58;alert%281%29\">x</a>",
+          LINKS_WITH_TITLES.sanitize(
+              "<a href=\"javascript&" + d + "#58;alert(1)\">x</a>"));
+    }
+  }
+
+  @Test
+  public static final void testSurrogatePairsAreKept() throws IOException {
+    StringBuilder sb = new StringBuilder();
+    Encoding.encodePcdataOnto("a\ud83d\ude00b", sb);  // U+1F600
+    assertEquals("a&#x1f600;b", sb.toString());
+    assertEquals(
+        "<b>a&#x1f600;b</b>",
+        LINKS_WITH_TITLES.sanitize("<b>a\ud83d\ude00b</b>"));
+    // The last assigned code point of a plane is kept; the two
+    // noncharacters after it are not.
+    sb.setLength(0);
+    Encoding.encodePcdataOnto("a\ud83f\udffdb\ud83f\udffe\ud83f\udfff", sb);
+    assertEquals("a&#x1fffd;b", sb.toString());
+  }
+
+  @Test
+  public static final void testFormFeedIsTagWhitespaceButElidedFromText()
+      throws IOException {
+    // U+000C is one of the five ASCII whitespace characters, so inside a tag
+    // it separates tokens like a space; it is not an XML character, so it
+    // is dropped from text.
+    assertEquals("<b>x</b>", LINKS_WITH_TITLES.sanitize("<b\f>x</b>"));
+    StringBuilder sb = new StringBuilder();
+    Encoding.encodePcdataOnto("a\fb", sb);
+    assertEquals("ab", sb.toString());
+  }
+
+  @Test
+  public static final void testCarriageReturnsAreNormalizedToLineFeeds() {
+    // As the HTML input stream preprocessor does, so rendering is unchanged
+    // and the output never contains a raw U+000D.
+    // CRLF and a lone CR each become LF; LF CR is two line breaks.
+    assertEquals("a\nb\nc\n\n", LINKS_WITH_TITLES.sanitize("a\r\nb\rc\n\r"));
+    assertEquals("a\nb", LINKS_WITH_TITLES.sanitize("a&#13;b"));
+    assertEquals(
+        "<a href=\"/\" title=\"a\nb\">x</a>",
+        LINKS_WITH_TITLES.sanitize("<a href=\"/\" title=\"a\r\nb\">x</a>"));
+  }
 }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/EncodingTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/EncodingTest.java
@@ -160,6 +160,26 @@ public final class EncodingTest extends TestCase {
     assertDecodedHtml("lt&&lt;gt", "\ufdddlt&&l\ufffet;\udc9c\ud835gt");
     assertDecodedHtml("lt&<", "lt&&lt;\udc9c");
     assertDecodedHtml("lt&<", "lt&&lt;\ud835");
+
+    // DEL and the C1 controls are stripped, raw or as references, like the
+    // C0 controls; encodeHtmlOnto elides them, and policies must see the
+    // same text that will be emitted.
+    assertDecodedHtml("ab", "a\u007fb");
+    assertDecodedHtml("ab", "a&#x7f;b");
+    assertDecodedHtml("ab", "a\u0085b");
+    assertDecodedHtml("ab", "a&#x85;b");
+    assertDecodedHtml("ab", "a&#x9f;b");
+    assertDecodedHtml("a&lt;b", "a\u0085&l\u0085t;b");
+    assertDecodedHtml("a\u00a0b", "a\u00a0b");
+
+    // Noncharacters, in the BMP and in the supplementary planes.
+    assertDecodedHtml("ab", "a\ufdd0b");
+    assertDecodedHtml("ab", "a&#xfdd0;b");
+    assertDecodedHtml("a\ufdcf\ufdf0b", "a\ufdcf\ufdf0b");
+    assertDecodedHtml("ab", "a\ud83f\udffeb");
+    assertDecodedHtml("ab", "a&#x1fffe;b");
+    assertDecodedHtml("ab", "a&#x10ffff;b");
+    assertDecodedHtml("a\ud83f\udffdb", "a\ud83f\udffdb");
   }
 
   @Test
@@ -186,7 +206,7 @@ public final class EncodingTest extends TestCase {
     Encoding.encodeHtmlAttribOnto(cps.toString(), out);
     assertEquals(
         "\t \n &#64; \u00a0 \u00ff \u0100 \u0fff \u1000 "
-        + "\u123a \ufffd &#x10000; &#x10fffd; ",
+        + "\u123a &#xfffd; &#x10000; &#x10fffd; ",
         out.toString());
   }
 
@@ -195,26 +215,29 @@ public final class EncodingTest extends TestCase {
       throws Exception {
     StringBuilder sb = new StringBuilder();
     StringBuilder cps = new StringBuilder();
-    // Test with a set of legal code points
-    for (int codepoint : new int[] { 8, '\r', 0x7f, 0x85, 0xfdd0, 0xfffe, 0x1fffe, 0x3ffff }) {
+    // Code points to which HTML forbids a numeric character reference.
+    for (int codepoint : new int[] {
+        0, 8, '\r', 0x1f, 0x7f, 0x80, 0x85, 0x9f, 0xd800, 0xdfff,
+        0xfdd0, 0xfdef, 0xfffe, 0xffff, 0x1fffe, 0x3ffff, 0x10ffff,
+        Character.MAX_CODE_POINT + 1, -1 }) {
       try {
         Encoding.appendNumericEntity(codepoint, sb);
-        fail("Illegal character was accepted: "+codepoint);
-      } catch ( IllegalArgumentException e ) {
+        fail("Illegal code point was accepted: " + codepoint);
+      } catch (IllegalArgumentException e) {
         // expected behaviour
       }
-
-      cps.appendCodePoint(codepoint).append(',');
+      if (0 <= codepoint && codepoint <= Character.MAX_CODE_POINT) {
+        cps.appendCodePoint(codepoint).append(',');
+      }
     }
-
     assertEquals("", sb.toString());
 
+    // The encoder elides all of them, except that CR becomes LF.
     StringBuilder out = new StringBuilder();
     Encoding.encodeHtmlAttribOnto(cps.toString(), out);
-    assertEquals(
-        ",\n,,,,,,,",
-        out.toString());
+    assertEquals(",,\n,,,,,,,,,,,,,,,", out.toString());
   }
+
   @Test
   public static final void testAngularJsBracesInTextNode() throws Exception {
     StringBuilder sb = new StringBuilder();
@@ -255,20 +278,29 @@ public final class EncodingTest extends TestCase {
     assertStripped("foo\ud800\udc00bar", "foo\udc00\ud800\udc00bar");
     assertStripped("foo\ud834\udd1ebar", "foo\ud834\udd1ebar");
     assertStripped("foo\ud834\udd1e", "foo\ud834\udd1e");
+    assertStripped("foobar", "foo\u007fbar");
+    assertStripped("foobar", "foo\u0080\u0085\u009fbar");
+    assertStripped("foo\u00a0bar", "foo\u00a0bar");
+    assertStripped("foobar", "foo\ufdd0bar\ufdef");
+    assertStripped("foo\ufdcf\ufdf0bar", "foo\ufdcf\ufdf0bar");
 
-    // Check stripping of non-characters from all planes
-    for(int i=0;i<=16;i++) {
-      int o = 0x10000 * i;
-      String s = new StringBuilder().append(String.format("%02x",i)).appendCodePoint(o+0xffef).appendCodePoint(o+0xfffd)
-          .appendCodePoint(o+0xfffe).appendCodePoint(o+0xffff).toString();
-      String t = s.substring(0,(i==0)?4:6);
-      assertStripped(t,s);
+    // The last two code points of every plane are noncharacters.
+    for (int plane = 0; plane <= 16; plane++) {
+      int o = 0x10000 * plane;
+      String s = new StringBuilder()
+          .append(String.format("%02x", plane))
+          .appendCodePoint(o + 0xffef).appendCodePoint(o + 0xfffd)
+          .appendCodePoint(o + 0xfffe).appendCodePoint(o + 0xffff)
+          .toString();
+      String t = s.substring(0, plane == 0 ? 4 : 6);
+      assertStripped(t, s);
 
-      s = new StringBuilder().append("foo").appendCodePoint(o+0xfffe).appendCodePoint(o+0xffff).append("bar").toString();
-      assertStripped("foobar",s);
+      s = new StringBuilder().append("foo")
+          .appendCodePoint(o + 0xfffe).appendCodePoint(o + 0xffff)
+          .append("bar").toString();
+      assertStripped("foobar", s);
     }
   }
-
 
   @Test
   public static final
@@ -299,63 +331,83 @@ public final class EncodingTest extends TestCase {
 
   @Test
   public static final void testRiskyNormalizationSetContents() {
-    // Test that the risky normalization set contains the expected values
-    for(char toTest='\u0080'; toTest<'\ufffe'; toTest++) {
+    // The table in Encoding is spelled out so that output does not depend
+    // on the JDK's Unicode version.  Check it against the running JDK.
+    for (char c = '\u0080'; c < '\ufffe'; c++) {
       boolean isRisky = false;
-      String decomposed = Normalizer.normalize(Character.toString(toTest), Form.NFKD);
-      for(int i=0;i<decomposed.length();i++) {
+      String decomposed = Normalizer.normalize(String.valueOf(c), Form.NFKD);
+      for (int i = 0; i < decomposed.length(); i++) {
         char ch = decomposed.charAt(i);
-        if( (' '<ch && ch<'0') || ('9'<ch && ch<'A') || ('Z'<ch && ch<'a') || ('z'<ch && ch<'\u007f') ) {
-          // Contains a non-alpha-numeric ASCII printable character, so we consider it a risky decomposition.
+        if ((' ' < ch && ch < '0') || ('9' < ch && ch < 'A')
+            || ('Z' < ch && ch < 'a') || ('z' < ch && ch < '\u007f')) {
+          // A printable, non-alphanumeric ASCII character.
           isRisky = true;
           break;
         }
       }
-
-      if( isRisky ) {
-        assertTrue(Encoding.RISKY_NORMALIZATION.contains(toTest));
-      } else {
-        assertFalse(Encoding.RISKY_NORMALIZATION.contains(toTest));
+      if (isRisky != Encoding.isRiskyNormalization(c)) {
+        fail(String.format(
+            "U+%04X has NFKD form %s: %s.  If this JDK's Unicode tables are"
+            + " newer than Encoding.RISKY_NORMALIZATION, update the table.",
+            (int) c, decomposed,
+            isRisky ? "missing from the table" : "should not be in the table"));
       }
     }
   }
 
+  private static void assertRcdataEncoded(String want, String plainText)
+      throws IOException {
+    StringBuilder sb = new StringBuilder();
+    Encoding.encodeRcdataOnto(plainText, sb);
+    assertEquals(plainText, want, sb.toString());
+  }
 
   @Test
   public static final void testRiskyNormalization() throws IOException {
-    StringBuilder attrib = new StringBuilder();
-    Encoding.encodeRcdataOnto("Small Less-than Sign : \ufe64",attrib);
-    assertEquals("Small Less-than Sign : &#xfe64;",attrib.toString());
+    // Characters whose compatibility decomposition contains ASCII
+    // punctuation are written as references so that a later normalization
+    // of the output cannot produce an HTML special character.
+    assertRcdataEncoded("Small Less-than Sign : &#xfe64;",
+        "Small Less-than Sign : \ufe64");
+    assertRcdataEncoded("Fullwidth Quotation Mark : &#xff02;",
+        "Fullwidth Quotation Mark : \uff02");
+    assertRcdataEncoded("Greek Varia : &#x1fef;", "Greek Varia : \u1fef");
+    assertRcdataEncoded("Greek Question Mark : &#x37e;",
+        "Greek Question Mark : \u037e");
+    assertRcdataEncoded("One Dot Leader : &#x2024;", "One Dot Leader : \u2024");
+    assertRcdataEncoded("Double Exclamation Mark : &#x203c;",
+        "Double Exclamation Mark : \u203c");
 
-    attrib.setLength(0);
-    Encoding.encodeRcdataOnto("Fullwidth Quotation Mark : \uff02",attrib);
-    assertEquals("Fullwidth Quotation Mark : &#xff02;",attrib.toString());
+    // Everything from U+FE60 up is written as a reference whether or not it
+    // normalizes to something risky: the byte order mark, the fullwidth
+    // letters and the replacement character among them.
+    assertRcdataEncoded("BOM : &#xfeff;", "BOM : \ufeff");
+    assertRcdataEncoded("Fullwidth A : &#xff21;", "Fullwidth A : \uff21");
+    assertRcdataEncoded("Replacement : &#xfffd;", "Replacement : \ufffd");
+    assertRcdataEncoded("Arabic ligature : &#xfefb;", "Arabic ligature : \ufefb");
 
-    attrib.setLength(0);
-    Encoding.encodeRcdataOnto("Greek Varia : \u1fef",attrib);
-    assertEquals("Greek Varia : &#x1fef;",attrib.toString());
+    // Below U+FE60, characters with a harmless or no decomposition pass.
+    assertRcdataEncoded("NBSP : \u00a0", "NBSP : \u00a0");
+    assertRcdataEncoded("Ligature : \ufb01", "Ligature : \ufb01");
+    assertRcdataEncoded("CJK : \u4e2d\u6587", "CJK : \u4e2d\u6587");
   }
 
   @Test
   public static final void testNewLineNormalization() throws IOException {
+    // https://infra.spec.whatwg.org/#normalize-newlines
+    assertRcdataEncoded("\none\ntwo\n", "\rone\ntwo\r");
+    assertRcdataEncoded("\none\ntwo\n", "\none\rtwo\n");
+    assertRcdataEncoded("\none\ntwo\n", "\r\none\r\ntwo\r\n");
+    assertRcdataEncoded("\n\none\n\ntwo\n\n", "\n\rone\n\rtwo\n\r");
+    assertRcdataEncoded("\n\none\n\ntwo\n\n", "\r\rone\n\ntwo\r\r");
+    assertRcdataEncoded("\n", "\r");
+    assertRcdataEncoded("", "");
+
     StringBuilder attrib = new StringBuilder();
-    Encoding.encodeRcdataOnto("\rone\ntwo\r",attrib);
-    assertEquals("\none\ntwo\n",attrib.toString());
-
-    attrib.setLength(0);
-    Encoding.encodeRcdataOnto("\none\rtwo\n",attrib);
-    assertEquals("\none\ntwo\n",attrib.toString());
-
-    attrib.setLength(0);
-    Encoding.encodeRcdataOnto("\r\none\r\ntwo\r\n",attrib);
-    assertEquals("\none\ntwo\n",attrib.toString());
-
-    attrib.setLength(0);
-    Encoding.encodeRcdataOnto("\n\rone\n\rtwo\n\r",attrib);
-    assertEquals("\n\none\n\ntwo\n\n",attrib.toString());
-
-    attrib.setLength(0);
-    Encoding.encodeRcdataOnto("\r\rone\n\ntwo\r\r",attrib);
-    assertEquals("\n\none\n\ntwo\n\n",attrib.toString());
+    Encoding.encodeHtmlAttribOnto("a\r\nb\rc", attrib);
+    assertEquals("a\nb\nc", attrib.toString());
+    StringBuilder pcdata = new StringBuilder();
+    Encoding.encodePcdataOnto("a\r\nb\rc", pcdata);
+    assertEquals("a\nb\nc", pcdata.toString());
   }
 }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/EncodingTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/EncodingTest.java
@@ -27,6 +27,10 @@
 
 package org.owasp.html;
 
+import java.io.IOException;
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
+
 import org.junit.Test;
 
 import junit.framework.TestCase;
@@ -144,6 +148,18 @@ public final class EncodingTest extends TestCase {
         "?foo&para=bar",
         "?foo&para=bar"
     );
+
+    // Banned code units are stripped after character references are decoded,
+    // so a banned code unit cannot split text that would otherwise be a
+    // character reference into one.
+    assertDecodedHtml("lt<", "lt&lt;");
+    assertDecodedHtml("ltlt;", "ltlt;");
+    assertDecodedHtml("lt&lt;", "lt&&#108;t;");
+    assertDecodedHtml("lt&<", "lt&&lt;");
+
+    assertDecodedHtml("lt&&lt;gt", "\ufdddlt&&l\ufffet;\udc9c\ud835gt");
+    assertDecodedHtml("lt&<", "lt&&lt;\udc9c");
+    assertDecodedHtml("lt&<", "lt&&lt;\ud835");
   }
 
   @Test
@@ -151,9 +167,10 @@ public final class EncodingTest extends TestCase {
       throws Exception {
     StringBuilder sb = new StringBuilder();
     StringBuilder cps = new StringBuilder();
+    // Test with a set of legal code points
     for (int codepoint : new int[] {
-        0, 9, '\n', '@', 0x80, 0xff, 0x100, 0xfff, 0x1000, 0x123a, 0xffff,
-        0x10000, Character.MAX_CODE_POINT }) {
+        9, '\n', '@', 0xa0, 0xff, 0x100, 0xfff, 0x1000, 0x123a, 0xfffd,
+        0x10000, Character.MAX_CODE_POINT-2 }) {
       Encoding.appendNumericEntity(codepoint, sb);
       sb.append(' ');
 
@@ -161,18 +178,43 @@ public final class EncodingTest extends TestCase {
     }
 
     assertEquals(
-         "&#0; &#9; &#10; &#64; &#x80; &#xff; &#x100; &#xfff; &#x1000; "
-         + "&#x123a; &#xffff; &#x10000; &#x10ffff; ",
+         "&#9; &#10; &#64; &#xa0; &#xff; &#x100; &#xfff; &#x1000; "
+         + "&#x123a; &#xfffd; &#x10000; &#x10fffd; ",
          sb.toString());
 
     StringBuilder out = new StringBuilder();
     Encoding.encodeHtmlAttribOnto(cps.toString(), out);
     assertEquals(
-        " \t \n &#64; \u0080 \u00ff \u0100 \u0fff \u1000 "
-        + "\u123a  &#x10000; &#x10ffff; ",
+        "\t \n &#64; \u00a0 \u00ff \u0100 \u0fff \u1000 "
+        + "\u123a \ufffd &#x10000; &#x10fffd; ",
         out.toString());
   }
 
+  @Test
+  public static final void testAppendIllegalNumericEntityAndEncodeOnto()
+      throws Exception {
+    StringBuilder sb = new StringBuilder();
+    StringBuilder cps = new StringBuilder();
+    // Test with a set of legal code points
+    for (int codepoint : new int[] { 8, '\r', 0x7f, 0x85, 0xfdd0, 0xfffe, 0x1fffe, 0x3ffff }) {
+      try {
+        Encoding.appendNumericEntity(codepoint, sb);
+        fail("Illegal character was accepted: "+codepoint);
+      } catch ( IllegalArgumentException e ) {
+        // expected behaviour
+      }
+
+      cps.appendCodePoint(codepoint).append(',');
+    }
+
+    assertEquals("", sb.toString());
+
+    StringBuilder out = new StringBuilder();
+    Encoding.encodeHtmlAttribOnto(cps.toString(), out);
+    assertEquals(
+        ",\n,,,,,,,",
+        out.toString());
+  }
   @Test
   public static final void testAngularJsBracesInTextNode() throws Exception {
     StringBuilder sb = new StringBuilder();
@@ -213,8 +255,20 @@ public final class EncodingTest extends TestCase {
     assertStripped("foo\ud800\udc00bar", "foo\udc00\ud800\udc00bar");
     assertStripped("foo\ud834\udd1ebar", "foo\ud834\udd1ebar");
     assertStripped("foo\ud834\udd1e", "foo\ud834\udd1e");
-    assertStripped("\uffef\ufffd", "\uffef\ufffd\ufffe\uffff");
+
+    // Check stripping of non-characters from all planes
+    for(int i=0;i<=16;i++) {
+      int o = 0x10000 * i;
+      String s = new StringBuilder().append(String.format("%02x",i)).appendCodePoint(o+0xffef).appendCodePoint(o+0xfffd)
+          .appendCodePoint(o+0xfffe).appendCodePoint(o+0xffff).toString();
+      String t = s.substring(0,(i==0)?4:6);
+      assertStripped(t,s);
+
+      s = new StringBuilder().append("foo").appendCodePoint(o+0xfffe).appendCodePoint(o+0xffff).append("bar").toString();
+      assertStripped("foobar",s);
+    }
   }
+
 
   @Test
   public static final
@@ -241,5 +295,67 @@ public final class EncodingTest extends TestCase {
     StringBuilder attrib = new StringBuilder();
     Encoding.encodeHtmlAttribOnto("a nonce=xyz ", attrib);
     assertEquals("a nonce&#61;xyz ", attrib.toString());
+  }
+
+  @Test
+  public static final void testRiskyNormalizationSetContents() {
+    // Test that the risky normalization set contains the expected values
+    for(char toTest='\u0080'; toTest<'\ufffe'; toTest++) {
+      boolean isRisky = false;
+      String decomposed = Normalizer.normalize(Character.toString(toTest), Form.NFKD);
+      for(int i=0;i<decomposed.length();i++) {
+        char ch = decomposed.charAt(i);
+        if( (' '<ch && ch<'0') || ('9'<ch && ch<'A') || ('Z'<ch && ch<'a') || ('z'<ch && ch<'\u007f') ) {
+          // Contains a non-alpha-numeric ASCII printable character, so we consider it a risky decomposition.
+          isRisky = true;
+          break;
+        }
+      }
+
+      if( isRisky ) {
+        assertTrue(Encoding.RISKY_NORMALIZATION.contains(toTest));
+      } else {
+        assertFalse(Encoding.RISKY_NORMALIZATION.contains(toTest));
+      }
+    }
+  }
+
+
+  @Test
+  public static final void testRiskyNormalization() throws IOException {
+    StringBuilder attrib = new StringBuilder();
+    Encoding.encodeRcdataOnto("Small Less-than Sign : \ufe64",attrib);
+    assertEquals("Small Less-than Sign : &#xfe64;",attrib.toString());
+
+    attrib.setLength(0);
+    Encoding.encodeRcdataOnto("Fullwidth Quotation Mark : \uff02",attrib);
+    assertEquals("Fullwidth Quotation Mark : &#xff02;",attrib.toString());
+
+    attrib.setLength(0);
+    Encoding.encodeRcdataOnto("Greek Varia : \u1fef",attrib);
+    assertEquals("Greek Varia : &#x1fef;",attrib.toString());
+  }
+
+  @Test
+  public static final void testNewLineNormalization() throws IOException {
+    StringBuilder attrib = new StringBuilder();
+    Encoding.encodeRcdataOnto("\rone\ntwo\r",attrib);
+    assertEquals("\none\ntwo\n",attrib.toString());
+
+    attrib.setLength(0);
+    Encoding.encodeRcdataOnto("\none\rtwo\n",attrib);
+    assertEquals("\none\ntwo\n",attrib.toString());
+
+    attrib.setLength(0);
+    Encoding.encodeRcdataOnto("\r\none\r\ntwo\r\n",attrib);
+    assertEquals("\none\ntwo\n",attrib.toString());
+
+    attrib.setLength(0);
+    Encoding.encodeRcdataOnto("\n\rone\n\rtwo\n\r",attrib);
+    assertEquals("\n\none\n\ntwo\n\n",attrib.toString());
+
+    attrib.setLength(0);
+    Encoding.encodeRcdataOnto("\r\rone\n\ntwo\r\r",attrib);
+    assertEquals("\n\none\n\ntwo\n\n",attrib.toString());
   }
 }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
@@ -424,6 +424,47 @@ public class HtmlLexerTest extends TestCase {
     );
   }
 
+  @Test
+  public static final void testOnlyAsciiWhitespaceSeparatesTagTokens()
+      throws Exception {
+    // The five ASCII whitespace characters end a tag name or an unquoted
+    // attribute value.  Character.isWhitespace also accepts U+000B,
+    // U+001C..U+001F and the Unicode space separators, but the WHATWG
+    // tokenizer keeps those inside names and values, as validator.nu
+    // confirms for each of the characters below.
+    for (String ws : new String[] {" ", "\t", "\n", "\f", "\r"}) {
+      assertTokens("<b" + ws + "title=x>y</b>",
+          "TAGBEGIN: <b", "ATTRNAME: title", "ATTRVALUE: x", "TAGEND: >",
+          "TEXT: y", "TAGBEGIN: </b", "TAGEND: >");
+      assertTokens("<style>a</style" + ws + ">b",
+          "TAGBEGIN: <style", "TAGEND: >", "UNESCAPED: a",
+          "TAGBEGIN: </style", "TAGEND: >", "TEXT: b");
+    }
+    for (String notWs : new String[] {
+        "\u000b", "\u001c", "\u001f", "\u0085", "\u00a0", "\u1680",
+        "\u2000", "\u2028", "\u2029", "\u205f", "\u3000"}) {
+      String m = String.format("U+%04X", (int) notWs.charAt(0));
+      // Part of the tag name.
+      assertTokensFor(m, "<b" + notWs + "title=x>y</b>",
+          "TAGBEGIN: <b" + notWs + "title=x", "TAGEND: >",
+          "TEXT: y", "TAGBEGIN: </b", "TAGEND: >");
+      // Part of an unquoted attribute value.
+      assertTokensFor(m, "<b title=x" + notWs + "id=z>y</b>",
+          "TAGBEGIN: <b", "ATTRNAME: title", "ATTRVALUE: x" + notWs + "id=z",
+          "TAGEND: >", "TEXT: y", "TAGBEGIN: </b", "TAGEND: >");
+      // Part of the next attribute's name after a quoted value.
+      assertTokensFor(m, "<b title='x'" + notWs + "id=z>y</b>",
+          "TAGBEGIN: <b", "ATTRNAME: title", "ATTRVALUE: 'x'",
+          "ATTRNAME: " + notWs + "id", "ATTRVALUE: z", "TAGEND: >",
+          "TEXT: y", "TAGBEGIN: </b", "TAGEND: >");
+      // Does not end the end tag of a raw text element, so the element
+      // stays open just as it does in a browser.
+      assertTokensFor(m, "<style>a</style" + notWs + ">b",
+          "TAGBEGIN: <style", "TAGEND: >",
+          "UNESCAPED: a</style" + notWs + ">b");
+    }
+  }
+
   private static void lex(String input, Appendable out) throws Exception {
     HtmlLexer lexer = new HtmlLexer(input);
     int maxTypeLength = 0;
@@ -449,12 +490,17 @@ public class HtmlLexerTest extends TestCase {
   }
 
   private static void assertTokens(String markup, String... golden) {
+    assertTokensFor(markup, markup, golden);
+  }
+
+  private static void assertTokensFor(
+      String message, String markup, String... golden) {
     HtmlLexer lexer = new HtmlLexer(markup);
     List<String> actual = new ArrayList<>();
     while (lexer.hasNext()) {
       HtmlToken t = lexer.next();
       actual.add(t.type + ": " + markup.substring(t.start, t.end));
     }
-    assertEquals(Arrays.asList(golden), actual);
+    assertEquals(message, Arrays.asList(golden), actual);
   }
 }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerFuzzerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerFuzzerTest.java
@@ -59,6 +59,19 @@ public class HtmlSanitizerFuzzerTest extends FuzzyTestCase {
         public void text(String textChunk) { /* do nothing */ }
       };
 
+  /**
+   * Characters that the sanitizer strips, normalizes, writes as references
+   * or treats as whitespace, including the halves of surrogate pairs for
+   * the noncharacters at the end of the supplementary planes.
+   */
+  static final char[] AWKWARD_CHARS = {
+    '\0', '\u0001', '\t', '\n', '\u000b', '\f', '\r', '\u001c', '\u001f',
+    ' ', '\u007f', '\u0080', '\u0085', '\u009f', '\u00a0', '\u2028',
+    '\u3000', '\ud800', '\ud83f', '\udbff', '\udc00', '\udffe', '\udfff',
+    '\ufdd0', '\ufdef', '\ufe64', '\ufeff', '\uff1c', '\ufffd', '\ufffe',
+    '\uffff',
+  };
+
   public final void testFuzzHtmlParser() throws Exception {
     String html;
     try (InputStream resourceStream = getClass().getClassLoader()
@@ -89,7 +102,12 @@ public class HtmlSanitizerFuzzerTest extends FuzzyTestCase {
       for (int i = length; --i >= 0;) { fuzzyHtml0[i] = html.charAt(i); }
       for (int fuzz = 1 + rnd.nextInt(25); --fuzz >= 0;) {
         if (rnd.nextBoolean()) {
-          fuzzyHtml0[rnd.nextInt(length)] = (char) rnd.nextInt(0x10000);
+          // Half of the time pick a character that the sanitizer strips,
+          // normalizes or treats as whitespace, since dropping a character
+          // is where two harmless tokens can join into a harmful one.
+          fuzzyHtml0[rnd.nextInt(length)] = rnd.nextBoolean()
+              ? (char) rnd.nextInt(0x10000)
+              : AWKWARD_CHARS[rnd.nextInt(AWKWARD_CHARS.length)];
           continue;
         }
         int s0 = rnd.nextInt(length - 1);

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -422,53 +422,6 @@ public class HtmlSanitizerTest extends TestCase {
             codeUnits));
   }
 
-  @Test
-  public static final void testMacOSAndIOSQueryOfDeath() {
-    // https://manishearth.github.io/blog/2018/02/15/picking-apart-the-crashing-ios-string/
-    String[][] tests = {
-        {
-          "\u0C1C\u0C4D\u0C1E\u200C\u0C3E",
-          "\u0C1C\u0C4D\u0C1E\u0C3E",
-        },
-        {
-          "\u09B8\u09CD\u09B0<interrupted>\u200C\u09C1",
-          "\u09B8\u09CD\u09B0\u09C1",
-        },
-        {
-          "\u0C1C\u0C4D\u0C1E\u200C\u0C3E",
-          "\u0C1C\u0C4D\u0C1E\u0C3E",
-        },
-        {
-          "\u09B8\u09CD\u09B0\u200C<interrupted>\u09C1",
-          "\u09B8\u09CD\u09B0\u09C1",
-        },
-        {
-          "&#x0C1C;&#x0C4D;&#x0C1E;&#x200C;&#x0C3E;",
-          "\u0C1C\u0C4D\u0C1E\u0C3E",
-        },
-        {
-          "&#x0C1C;&#x0C4D;&#x0C1E;<interrupted>&#x200C;&#x0C3E;",
-          "\u0C1C\u0C4D\u0C1E\u0C3E",
-        },
-        {
-          "&#x09B8;&#x09CD;&#x09B0;&#x200C;&#x09C1;",
-          "\u09B8\u09CD\u09B0\u09C1",
-        },
-        {
-          "&#x09B8;&#x09CD;&#x09B0;&#x200C;<interrupted>&#x09C1;",
-          "\u09B8\u09CD\u09B0\u09C1",
-        },
-        {
-          "\u0915\u094D\u0930\u200C\u093E",
-          "\u0915\u094D\u0930\u093E",
-        },
-    };
-
-    for (int i = 0, n = tests.length; i < n; ++i) {
-      String[] test = tests[i];
-      assertEquals(i + " : " + test[0], test[1], sanitize(test[0]));
-    }
-  }
 
   @Test
   public static final void testIssue254SemicolonlessNamedCharactersInUrls() {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
@@ -474,7 +474,10 @@ public class SanitizersTest extends TestCase {
       .and(Sanitizers.STYLES)
       .and(Sanitizers.IMAGES)
       .and(Sanitizers.TABLES);
-    assertEquals("<table></table>Hallo\r\n\nEnde\n\r", pf.sanitize(input));
+    // The CRLF after "Hallo" becomes LF
+    // The LF before "Ende" becomes LF
+    // The LF CR after "Ende" becomes LF LF
+    assertEquals("<table></table>Hallo\n\nEnde\n\n", pf.sanitize(input));
   }
 
   @Test


### PR DESCRIPTION
Fixes #223. Supersedes #225, whose changes this carries onto current `main` with @simon-greatrix's authorship preserved on the first commit.

## Why

The HTML standard forbids numeric character references to noncharacters, U+000D and controls other than ASCII whitespace, and treats those code points in the input stream as parse errors. On `main` the sanitizer still emits supplementary-plane noncharacters as `&#x5fffe;`-style references and passes U+FDD0..U+FDEF, U+007F and the C1 controls U+0080..U+009F through raw. Running its output through validator.nu reports "Character reference expands to an astral non-character" and "Forbidden code point" errors for each of those; after this change it reports none. None of the token-merging inputs from the #223 discussion were exploitable on `main`, so this is a conformance fix rather than an XSS fix.

## What changes

**Commit 1** (Simon Greatrix, squashed and rebased from #225):

- Noncharacters (U+FDD0..U+FDEF and the last two code points of every plane), DEL and the C1 controls are elided from text and attribute values instead of being passed through or written as references.
- CR and CRLF in text and attribute values are normalized to LF, as the HTML input stream preprocessor does. Rendering is unchanged; the bytes are not. See the updated expectation in `SanitizersTest.testScriptInTable`.
- Characters whose compatibility decomposition contains ASCII punctuation (U+FE64 SMALL LESS-THAN SIGN, U+1FEF GREEK VARIA, ...) are written as numeric references, generalizing the old U+1FEF special case.
- `appendNumericEntity` refuses code points that cannot be written as a reference.
- Only the five ASCII whitespace characters separate tokens inside a tag. `Character.isWhitespace` also accepted U+000B, U+001C..U+001F and Unicode spaces such as U+3000, so `<b` U+3000 `onclick=x>` was read as `<b onclick=x>` where browsers see one unknown element whose name contains the U+3000 and the `onclick=x`.
- The February 2018 iOS "query of death" ZWNJ workaround is removed, as agreed in the 2021 review.

Adapted while rebasing: sources moved under `owasp-java-html-sanitizer/`; the new `EncodingTest` assertions use the `assertDecodedHtml` helper `main` added with `decodeHtml(String, boolean)`; the PR's `isAsciiWhitespace` helper is replaced by the equivalent `Strings.isHtmlSpace`; the Guava and Travis edits are dropped since neither exists any more.

**Commit 2** (review fixes):

- DEL and C1 are also stripped on the decode side, in `stripBannedCodeunits` and `longestPrefixOfGoodCodeunits`. #225 elided them only on output, which broke the invariant `main` keeps for C0 controls, lone surrogates and U+FFFE/U+FFFF: everything the encoder elides is stripped before policies run, so a URL policy judges `javascript:` rather than `java` U+0085 `script:`. The same strip guards raw `<script>`/`<style>` content in `HtmlStreamRenderer`.
- Everything at or above U+FE60 is still written as a reference, as `main` does today (BOM, fullwidth letters, U+FFFD, Arabic presentation forms). #225 narrowed that to its risky-normalization set; the old rule is kept as a superset so nothing previously encoded is now emitted raw.
- The risky-normalization table is a `BitSet` instead of a `HashSet<Character>`, which boxed every non-ASCII character on the encoding hot path. It stays spelled out so output does not depend on the JDK's Unicode version; `EncodingTest` checks it against the running JDK and names the character to add if they ever disagree.
- `appendNumericEntity` also rejects surrogates and values above U+10FFFF.
- Tests: `ElidedCharactersTest` runs the #223 token-merging cases (`<?script>`, `<s?cript>`, `<a?href=...>`, `href="java?script:"`, `title=?onclick=...`, `href="javascript&?#58;"`, where `?` stands for each forbidden code point) for every one of them; `HtmlLexerTest` pins the ASCII-only whitespace rule for U+000B, U+001C, U+001F, U+0085, U+00A0, U+1680, U+2000, U+2028, U+2029, U+205F and U+3000; `HtmlSanitizerFuzzerTest` draws half its substitutions from the stripped and normalized characters.
- `change_log.md` entry.

## Verification

- `./mvnw verify` passes on JDK 11, 17, 21 and 25 (376 tests).
- The tokenizer cases in `HtmlLexerTest` were checked against validator.nu (all of them) and Chrome (VT, U+001C, U+001F, U+0085, U+00A0, U+1680, U+2000, U+3000 with exact inputs): each character stays inside the tag or attribute name and does not end a `</style?>` end tag.
- Sanitizer output for every input that produced a validator.nu parse error on `main` produces none on this branch.

## Not changed

References `&#x80;` through `&#x9f;` decode to C1 controls, which are now removed, whereas browsers map them to Windows-1252 characters such as U+2026 HORIZONTAL ELLIPSIS. Matching browsers there is a separate change to the entity decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
