### PR TITLE
Allow the CSS-wide keywords on every property

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,10 +2,16 @@
 
 Most recent at top.
   * Next release
-    * CSS: `text-align` now accepts the CSS-wide keywords `initial`, `revert`,
-      `revert-layer` and `unset` alongside the `inherit` it already allowed,
-      so declarations that reset the property survive sanitizing instead of
-      being dropped.  Follow-up to PR #335; requested by EugenMayer.
+    * CSS: the CSS-wide keywords -- `inherit`, `initial`, `revert`,
+      `revert-layer` and `unset` -- are now accepted on **every** property,
+      not just the handful whose literal sets happened to name `inherit`.
+      They are valid on any property per CSS Cascade, and only ever reset a
+      property to a value the cascade already chose, so `color: revert` and
+      `font-size: unset` now survive sanitizing instead of being dropped.
+      Schemas for function arguments are deliberately excluded: `initial` is
+      a value for `color`, not for a channel of `rgb(...)`.  This widens what
+      round-trips, not what can execute.  Follow-up to PR #335; reported by
+      EugenMayer.
     * Examples: `EbayPolicyExample` and `SlashdotPolicyExample` gain a
       `run(Reader, Appendable)` method that does the sanitizing; `main` now
       handles only the command line and delegates to it.  Purely additive;

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -30,6 +30,7 @@ package org.owasp.html;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -256,6 +257,17 @@ public final class CssSchema {
     }
     return prefixLen == 0 ? null : cssKeyword.substring(prefixLen);
   }
+
+  /**
+   * The CSS-wide keywords, which every CSS property accepts as its entire
+   * value.  They only ever reset a property to a value the cascade already
+   * chose, so they carry no attacker-controlled content.
+   *
+   * @see <a href="https://www.w3.org/TR/css-cascade-4/#defaulting-keywords"
+   *   >CSS Cascade 4, Explicit Defaulting</a>
+   */
+  static final Set<String> CSS_WIDE_KEYWORDS = j8().setOf(
+      "inherit", "initial", "revert", "revert-layer", "unset");
 
   /** Maps lower-cased CSS property names to information about them. */
   static final Map<String, Property> DEFINITIONS;
@@ -867,6 +879,26 @@ public final class CssSchema {
     builder.put("z-index", bottom);
     builder.put("repeating-linear-gradient()", linearGradient$Fun);
     builder.put("repeating-radial-gradient()", radialGradient$Fun);
+    // Fold the CSS-wide keywords into every property, rather than repeating
+    // them in each literal set above.  Keys ending in "()" describe the
+    // arguments of a function, not a property, and are left alone: "initial"
+    // is a value for "color", not for the red channel of "rgb(...)".
+    // Definitions are shared between properties -- "pause-after" and
+    // "richness" are the same object -- so widen each distinct one once and
+    // keep the sharing.
+    Map<Property, Property> widened = new IdentityHashMap<>();
+    for (Map.Entry<String, Property> e : builder.entrySet()) {
+      if (e.getKey().endsWith("()")) { continue; }
+      Property narrow = e.getValue();
+      Property wide = widened.get(narrow);
+      if (wide == null) {
+        @SuppressWarnings("unchecked")
+        Set<String> literals = union(narrow.literals, CSS_WIDE_KEYWORDS);
+        wide = new Property(narrow.bits, literals, narrow.fnKeys);
+        widened.put(narrow, wide);
+      }
+      e.setValue(wide);
+    }
     DEFINITIONS = Collections.unmodifiableMap(builder);
   }
 

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
@@ -112,6 +112,24 @@ final class CssSchemaTest {
   }
 
   @Test
+  void testCssWideKeywordsAllowedOnEveryProperty() {
+    for (Map.Entry<String, CssSchema.Property> e
+         : CssSchema.DEFINITIONS.entrySet()) {
+      String key = e.getKey();
+      // Keys ending in "()" describe a function's arguments rather than a
+      // property, and must not pick the keywords up: "initial" is a value
+      // for "color", not for a channel of "rgb(...)".
+      boolean isFunction = key.endsWith("()");
+      for (String keyword : CssSchema.CSS_WIDE_KEYWORDS) {
+        assertEquals(
+            !isFunction,
+            e.getValue().literals.contains(keyword),
+            key + " should" + (isFunction ? " not" : "") + " allow " + keyword);
+      }
+    }
+  }
+
+  @Test
   void testCustom() {
     CssSchema custom = CssSchema.union(
         CssSchema.DEFAULT,

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -1328,6 +1328,33 @@ class HtmlPolicyBuilderTest {
   }
 
   @Test
+  void testCSSWideKeywords() {
+    HtmlPolicyBuilder builder = new HtmlPolicyBuilder();
+    PolicyFactory factory = builder.allowElements("span")
+        .allowAttributes("style").onElements("span").allowStyling()
+        .toFactory();
+
+    // Not just text-align: the CSS-wide keywords reset any property.
+    for (String property
+         : new String[] { "color", "font-size", "text-decoration" }) {
+      for (String keyword
+           : new String[] {
+               "inherit", "initial", "revert", "revert-layer", "unset" }) {
+        String toSanitize =
+            "<span style=\"" + property + ":" + keyword + "\">x</span>";
+        assertEquals(
+            toSanitize, factory.sanitize(toSanitize), property + ":" + keyword);
+      }
+    }
+
+    // They are whole values, not arguments to a function, so inside rgb(...)
+    // "initial" is dropped like any other word the function does not take.
+    assertEquals(
+        factory.sanitize("<span style=\"color:rgb(foo,0,0)\">x</span>"),
+        factory.sanitize("<span style=\"color:rgb(initial,0,0)\">x</span>"));
+  }
+
+  @Test
   void testCSSFontSize() {
     HtmlPolicyBuilder builder = new HtmlPolicyBuilder();
     PolicyFactory factory = builder.allowElements("span")


### PR DESCRIPTION
Follow-up to #420, which fixed `text-align` only. The same gap existed everywhere else.

## The gap

Before this change, `CssSchema` had **31** literal sets naming `inherit` and — after #420 — exactly **one** naming `initial`/`revert`/`unset`. So `color: revert`, `font-size: unset` and `display: initial` were all silently dropped, even though [CSS Cascade](https://www.w3.org/TR/css-cascade-4/#defaulting-keywords) makes the CSS-wide keywords valid on every property.

## The change

Rather than hand-editing ~150 literal sets, the keywords are folded into each definition once the builder is populated. Two details worth review:

- **Function-argument schemas are excluded.** Keys ending in `()` describe the arguments of a function, not a property. `initial` is a value for `color`, not for a channel of `rgb(...)`. Verified that inside a function it is now dropped exactly as `foo` and `expression` already were — `rgb(initial,0,0)`, `rgb(foo,0,0)` and `rgb(expression,0,0)` all sanitize identically.
- **Definition sharing is preserved.** Many properties share one `Property` instance (`pause-after` and `richness` are the same object), so each distinct one is widened once via an `IdentityHashMap`. This keeps the sharing that `CssSchemaTest.testCustom` asserts with `assertSame`.

## Security

The keywords are inert: no URLs, no functions, no new token classes, and `DISALLOWED` properties stay disallowed. They only ever reset a property to a value the cascade already chose. This widens what round-trips, not what can execute.

## Tests

Both halves are covered at the schema level (every property has the keywords, no function schema does) and end to end across `color`, `font-size` and `text-decoration`. `./mvnw verify` passes across all modules — 383 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ytr5gdvo5eNrXcZKmQaNt
