### PR TITLE
Retire stale links and stop importing the bundled shim package in OSGi

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,10 @@ If you wish to report a vulnerability, please see
 [AttackReviewGroundRules](docs/attack_review_ground_rules.md).
 
 Subscribe to the
-[mailing list](https://groups.google.com/group/owasp-java-html-sanitizer-support)
+[mailing list](https://groups.google.com/g/owasp-java-html-sanitizer-support)
+or watch this repository's
+[releases](https://github.com/OWASP/java-html-sanitizer/releases) and
+[security advisories](https://github.com/OWASP/java-html-sanitizer/security/advisories)
 to be notified of known [Vulnerabilities](docs/vulnerabilities.md) and important updates.
 
 ## Contributing

--- a/docs/attack_review_ground_rules.md
+++ b/docs/attack_review_ground_rules.md
@@ -2,13 +2,13 @@
 ## How to win 
 There are many ways we might have failed.
 
-If you are the first to provide me with a payload that does any of the following on one of [Yahoo's A-list browsers](http://yuilibrary.com/yui/docs/tutorials/gbs/), then I will be happy to give credit via the project wiki and README, and I owe you a nice dinner next time we're in the same city (or coupon for dinner in your city).  Only the first reported payload that demonstrates a particular bug counts.
+If you are the first to provide me with a payload that does any of the following on a current release of a mainstream browser (Chrome, Firefox, Safari, or Edge), then I will be happy to give credit via the project wiki and README, and I owe you a nice dinner next time we're in the same city (or coupon for dinner in your city).  Only the first reported payload that demonstrates a particular bug counts.
 
   * Pop up an `alert` with any text.
-  * Cause a network load of `http://ha.ckers.org/xss.js` as JS
+  * Cause a network load of `https://attacker.example/xss.js` as JS
   * Set or retrieve `document.cookie`.
   * Cause the DOM to contain an element or attribute not explicitly allowed by the policy linked above (and not contained by `/reflect` with a blank input).
-  * Cause an redirect to `http://ha.ckers.org/` or a URL of your choosing without user interaction.
+  * Cause an redirect to `https://attacker.example/` or a URL of your choosing without user interaction.
   * Cause a save-file dialog to pop-up.
   * Crash the browser or cause it to loop infinitely until the browser halts JS or consume inordinate resources for an input of that size.
   * Cause an exception, crash, or inf. loop in the sanitizer that causes it to fail to provide service or consume inordinate resources for an input of that size.
@@ -31,6 +31,6 @@ If you wish to remain anonymous, please create a sock account, and email the add
 We are testing the HTML sanitizer as written, not the servers on which the test framework runs, so hacking the server to change the code behind it or rewrite the HTML sanitizer is out of bounds.
 
 ## Questions 
-Feel free to ask question in comments on this wiki page, or via the [project group](http://groups.google.com/group/owasp-java-html-sanitizer-support), or via my email address above.
+Feel free to ask questions by opening a [GitHub issue](https://github.com/OWASP/java-html-sanitizer/issues), or via the email address above.
 
 I will also lurk on IRC `/join #owasp-html-sanitizer` using the handle `mikesamuel`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -42,6 +42,6 @@ For advanced use, see:
 
 ## Asking Questions
 
-Feel free to post questions at the
-[discussion group](http://groups.google.com/group/owasp-java-html-sanitizer-support)
+Feel free to post questions as a
+[GitHub issue](https://github.com/OWASP/java-html-sanitizer/issues)
 and we'll do our best to help.

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -28,8 +28,8 @@ can shed light on the salient differences.
 
 You should be able to build with the HTML sanitizer.  You can read the
 [javadoc](https://static.javadoc.io/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/latest/index.html),
-and if you have questions that aren't answered by these wiki pages,
-you can ask on the
-[mailing list](http://groups.google.com/group/owasp-java-html-sanitizer-support).
+and if you have questions that aren't answered by these pages,
+you can open a
+[GitHub issue](https://github.com/OWASP/java-html-sanitizer/issues).
 
 Happy sanitizing...

--- a/owasp-java-html-sanitizer/pom.xml
+++ b/owasp-java-html-sanitizer/pom.xml
@@ -60,6 +60,12 @@
         <configuration>
           <instructions>
             <Export-Package>org.owasp.html</Export-Package>
+            <!-- The java8-shim and java10-shim classes are inlined into this
+                 JAR by the shade plugin below, which runs after bnd has
+                 written this manifest.  Tell bnd not to import
+                 org.owasp.shim so the bundled copy always wins over any
+                 stray shim bundle installed alongside. -->
+            <Import-Package>!org.owasp.shim,*</Import-Package>
             <!-- Explicit JPMS automatic module name so consumers using the
                  module path can require this module by a stable name that
                  is independent of the JAR filename. -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@ application while protecting against XSS.
       <name>User Support List</name>
       <subscribe>owasp-java-html-sanitizer-support+subscribe@googlegroups.com</subscribe>
       <unsubscribe>owasp-java-html-sanitizer-support+unsubscribe@googlegroups.com</unsubscribe>
-      <archive>https://groups.google.com/forum/#!forum/owasp-java-html-sanitizer-support</archive>
+      <archive>https://groups.google.com/g/owasp-java-html-sanitizer-support</archive>
     </mailingList>
   </mailingLists>
 


### PR DESCRIPTION
Follow-up to the repo cleanup pass. Three of the remaining items from that list, verified against the current tree.

## Links

- The docs pointed question-asking at the Google Group. Per the #360 minutes the forum is being retired in favour of GitHub, so `docs/getting_started.md`, `docs/maven.md`, and `docs/attack_review_ground_rules.md` now point at GitHub issues, matching the README's contributing section.
- The group is still alive and still carries announcements, so the README keeps it for that purpose, now alongside GitHub releases and security advisories. Its URL and the POM `<archive>` move to the current `groups.google.com/g/` form.
- `attack_review_ground_rules.md` used `ha.ckers.org` as the example payload host and linked the long-retired YUI graded browser support chart. The host is now the reserved `attacker.example` and the browser list is spelled out.
- The 2015 announcement link in `change_log.md` is left as historical record.

## OSGi manifest

`bnd` writes the manifest at package time, before `maven-shade-plugin` inlines `java8-shim` and `java10-shim`. The shaded JAR therefore declared `Import-Package: org.owasp.shim;resolution:=optional` for a package it now contains but does not export. If a stray shim bundle were installed alongside, the OSGi resolver would wire the import to it and shadow the bundled copy. Adding `<Import-Package>!org.owasp.shim,*</Import-Package>` drops that import.

Verified on a fresh JDK 17 build:

```
Export-Package: org.owasp.html;version="20000101.0.0";uses:="javax.annotation"
Import-Package: javax.annotation;version="[3.0,4)",org.owasp.html;version="[20000101.0,20000102)"
```

The JAR still contains the 11 shim classes. Full reactor `./mvnw verify` passes, 381 tests.

Not in this PR: deleting `origin/master` and the 2014 `release-223` tag, which is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
