### PR TITLE
Decode C1-range numeric character references as Windows-1252

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -51,6 +51,12 @@ Most recent at top.
       accepted U+000B, U+001C..U+001F and Unicode space separators such as
       U+3000, so `<b\u3000onclick=x>` was read as `<b onclick=x>` where a
       browser sees an unknown element named `b\u3000onclick=x`.
+    * HTML: Numeric character references in the C1 range, `&#x80;` through
+      `&#x9f;`, decode to the Windows-1252 characters that browsers use, so
+      `&#x85;` is U+2026 HORIZONTAL ELLIPSIS and `&#x99;` is U+2122 TRADE
+      MARK SIGN rather than control characters that are then removed.  The
+      five bytes Windows-1252 leaves undefined, 0x81, 0x8D, 0x8F, 0x90 and
+      0x9D, remain controls and are removed.
     * HTML: Attribute names may begin with an underscore.
     * HTML: `Sanitizers.TABLES` allows integer `colspan` and `rowspan` on
       `td` and `th`; `Sanitizers.IMAGES` allows `loading="lazy|eager"`.

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlEntities.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlEntities.java
@@ -2468,9 +2468,29 @@ final class HtmlEntities {
       sb.append('&');
       return offset + 1;
     }
+    if (0x80 <= codepoint && codepoint <= 0x9f) {
+      // Browsers read a numeric reference in the C1 range as a Windows-1252
+      // byte, so "&#x85;" is U+2026 HORIZONTAL ELLIPSIS and not the NEL
+      // control.  The five bytes that Windows-1252 leaves undefined keep
+      // their C1 meaning and are stripped later like any other control.
+      // https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
+      codepoint = WINDOWS_1252_C1[codepoint - 0x80];
+    }
     sb.appendCodePoint(codepoint);
     return tail;
   }
