### PR TITLE
Build a style AttributePolicy from a CssSchema

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,21 @@
 
 Most recent at top.
   * Next release
+    * CSS: `CssSchema.toAttributePolicy()` and
+      `toAttributePolicy(Function<String, String> urlRewriter)` turn a schema
+      into an `AttributePolicy`, so a policy can allow different CSS
+      properties on different elements -- `color` on `span`, `width` on
+      `table` -- which the global `allowStyling(CssSchema)` cannot express.
+      Such a policy is **not** wired to `allowUrlsInStyles` /
+      `allowUrlProtocols`, since that wiring lives in the `style` attribute
+      guard and cannot see a policy handed to `matching`: the no-arg variant
+      therefore drops every `url(...)` value, and the rewriter variant puts
+      URL vetting entirely on the caller.  Joining one of these with a global
+      `allowStyling` takes the union of the schemas but runs both URL
+      rewriters, so a per-element policy that drops URLs is never widened by
+      a permissive global one.  Requested in #131 by ggrandes and EugenMayer;
+      an alternative to PR #339 that keeps `StylingPolicy` internal.
+      Closes #381.
     * CSS: the CSS-wide keywords -- `inherit`, `initial`, `revert`,
       `revert-layer` and `unset` -- are now accepted on **every** property,
       not just the handful whose literal sets happened to name `inherit`.

--- a/change_log.md
+++ b/change_log.md
@@ -13,10 +13,17 @@ Most recent at top.
       therefore drops every `url(...)` value, and the rewriter variant puts
       URL vetting entirely on the caller.  Joining one of these with a global
       `allowStyling` takes the union of the schemas but runs both URL
-      rewriters, so a per-element policy that drops URLs is never widened by
-      a permissive global one.  Requested in #131 by ggrandes and EugenMayer;
+      rewriters in turn, so a per-element policy that drops URLs is never
+      widened by a permissive global one, and a rewriter is never handed the
+      null that means the URL before it was dropped.  Requested in #131 by ggrandes and EugenMayer;
       an alternative to PR #339 that keeps `StylingPolicy` internal.
       Closes #381.
