### PR TITLE
Point questions at GitHub Discussions and align the attack review page with SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,9 @@ See ["Why sanitize when you can validate"](https://github.com/OWASP/java-html-sa
 
 ## Questions?
 
-If you wish to report a vulnerability, please see
-[AttackReviewGroundRules](docs/attack_review_ground_rules.md).
+If you wish to report a vulnerability, please see the
+[security policy](SECURITY.md) and the
+[attack review ground rules](docs/attack_review_ground_rules.md).
 
 Subscribe to the
 [mailing list](https://groups.google.com/g/owasp-java-html-sanitizer-support)

--- a/docs/attack_review_ground_rules.md
+++ b/docs/attack_review_ground_rules.md
@@ -1,13 +1,15 @@
-# Attack Review Ground Rules 
-## How to win 
+# Attack Review Ground Rules
+
+## How to win
+
 There are many ways we might have failed.
 
-If you are the first to provide me with a payload that does any of the following on a current release of a mainstream browser (Chrome, Firefox, Safari, or Edge), then I will be happy to give credit via the project wiki and README, and I owe you a nice dinner next time we're in the same city (or coupon for dinner in your city).  Only the first reported payload that demonstrates a particular bug counts.
+If you are the first to provide a payload that does any of the following on a current release of a mainstream browser (Chrome, Firefox, Safari, or Edge), we will be happy to give credit in the project documentation and README.  Only the first reported payload that demonstrates a particular bug counts.
 
   * Pop up an `alert` with any text.
   * Cause a network load of `https://attacker.example/xss.js` as JS
   * Set or retrieve `document.cookie`.
-  * Cause the DOM to contain an element or attribute not explicitly allowed by the policy linked above (and not contained by `/reflect` with a blank input).
+  * Cause the DOM to contain an element or attribute not explicitly allowed by the policy in use.
   * Cause an redirect to `https://attacker.example/` or a URL of your choosing without user interaction.
   * Cause a save-file dialog to pop-up.
   * Crash the browser or cause it to loop infinitely until the browser halts JS or consume inordinate resources for an input of that size.
@@ -17,20 +19,20 @@ If you are the first to provide me with a payload that does any of the following
 
 This is not an exhaustive list and creative attacks are welcome.
 
-If you find the web interface cumbersome, feel free to download and test the sanitizer directly.  See [GettingStarted](getting_started.md) for instructions.
+See [GettingStarted](getting_started.md) for how to build the sanitizer and run it locally against a policy of your choosing.
 
-## Reporting Vulnerabilities 
-Please report successful attacks with example input via [OWASP's bugcrowd queue](https://bugcrowd.com/owaspjavasanitizer)
-or contact `mikesamuel`@`gmail`.`com` and I will create a [repository security advisory](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory) to coordinate.
+## Reporting Vulnerabilities
 
-If you wish to be credited, please provide a name or handle for me to credit.
+Please follow the project's [security policy](../SECURITY.md).  In short: report successful attacks with example input via [OWASP's Bugcrowd queue](https://bugcrowd.com/owaspjavasanitizer) or by email to `jim@owasp.org`, and a maintainer will create a [repository security advisory](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory) to coordinate a fix.
 
-If you wish to remain anonymous, please create a sock account, and email the address above.
+If you wish to be credited, please provide a name or handle.
 
-## Out of Bounds 
-We are testing the HTML sanitizer as written, not the servers on which the test framework runs, so hacking the server to change the code behind it or rewrite the HTML sanitizer is out of bounds.
+If you wish to remain anonymous, say so in your report.
 
-## Questions 
-Feel free to ask questions by opening a [GitHub issue](https://github.com/OWASP/java-html-sanitizer/issues), or via the email address above.
+## Out of Bounds
 
-I will also lurk on IRC `/join #owasp-html-sanitizer` using the handle `mikesamuel`.
+The target is the sanitizer as written.  Attacks on the project's infrastructure, such as GitHub, the CI runners, or Bugcrowd, are out of bounds.
+
+## Questions
+
+Feel free to ask questions in the project's [GitHub Discussions](https://github.com/OWASP/java-html-sanitizer/discussions/categories/q-a).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -42,6 +42,6 @@ For advanced use, see:
 
 ## Asking Questions
 
-Feel free to post questions as a
-[GitHub issue](https://github.com/OWASP/java-html-sanitizer/issues)
+Feel free to post questions in
+[GitHub Discussions](https://github.com/OWASP/java-html-sanitizer/discussions/categories/q-a)
 and we'll do our best to help.

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -29,7 +29,7 @@ can shed light on the salient differences.
 You should be able to build with the HTML sanitizer.  You can read the
 [javadoc](https://static.javadoc.io/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/latest/index.html),
 and if you have questions that aren't answered by these pages,
-you can open a
-[GitHub issue](https://github.com/OWASP/java-html-sanitizer/issues).
+you can ask in
+[GitHub Discussions](https://github.com/OWASP/java-html-sanitizer/discussions/categories/q-a).
 
 Happy sanitizing...


### PR DESCRIPTION
Second half of the repo cleanup pass, following #419.

## GitHub Discussions

Discussions is now enabled on the repository with GitHub's default categories, completing the "use GH discussions as new forum" item from the 22 Aug 2025 minutes in #360. The question-asking links in `docs/getting_started.md`, `docs/maven.md`, and `docs/attack_review_ground_rules.md` move from Issues to the [Q&A category](https://github.com/OWASP/java-html-sanitizer/discussions/categories/q-a). Issues stay the channel for bug reports and contributions, so the README's contributing section is unchanged.

## Attack review ground rules

The page still named the original author's personal email as the security contact, which contradicted `SECURITY.md`, and described a web harness at canyouxssthis.com that no longer responds. Changes:

- Reporting now defers to `SECURITY.md`: the Bugcrowd queue (still live) or jim@owasp.org, with a repository security advisory to coordinate.
- The public credit offer for a first-reported bypass stays. The personal dinner offer is dropped.
- The dead harness, its `/reflect` endpoint, and the IRC channel are removed. The out-of-bounds section is reworded for a project with no test server.
- The README's vulnerability pointer now links `SECURITY.md` first, with the ground rules second.

## Also done outside this PR

- `origin/master` deleted. Its six unique commits were 2021 change-log edits whose content main's change log already covers in more detail.
- Tag `release-223` deleted. It dated to March 2014, had no Release object attached, and its number was the source of the scanner confusion in #357.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