+
+  /**
+   * Maps the byte values 0x80..0x9F to the characters that Windows-1252
+   * assigns them, as the HTML numeric character reference end state does.
+   * Bytes that Windows-1252 leaves undefined map to themselves.
+   */
+  private static final char[] WINDOWS_1252_C1 = {
+    '\u20ac', '\u0081', '\u201a', '\u0192', '\u201e', '\u2026', '\u2020', '\u2021',
+    '\u02c6', '\u2030', '\u0160', '\u2039', '\u0152', '\u008d', '\u017d', '\u008f',
+    '\u0090', '\u2018', '\u2019', '\u201c', '\u201d', '\u2022', '\u2013', '\u2014',
+    '\u02dc', '\u2122', '\u0161', '\u203a', '\u0153', '\u009d', '\u017e', '\u0178',
+  };
 
   private static boolean isHtmlIdContinueChar(char ch) {
     int chLower = ch | 32;

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/EncodingTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/EncodingTest.java
@@ -167,9 +167,29 @@ public final class EncodingTest extends TestCase {
     assertDecodedHtml("ab", "a\u007fb");
     assertDecodedHtml("ab", "a&#x7f;b");
     assertDecodedHtml("ab", "a\u0085b");
-    assertDecodedHtml("ab", "a&#x85;b");
-    assertDecodedHtml("ab", "a&#x9f;b");
+    assertDecodedHtml("ab", "a\u009fb");
     assertDecodedHtml("a&lt;b", "a\u0085&l\u0085t;b");
+
+    // A numeric reference in the C1 range is read as a Windows-1252 byte,
+    // as browsers do, so it is a printable character rather than a control.
+    assertDecodedHtml("a\u2026b", "a&#x85;b");
+    assertDecodedHtml("a\u2026b", "a&#133;b");
+    assertDecodedHtml("a\u2026b", "a&#x0085;b");
+    assertDecodedHtml("a\u20acb", "a&#x80;b");
+    assertDecodedHtml("a\u0178b", "a&#x9f;b");
+    assertDecodedHtml("a\u2122b", "a&#153;b");
+    // The bytes that Windows-1252 leaves undefined stay C1 controls, which
+    // are stripped.
+    assertDecodedHtml("ab", "a&#x81;b");
+    assertDecodedHtml("ab", "a&#x8d;b");
+    assertDecodedHtml("ab", "a&#x8f;b");
+    assertDecodedHtml("ab", "a&#x90;b");
+    assertDecodedHtml("ab", "a&#x9d;b");
+    // The mapping applies only to references, not to raw characters, and
+    // not to the neighbouring ranges.
+    assertDecodedHtml("ab", "a\u0080b");
+    assertDecodedHtml("a\u00a0b", "a&#xa0;b");
+    assertDecodedHtml("ab", "a&#x7f;b");
     assertDecodedHtml("a\u00a0b", "a\u00a0b");
 
     // Noncharacters, in the BMP and in the supplementary planes.
@@ -180,6 +200,32 @@ public final class EncodingTest extends TestCase {
     assertDecodedHtml("ab", "a&#x1fffe;b");
     assertDecodedHtml("ab", "a&#x10ffff;b");
     assertDecodedHtml("a\ud83f\udffdb", "a\ud83f\udffdb");
+  }
+
+  @Test
+  public static final void testC1NumericReferencesDecodeAsWindows1252() {
+    // https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
+    int[][] table = {
+        {0x80, 0x20ac}, {0x82, 0x201a}, {0x83, 0x0192}, {0x84, 0x201e},
+        {0x85, 0x2026}, {0x86, 0x2020}, {0x87, 0x2021}, {0x88, 0x02c6},
+        {0x89, 0x2030}, {0x8a, 0x0160}, {0x8b, 0x2039}, {0x8c, 0x0152},
+        {0x8e, 0x017d}, {0x91, 0x2018}, {0x92, 0x2019}, {0x93, 0x201c},
+        {0x94, 0x201d}, {0x95, 0x2022}, {0x96, 0x2013}, {0x97, 0x2014},
+        {0x98, 0x02dc}, {0x99, 0x2122}, {0x9a, 0x0161}, {0x9b, 0x203a},
+        {0x9c, 0x0153}, {0x9e, 0x017e}, {0x9f, 0x0178},
+    };
+    boolean[] mapped = new boolean[0x20];
+    for (int[] row : table) {
+      String want = String.valueOf((char) row[1]);
+      assertDecodedHtml(want, "&#x" + Integer.toHexString(row[0]) + ";");
+      assertDecodedHtml(want, "&#" + row[0] + ";");
+      mapped[row[0] - 0x80] = true;
+    }
+    for (int b = 0x80; b <= 0x9f; ++b) {
+      if (!mapped[b - 0x80]) {
+        assertDecodedHtml("", "&#x" + Integer.toHexString(b) + ";");
+      }
+    }
   }
 
   @Test

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -62,6 +62,23 @@ public class HtmlSanitizerTest extends TestCase {
   }
 
   @Test
+  public static final void testC1NumericReferencesAreWindows1252() {
+    // "&#x85;" is an ellipsis in a browser, not the NEL control.  The
+    // ellipsis is written back as a reference since its compatibility
+    // decomposition is three full stops.
+    assertEquals(
+        "<b>a&#x2026;b</b>",
+        Sanitizers.FORMATTING.sanitize("<b>a&#x85;b</b>"));
+    assertEquals(
+        "<b>a\u20acb</b>",
+        Sanitizers.FORMATTING.sanitize("<b>a&#128;b</b>"));
+    // An undefined Windows-1252 byte stays a control and is removed.
+    assertEquals(
+        "<b>ab</b>",
+        Sanitizers.FORMATTING.sanitize("<b>a&#x81;b</b>"));
+  }
+
+  @Test
   public static final void testUnknownTagsRemoved() {
     assertEquals("<b>hello <i>world</i></b>",
                  sanitize("<b>hello <bogus></bogus><i>world</i></b>"));


### PR DESCRIPTION
Follow-up to #413, which noted this as the one thing it left alone.

## Why

Browsers read a numeric character reference in the range 0x80..0x9F as a Windows-1252 byte, per the [numeric character reference end state](https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state): `&#x85;` is U+2026 HORIZONTAL ELLIPSIS and `&#x99;` is U+2122 TRADE MARK SIGN. The decoder produced the C1 control instead, which #413 then removed, so those characters vanished from sanitized output where a browser would have shown them.

## What changes

`HtmlEntities.appendDecodedEntity` applies the spec's table to both hexadecimal and decimal references. The five bytes that Windows-1252 leaves undefined (0x81, 0x8D, 0x8F, 0x90 and 0x9D) stay C1 controls and are removed as before. Raw C1 characters are unaffected; only references are mapped.

`<b>a&#x85;b</b>` now sanitizes to `<b>a&#x2026;b</b>` (the ellipsis is written back as a reference because its compatibility decomposition is three full stops) instead of `<b>ab</b>`.

## Verification

- `EncodingTest.testC1NumericReferencesDecodeAsWindows1252` checks all 27 mapped bytes in both forms and the 5 unmapped ones; `HtmlSanitizerTest.testC1NumericReferencesAreWindows1252` checks end-to-end output.
- `./mvnw verify` passes on JDK 11, 17, 21 and 25 (378 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