+    * CSS: joining two styling policies -- which `PolicyFactory.and` can do
+      when both factories allow styling -- now runs both URL policies instead
+      of keeping whichever of the two the join happened to visit first.  This
+      is what `and` documents ("intersects policies where they overlap"), and
+      it is the stricter of the two, so a combined factory can only drop URLs
+      it used to allow, never the reverse.
     * CSS: the CSS-wide keywords -- `inherit`, `initial`, `revert`,
       `revert-layer` and `unset` -- are now accepted on **every** property,
       not just the handful whose literal sets happened to name `inherit`.

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -273,6 +273,16 @@ public final class CssSchema {
    * of scrutiny is warranted than for a link.  If in doubt, prefer
    * {@link #toAttributePolicy()}, which drops them.
    *
+   * <p>To vet URLs by protocol the way {@link HtmlPolicyBuilder} does, reuse
+   * a {@link FilterUrlByProtocolAttributePolicy}.  It ignores the element and
+   * attribute names it is given, so any will do:
+   *
+   * <pre>{@code
+   * AttributePolicy urlPolicy = new FilterUrlByProtocolAttributePolicy(
+   *     Arrays.asList("https", "mailto"));
+   * schema.toAttributePolicy(url -> urlPolicy.apply("img", "src", url));
+   * }</pre>
+   *
    * <p>If an element also gets a {@code style} policy from
    * {@link HtmlPolicyBuilder#allowStyling()}, the two are joined: the schemas
    * union, and both rewriters run in turn, so either one can drop a URL.

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -273,9 +273,13 @@ public final class CssSchema {
    * of scrutiny is warranted than for a link.  If in doubt, prefer
    * {@link #toAttributePolicy()}, which drops them.
    *
+   * <p>If an element also gets a {@code style} policy from
+   * {@link HtmlPolicyBuilder#allowStyling()}, the two are joined: the schemas
+   * union, and both rewriters run in turn, so either one can drop a URL.
+   *
    * @param urlRewriter receives the decoded content of a {@code url(...)}
    *     value and returns the URL to use, or {@code null} or the empty string
-   *     to drop it.  It is never passed {@code null}.
+   *     to drop it.  It is never passed {@code null} or the empty string.
    * @return an attribute policy suitable for the {@code style} attribute.
    */
   public AttributePolicy toAttributePolicy(

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Function;
 import static org.owasp.shim.Java8Shim.j8;
 
 import javax.annotation.Nullable;
@@ -218,6 +219,77 @@ public final class CssSchema {
   public Set<String> allowedProperties() {
     return properties.keySet();
   }
+
+  /**
+   * An {@link AttributePolicy} that sanitizes a {@code style} attribute value
+   * against this schema, dropping every {@code url(...)} value it contains.
+   *
+   * <p>This is the per-element counterpart of
+   * {@link HtmlPolicyBuilder#allowStyling(CssSchema)}, which applies one
+   * schema to the {@code style} attribute of every element.  Passing the
+   * result to {@link HtmlPolicyBuilder.AttributeBuilder#matching(AttributePolicy)}
+   * lets different elements allow different CSS properties:
+   *
+   * <pre>{@code
+   * new HtmlPolicyBuilder()
+   *     .allowElements("span", "table")
+   *     .allowAttributes("style")
+   *         .matching(CssSchema.withProperties(
+   *              Arrays.asList("color", "background-color")).toAttributePolicy())
+   *         .onElements("span")
+   *     .allowAttributes("style")
+   *         .matching(CssSchema.withProperties(
+   *              Arrays.asList("width", "height")).toAttributePolicy())
+   *         .onElements("table")
+   *     .toFactory();
+   * }</pre>
+   *
+   * <p><b>Security note:</b> a policy built this way is <b>not</b> wired to
+   * {@link HtmlPolicyBuilder#allowUrlsInStyles(AttributePolicy)} or
+   * {@link HtmlPolicyBuilder#allowUrlProtocols(String...)}.  That wiring
+   * happens only inside the {@code style} attribute guard that
+   * {@link HtmlPolicyBuilder#allowStyling()} installs, and it cannot see a
+   * policy handed to {@code matching}.  Rather than let URLs through
+   * unvetted, this variant drops them all; use
+   * {@link #toAttributePolicy(Function)} to vet them yourself.
+   *
+   * @return an attribute policy suitable for the {@code style} attribute.
+   */
+  public AttributePolicy toAttributePolicy() {
+    return new StylingPolicy(this, REJECT_ALL_URLS);
+  }
+
+  /**
+   * An {@link AttributePolicy} that sanitizes a {@code style} attribute value
+   * against this schema, passing the content of each {@code url(...)} value
+   * through {@code urlRewriter}.
+   *
+   * <p><b>Security note:</b> as with {@link #toAttributePolicy()}, a policy
+   * built this way is <b>not</b> wired to
+   * {@link HtmlPolicyBuilder#allowUrlsInStyles(AttributePolicy)} or
+   * {@link HtmlPolicyBuilder#allowUrlProtocols(String...)}, so vetting URLs
+   * is entirely the caller's job.  URLs in CSS are typically loaded without
+   * user interaction, the way {@code <img src=...>} is, so a greater degree
+   * of scrutiny is warranted than for a link.  If in doubt, prefer
+   * {@link #toAttributePolicy()}, which drops them.
+   *
+   * @param urlRewriter receives the decoded content of a {@code url(...)}
+   *     value and returns the URL to use, or {@code null} or the empty string
+   *     to drop it.  It is never passed {@code null}.
+   * @return an attribute policy suitable for the {@code style} attribute.
+   */
+  public AttributePolicy toAttributePolicy(
+      Function<String, String> urlRewriter) {
+    return new StylingPolicy(this, Objects.requireNonNull(urlRewriter));
+  }
+
+  /** Drops every URL it is given. */
+  private static final Function<String, String> REJECT_ALL_URLS
+      = new Function<String, String>() {
+        public @Nullable String apply(String url) {
+          return null;
+        }
+      };
 
   /** The schema for the named property or function key. */
   Property forKey(String propertyName) {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
@@ -248,15 +248,21 @@ final class StylingPolicy implements JoinableAttributePolicy {
     return true;
   }
 
+  // The url rewriter takes part in equality because joining groups policies
+  // into a Set first: two styling policies that share a schema but vet URLs
+  // differently must both survive to be joined, or one rewriter would be
+  // dropped silently.
   @Override
   public boolean equals(Object o) {
-    return o != null && getClass() == o.getClass()
-        && cssSchema.equals(((StylingPolicy) o).cssSchema);
+    if (o == null || getClass() != o.getClass()) { return false; }
+    StylingPolicy that = (StylingPolicy) o;
+    return cssSchema.equals(that.cssSchema)
+        && urlRewriter.equals(that.urlRewriter);
   }
 
   @Override
   public int hashCode() {
-    return cssSchema.hashCode();
+    return cssSchema.hashCode() + 31 * urlRewriter.hashCode();
   }
 
   public Joinable.JoinStrategy<JoinableAttributePolicy> getJoinStrategy() {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
@@ -286,10 +286,28 @@ final class StylingPolicy implements JoinableAttributePolicy {
         urlRewriter = urlRewriter.equals(identity)
             || urlRewriter.equals(sp.urlRewriter)
             ? sp.urlRewriter
-            : urlRewriter.compose(sp.urlRewriter);
+            : andThen(urlRewriter, sp.urlRewriter);
       }
       return new StylingPolicy(cssSchema, urlRewriter);
     }
 
+    /**
+     * A rewriter that runs both in turn, so a URL has to satisfy both to
+     * survive.  A rewriter signals "dropped" by returning null or the empty
+     * string, which is not a URL, so it short-circuits instead of being
+     * passed on to the next rewriter.
+     */
+    private static Function<String, String> andThen(
+        final Function<String, String> first,
+        final Function<String, String> second) {
+      return new Function<String, String>() {
+        public @Nullable String apply(String url) {
+          String rewritten = first.apply(url);
+          return rewritten == null || rewritten.isEmpty()
+              ? null
+              : second.apply(rewritten);
+        }
+      };
+    }
   }
 }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
@@ -205,4 +205,66 @@ final class CssSchemaAttributePolicyTest {
             "<div style=\"background-image: url(http://example.com/i.png)\">"
             + "x</div>"));
   }
+
+  /**
+   * A rewriter signals "dropped" by returning null, which is not a URL, so a
+   * joined rewriter is never handed one.
+   */
+  @Test
+  void testCallerRewriterNeverSeesADroppedUrl() {
+    Function<String, String> rewriter = new Function<String, String>() {
+      public String apply(String url) {
+        // Would throw if handed the null that means "dropped".
+        return url.startsWith("http://example.com/") ? url : null;
+      }
+    };
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowStandardUrlProtocols()
+        // No allowUrlsInStyles, so the global guard vetoes every URL.
+        .allowStyling(IMAGE_SCHEMA)
+        .allowAttributes("style")
+            .matching(IMAGE_SCHEMA.toAttributePolicy(rewriter))
+            .onElements("div")
+        .toFactory();
+
+    assertEquals(
+        "<div>x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://example.com/i.png)\">"
+            + "x</div>"));
+  }
+
+  /** Joined rewriters run in turn, each seeing the previous one's output. */
+  @Test
+  void testJoinedRewritersRunInTurn() {
+    Function<String, String> rewriter = new Function<String, String>() {
+      public String apply(String url) {
+        return url + "?vetted";
+      }
+    };
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowStandardUrlProtocols()
+        .allowStyling(IMAGE_SCHEMA)
+        .allowUrlsInStyles(AttributePolicy.IDENTITY_ATTRIBUTE_POLICY)
+        .allowAttributes("style")
+            .matching(IMAGE_SCHEMA.toAttributePolicy(rewriter))
+            .onElements("div")
+        .toFactory();
+
+    // The caller's rewrite survives, and the global protocol policy still
+    // gets to veto what comes out of it.
+    assertEquals(
+        "<div style=\"background-image:url(&#39;"
+        + "http://example.com/i.png?vetted&#39;)\">x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://example.com/i.png)\">"
+            + "x</div>"));
+    assertEquals(
+        "<div>x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(javascript:alert%281%29)\">"
+            + "x</div>"));
+  }
 }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
@@ -235,6 +235,32 @@ final class CssSchemaAttributePolicyTest {
             + "x</div>"));
   }
 
