### PR TITLE
Allow the CSS-wide keywords as text-align values

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,10 @@
 
 Most recent at top.
   * Next release
+    * CSS: `text-align` now accepts the CSS-wide keywords `initial`, `revert`,
+      `revert-layer` and `unset` alongside the `inherit` it already allowed,
+      so declarations that reset the property survive sanitizing instead of
+      being dropped.  Follow-up to PR #335; requested by EugenMayer.
     * Examples: `EbayPolicyExample` and `SlashdotPolicyExample` gain a
       `run(Reader, Appendable)` method that does the sanitizing; `main` now
       handles only the command line and delegates to it.  Purely additive;

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -459,7 +459,8 @@ public final class CssSchema {
     Set<String> tableLayoutLiterals0 = j8().setOf(
         "auto", "fixed", "inherit");
     Set<String> textAlignLiterals0 = j8().setOf(
-        "center", "end", "inherit", "justify", "justify-all", "match-parent", "start");
+        "center", "end", "inherit", "initial", "justify", "justify-all",
+        "match-parent", "revert", "revert-layer", "start", "unset");
     Set<String> textDecorationLiterals0 = j8().setOf(
         "blink", "line-through", "overline", "underline");
     Set<String> textTransformLiterals0 = j8().setOf(

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -459,8 +459,8 @@ public final class CssSchema {
     Set<String> tableLayoutLiterals0 = j8().setOf(
         "auto", "fixed", "inherit");
     Set<String> textAlignLiterals0 = j8().setOf(
-        "center", "end", "inherit", "initial", "justify", "justify-all",
-        "match-parent", "revert", "revert-layer", "start", "unset");
+        "center", "end", "inherit", "justify", "justify-all", "match-parent",
+        "start", "left", "right", "initial", "revert", "revert-layer", "unset");
     Set<String> textDecorationLiterals0 = j8().setOf(
         "blink", "line-through", "overline", "underline");
     Set<String> textTransformLiterals0 = j8().setOf(

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -1318,6 +1318,14 @@ class HtmlPolicyBuilderTest {
     String toSanitizeTextAlignEnd = "<span style=\"text-align:end\">end</span>";
     assertEquals(toSanitizeTextAlignEnd, factory.sanitize(toSanitizeTextAlignEnd));
 
+    // The CSS-wide keywords are valid on every property, text-align included.
+    for (String keyword
+         : new String[] {
+             "inherit", "initial", "revert", "revert-layer", "unset" }) {
+      String toSanitize = "<span style=\"text-align:" + keyword + "\">x</span>";
+      assertEquals(toSanitize, factory.sanitize(toSanitize), keyword);
+    }
+
     String toSanitizeTextAlignFoo = "<span style=\"text-align:foo\">foo</span>";
     assertEquals("foo", factory.sanitize(toSanitizeTextAlignFoo));
   }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -1312,18 +1312,15 @@ class HtmlPolicyBuilderTest {
         .allowAttributes("style").onElements("span").allowStyling()
         .toFactory();
 
-    String toSanitizeTextAlignStart = "<span style=\"text-align:start\">start</span>";
-    assertEquals(toSanitizeTextAlignStart, factory.sanitize(toSanitizeTextAlignStart));
-
-    String toSanitizeTextAlignEnd = "<span style=\"text-align:end\">end</span>";
-    assertEquals(toSanitizeTextAlignEnd, factory.sanitize(toSanitizeTextAlignEnd));
-
-    // The CSS-wide keywords are valid on every property, text-align included.
-    for (String keyword
+    // Every value text-align accepts: the keywords from the CSS Text spec
+    // followed by the CSS-wide keywords, which are valid on any property.
+    for (String value
          : new String[] {
-             "inherit", "initial", "revert", "revert-layer", "unset" }) {
-      String toSanitize = "<span style=\"text-align:" + keyword + "\">x</span>";
-      assertEquals(toSanitize, factory.sanitize(toSanitize), keyword);
+             "center", "end", "inherit", "justify", "justify-all",
+             "match-parent", "start", "left", "right", "initial", "revert",
+             "revert-layer", "unset" }) {
+      String toSanitize = "<span style=\"text-align:" + value + "\">x</span>";
+      assertEquals(toSanitize, factory.sanitize(toSanitize), value);
     }
 
     String toSanitizeTextAlignFoo = "<span style=\"text-align:foo\">foo</span>";


### PR DESCRIPTION
Addresses https://github.com/OWASP/java-html-sanitizer/pull/335#issuecomment-5579614320.

PR #335 brought `text-align` up to the named values in the CSS Text spec (`start`, `end`, `justify-all`, `match-parent`, with `left`/`right` already arriving via `azimuthLiterals1`). What it did not cover are the **CSS-wide keywords**, which are valid on every property: the schema allowed `inherit` but dropped `initial`, `revert`, `revert-layer` and `unset`, so a declaration that resets `text-align` was silently discarded.

This adds those four to `textAlignLiterals0` and covers all five in `testCSSTextAlign`.

They are inert keywords — no URLs, no functions, no new token classes — so this widens what round-trips without widening what can execute.

Scope note: `inherit` is spelled out per-property throughout `CssSchema`, and none of the other CSS-wide keywords appear anywhere in the schema today. Making them universal is the larger, more correct change; this PR stays with the property that was actually reported.

`./mvnw verify` passes (381 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ytr5gdvo5eNrXcZKmQaNt