### PR TITLE
Point the security contact and pom developer at the current lead

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Only the latest version is supported with updates.
 
 ## Reporting a Vulnerability
 
-Please report successful attacks with example input via OWASP's bugcrowd queue or contact mikesamuel@gmail.com and I will create a repository security advisory to coordinate.
+Please report successful attacks with example input via OWASP's bugcrowd queue or contact jim@owasp.org and I will create a repository security advisory to coordinate.
 
 If you wish to be credited, please provide a name or handle for me to credit.
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@ application while protecting against XSS.
 
   <developers>
     <developer>
-      <id>mikesamuel</id>
-      <name>Mike Samuel</name>
-      <email>mikesamuel@gmail.com</email>
+      <id>jmanico</id>
+      <name>Jim Manico</name>
+      <email>jim@owasp.org</email>
     </developer>
   </developers>
 


### PR DESCRIPTION
Follow-up to #416. Mike Samuel has stepped back from day-to-day maintenance (#360), and two places still routed people to him.

- **`SECURITY.md`** named `mikesamuel@gmail.com` as the vulnerability contact, now `jim@owasp.org`. This is the documented path for reporting a successful attack, so it is the more important of the two.
- **`pom.xml` `<developers>`** listed only `mikesamuel`, now `jmanico` / Jim Manico / `jim@owasp.org`. This metadata is published alongside the artifact to Maven Central.

Mike remains credited as founder and original author in the README and on the OWASP project page.

`pom.xml` verified well-formed with `xmllint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDR5tD1rfanor5DFykHc85