+  /** The javadoc's recipe for reusing the library's own protocol filter. */
+  @Test
+  void testReusingFilterUrlByProtocol() {
+    final AttributePolicy urlPolicy = new FilterUrlByProtocolAttributePolicy(
+        Arrays.asList("https", "mailto"));
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style")
+            .matching(IMAGE_SCHEMA.toAttributePolicy(
+                url -> urlPolicy.apply("img", "src", url)))
+            .onElements("div")
+        .toFactory();
+
+    assertEquals(
+        "<div style=\"background-image:url(&#39;"
+        + "https://example.com/i.png&#39;)\">x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(https://example.com/i.png)\">"
+            + "x</div>"));
+    assertEquals(
+        "<div>x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://example.com/i.png)\">"
+            + "x</div>"));
+  }
+
   /** Joined rewriters run in turn, each seeing the previous one's output. */
   @Test
   void testJoinedRewritersRunInTurn() {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
@@ -1,0 +1,208 @@
+// Copyright (c) 2013, Mike Samuel
+// All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.owasp.html;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Tests {@link CssSchema#toAttributePolicy}. */
+final class CssSchemaAttributePolicyTest {
+
+  private static final CssSchema TEXT_SCHEMA = CssSchema.withProperties(
+      Arrays.asList("color", "background-color"));
+  private static final CssSchema BOX_SCHEMA = CssSchema.withProperties(
+      Arrays.asList("width", "height"));
+  private static final CssSchema IMAGE_SCHEMA = CssSchema.withProperties(
+      Arrays.asList("background-image", "background-position"));
+
+  /** The motivating use case from issue #381: a schema per element. */
+  @Test
+  void testDifferentSchemasOnDifferentElements() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("span", "div")
+        .allowAttributes("style")
+            .matching(TEXT_SCHEMA.toAttributePolicy())
+            .onElements("span")
+        .allowAttributes("style")
+            .matching(BOX_SCHEMA.toAttributePolicy())
+            .onElements("div")
+        .toFactory();
+
+    assertEquals(
+        "<span style=\"color:red\">x</span>",
+        policy.sanitize("<span style=\"color: red; width: 10px\">x</span>"));
+    assertEquals(
+        "<div style=\"width:10px\">x</div>",
+        policy.sanitize("<div style=\"color: red; width: 10px\">x</div>"));
+  }
+
+  /**
+   * A property allowed on one element does not leak onto an element whose own
+   * schema omits it, and a style attribute left with nothing goes away.
+   */
+  @Test
+  void testStyleDroppedEntirelyWhenNothingSurvives() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("span", "div")
+        .allowAttributes("style")
+            .matching(BOX_SCHEMA.toAttributePolicy())
+            .onElements("div")
+        .toFactory();
+
+    assertEquals(
+        "<div>x</div>",
+        policy.sanitize("<div style=\"color: red\">x</div>"));
+    // No policy at all for style on span, so it is not allowed there, and a
+    // span with no attributes is elided by default.
+    assertEquals(
+        "x",
+        policy.sanitize("<span style=\"width: 10px\">x</span>"));
+  }
+
+  /** The no-arg factory is not wired to any URL policy, so it drops URLs. */
+  @Test
+  void testUrlsDroppedByDefault() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowStandardUrlProtocols()
+        .allowAttributes("style")
+            .matching(IMAGE_SCHEMA.toAttributePolicy())
+            .onElements("div")
+        .toFactory();
+
+    // The url() token goes, and with it the only value of the property.
+    assertEquals(
+        "<div>x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://example.com/i.png)\">"
+            + "x</div>"));
+    // Surviving values of an allowed property are kept.
+    assertEquals(
+        "<div style=\"background-position:left\">x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://example.com/i.png);"
+            + " background-position: left\">x</div>"));
+  }
+
+  /** The caller's rewriter sees the URL and decides. */
+  @Test
+  void testUrlRewriterHonored() {
+    Function<String, String> rewriter = new Function<String, String>() {
+      public String apply(String url) {
+        return url.startsWith("http://example.com/")
+            ? url + "?vetted" : null;
+      }
+    };
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style")
+            .matching(IMAGE_SCHEMA.toAttributePolicy(rewriter))
+            .onElements("div")
+        .toFactory();
+
+    assertEquals(
+        "<div style=\"background-image:url(&#39;"
+        + "http://example.com/i.png?vetted&#39;)\">x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://example.com/i.png)\">"
+            + "x</div>"));
+    // Returning null drops the URL.
+    assertEquals(
+        "<div>x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://evil.example/i.png)\">"
+            + "x</div>"));
+  }
+
+  /** A rewriter never has to cope with a null URL, so it may not be null. */
+  @Test
+  void testNullUrlRewriterRejected() {
+    assertThrows(
+        NullPointerException.class,
+        () -> TEXT_SCHEMA.toAttributePolicy(null));
+  }
+
+  /**
+   * A per-element schema and a global {@code allowStyling} schema join to the
+   * union of the two, on that element only.
+   */
+  @Test
+  void testJoinsWithGlobalAllowStyling() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("span", "div")
+        .allowStyling(BOX_SCHEMA)
+        .allowAttributes("style")
+            .matching(TEXT_SCHEMA.toAttributePolicy())
+            .onElements("span")
+        .toFactory();
+
+    assertEquals(
+        "<span style=\"color:red;width:10px\">x</span>",
+        policy.sanitize("<span style=\"color: red; width: 10px\">x</span>"));
+    assertEquals(
+        "<div style=\"width:10px\">x</div>",
+        policy.sanitize("<div style=\"color: red; width: 10px\">x</div>"));
+  }
+
+  /**
+   * Joining takes the union of the schemas but the intersection of the URL
+   * policies, so a URL-dropping per-element policy is not widened by a
+   * permissive global one.
+   */
+  @Test
+  void testJoiningDoesNotWidenUrlPolicy() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("p", "div")
+        .allowStandardUrlProtocols()
+        .allowStyling(IMAGE_SCHEMA)
+        .allowUrlsInStyles(AttributePolicy.IDENTITY_ATTRIBUTE_POLICY)
+        .allowAttributes("style")
+            .matching(IMAGE_SCHEMA.toAttributePolicy())
+            .onElements("div")
+        .toFactory();
+
+    // The global policy alone still lets the URL through.
+    assertEquals(
+        "<p style=\"background-image:url(&#39;http://example.com/i.png&#39;)\">"
+        + "x</p>",
+        policy.sanitize(
+            "<p style=\"background-image: url(http://example.com/i.png)\">"
+            + "x</p>"));
+    // On div, the per-element policy's veto wins.
+    assertEquals(
+        "<div>x</div>",
+        policy.sanitize(
+            "<div style=\"background-image: url(http://example.com/i.png)\">"
+            + "x</div>"));
+  }
+}


### PR DESCRIPTION
Closes #381.

`allowStyling(CssSchema)` is global: one schema applies to the `style` attribute on every element. This adds a public factory on `CssSchema` so a schema can be handed to `allowAttributes("style").matching(...)`, letting different elements allow different CSS properties.

```java
new HtmlPolicyBuilder()
    .allowElements("span", "table")
    .allowAttributes("style")
        .matching(CssSchema.withProperties(
            Arrays.asList("color", "background-color")).toAttributePolicy())
        .onElements("span")
    .allowAttributes("style")
        .matching(CssSchema.withProperties(
            Arrays.asList("width", "height")).toAttributePolicy())
        .onElements("table")
    .toFactory();
```

`StylingPolicy` stays package-private (it is `@TCB` and its internals are package-private); only the factory is exposed. This is the alternative to #339 sketched in the issue.

### URLs

A policy built this way is **not** wired to `allowUrlsInStyles` / `allowUrlProtocols` — that wiring happens inside the `style` attribute guard in `HtmlPolicyBuilder.compilePolicies`, which cannot see a policy handed to `matching`. So:

- `toAttributePolicy()` drops every `url(...)` value.
- `toAttributePolicy(Function<String, String> urlRewriter)` puts URL vetting entirely on the caller; returning `null` or `""` drops the URL.

Both variants say so in the javadoc.

### Two fixes in the join (second commit)

Joining a per-element policy with a global `allowStyling` had two problems, both in code the new API makes reachable for the first time.

**One of the two URL policies could be dropped.** `Joinable.JoinHelper` groups joinables into a `LinkedHashSet` before handing them to the join strategy, and `StylingPolicy.equals` compared only the schema — so two styling policies sharing a schema collapsed into one, and which one survived was insertion order. In the bad direction that means a caller-supplied permissive rewriter displacing the protocol-checked global one, bypassing `allowUrlProtocols` for `url()` values on that element. `equals`/`hashCode` now include the url rewriter, so both survive to be joined.

**A joined rewriter was handed the `null` that means "dropped."** `StylingPolicyJoinStrategy` composed rewriters with `Function.compose`, feeding one rewriter's return value straight into the next. A rewriter returns `null` to drop a URL, so the next one received `null` as though it were a URL. The rewriter `HtmlPolicyBuilder` installs maps `null` to `"about:invalid"` and survived that by luck; a caller's rewriter has no reason to expect it, and the straightforward one throws `NullPointerException` out of `PolicyFactory.sanitize` on attacker-controlled input. The rewriters are now chained with a short-circuit on `null`/`""`, so a URL has to satisfy every rewriter in the join and each one only ever sees a URL.

Net semantics: **union of the schemas, intersection of the URL policies.** A per-element policy that drops URLs is never widened by a permissive global one.

This also changes `PolicyFactory.and` where both factories allow styling: it now runs both URL policies instead of keeping whichever the join visited first. That is what `and` documents ("intersects policies where they overlap"), and it is the stricter of the two, so a combined factory can only drop URLs it used to allow, never the reverse.

### Tests

New `CssSchemaAttributePolicyTest`, 9 cases: per-element schemas applied independently, the style attribute vanishing when nothing survives, `url()` dropped by default, the rewriter honored (including `null` → drop), a null rewriter rejected, joining with a global `allowStyling` (union on that element only), joining not widening the URL policy, a caller rewriter never seeing a dropped URL, and joined rewriters running in turn.

`./mvnw verify` passes (392 tests). Change log entries included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ytr5gdvo5eNrXcZKmQaNt