### PR TITLE
Document thread safety and style-text vetting, and unpin OSGi from javax.annotation

### DIFF
--- a/owasp-java-html-sanitizer/pom.xml
+++ b/owasp-java-html-sanitizer/pom.xml
@@ -65,7 +65,13 @@
                  written this manifest.  Tell bnd not to import
                  org.owasp.shim so the bundled copy always wins over any
                  stray shim bundle installed alongside. -->
-            <Import-Package>!org.owasp.shim,*</Import-Package>
+            <!-- The nullability/concurrency annotations are compile-time
+                 documentation with no runtime behaviour, but jsr305 gives some
+                 of them RUNTIME retention, so bnd sees them in the class files
+                 and would otherwise emit a mandatory javax.annotation import.
+                 Marking it optional keeps the bundle resolvable in containers
+                 that do not export javax.annotation.  See issue #146. -->
+            <Import-Package>!org.owasp.shim,javax.annotation;resolution:=optional,javax.annotation.concurrent;resolution:=optional,*</Import-Package>
             <!-- Explicit JPMS automatic module name so consumers using the
                  module path can require this module by a stable name that
                  is independent of the JAR filename. -->

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -142,14 +142,34 @@ import static org.owasp.shim.Java8Shim.j8;
  *
  * <h3>Thread safety and efficiency</h3>
  * <p>
- * This class is not thread-safe.  The resulting policy will not violate its
- * security guarantees as a result of race conditions, but is not thread safe
- * because it maintains state to track whether text inside disallowed elements
- * should be suppressed.
+ * In short: build a {@link PolicyFactory} once with {@link #toFactory()} and
+ * share it across threads.  Do not share a builder, and do not share a policy
+ * built with {@link #build}.
  * <p>
- * The resulting policy can be reused, but if you use the
- * {@link HtmlPolicyBuilder#toFactory()} method instead of {@link #build}, then
- * binding policies to output channels is cheap so there's no need.
+ * In detail, there are three objects here with three different rules:
+ * <ul>
+ *   <li><b>{@code HtmlPolicyBuilder} is not thread-safe.</b>  It is mutable,
+ *     so confine it to the thread that is configuring it.
+ *   <li><b>{@link PolicyFactory}, from {@link #toFactory()}, is thread-safe
+ *     and immutable.</b>  This is the object to build once and reuse.  Binding
+ *     one to an output channel is cheap, so there is no reason to cache
+ *     anything further down.
+ *   <li><b>The {@link HtmlSanitizer.Policy} from {@link #build} is not
+ *     thread-safe</b>, and neither is it reusable across concurrent
+ *     sanitizations: it is bound to a single output channel and keeps state to
+ *     track whether text inside disallowed elements should be suppressed.  Use
+ *     one per sanitization.
+ * </ul>
+ * <p>
+ * Sharing a stateful policy across threads corrupts output rather than
+ * security: a race cannot make the policy accept something it would otherwise
+ * reject, but it can interleave or suppress the wrong content.
+ * <p>
+ * The same rule applies to anything you plug in.  An
+ * {@link HtmlStreamEventProcessor} is asked to
+ * {@link HtmlStreamEventProcessor#wrap wrap} a sink once per sanitization, so
+ * any per-document state a pre-processor keeps belongs in the receiver it
+ * returns, not in the processor itself.
  * </p>
  *
  * @author Mike Samuel (mikesamuel@gmail.com)
@@ -281,6 +301,17 @@ public class HtmlPolicyBuilder {
    * <p>
    * To write a policy that whitelists {@code <script>} or {@code <style>}
    * elements, first {@code allowTextIn("script")}.
+   * <p>
+   * <b>Security note:</b> this method allows the element's text through as
+   * <i>text</i>; it does not vet that text.  In particular, allowing text in
+   * {@code <style>} does <b>not</b> run the stylesheet through
+   * {@link CssSchema}: the schema guards the {@code style} <i>attribute</i>,
+   * so a rule like {@code a { background: url(javascript:alert(1)) }} inside a
+   * {@code <style>} element survives untouched, as does any selector that
+   * restyles the surrounding page.  The same goes for {@code <script>}, where
+   * the text is script source.  If you allow text in either element and the
+   * input is untrusted, vet that text yourself, for example with a
+   * {@link #withPreprocessor pre-processor} that parses and rewrites it.
    */
   public HtmlPolicyBuilder allowTextIn(String... elementNames) {
     invalidateCompiledState();
@@ -553,6 +584,21 @@ public class HtmlPolicyBuilder {
    * <p>
    * URLs in CSS are typically loaded without user-interaction, the way links
    * are, so a greater degree of scrutiny is warranted.
+   * <p>
+   * <b>This method only narrows what is allowed; it cannot widen it.</b>  The
+   * policy given here runs <i>after</i> the protocol filter built from
+   * {@link #allowUrlProtocols(String...)}, so a URL has to clear both.  If
+   * {@code allowUrlProtocols} was never called, that filter rejects every
+   * URL and this policy is never consulted -- calling
+   * {@code allowUrlsInStyles} on its own looks like a no-op.  Pair it with an
+   * {@code allowUrlProtocols} call:
+   *
+   * <pre>{@code
+   * new HtmlPolicyBuilder()
+   *     .allowStyling()
+   *     .allowUrlProtocols("https")          // without this, the next line
+   *     .allowUrlsInStyles(myUrlPolicy)      // never sees a URL
+   * }</pre>
    *
    * @param newStyleUrlPolicy receives URLs from the CSS that pass the allowed
    *     protocol policies, and may return null to veto the URL or the URL

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamEventProcessor.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamEventProcessor.java
@@ -4,6 +4,31 @@ package org.owasp.html;
 
 /**
  * Receives the output sink to allow user-code to post-process events.
+ *
+ * <p><b>Thread safety:</b> a single processor is shared by every sanitization
+ * that uses the policy it was installed on, including concurrent ones, so a
+ * processor must be safe to call {@link #wrap} on from several threads.
+ * {@code wrap} is called once per sanitization, though, and the receiver it
+ * returns is used by that sanitization alone.  So per-document state -- "am I
+ * inside a {@code <style>} element?", a depth counter, a buffer -- belongs in
+ * the returned receiver, not in a field of the processor:
+ *
+ * <pre>{@code
+ * // Correct: the flag lives in the per-sanitization wrapper.
+ * new HtmlStreamEventProcessor() {
+ *   public HtmlStreamEventReceiver wrap(HtmlStreamEventReceiver sink) {
+ *     return new HtmlStreamEventReceiverWrapper(sink) {
+ *       private boolean inStyle;
+ *       ...
+ *     };
+ *   }
+ * }
+ * }</pre>
+ *
+ * A flag hoisted into the processor itself would be shared by concurrent
+ * sanitizations, which corrupts output rather than security: one document's
+ * events cannot escape the policy, but they can make another document's
+ * wrapper act on the wrong text.
  */
 public interface HtmlStreamEventProcessor {
   /**
@@ -11,7 +36,8 @@ public interface HtmlStreamEventProcessor {
    *    sanitizer policy to build a safe output on an appropriate buffer.
    * @return  an HTML stream event receiver that can take events from a
    *    sanitizer policy to build a safe output on an appropriate buffer by
-   *    sending events to sink.
+   *    sending events to sink.  It is used by one sanitization only, so it is
+   *    the right place for any state the processor needs to keep.
    */
   HtmlStreamEventReceiver wrap(HtmlStreamEventReceiver sink);
 

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@ application while protecting against XSS.
           <plugin>
             <groupId>org.jreleaser</groupId>
             <artifactId>jreleaser-maven-plugin</artifactId>
-            <version>1.22.0</version>
+            <version>1.26.0</version>
             <inherited>false</inherited>
             <configuration>
               <jreleaser>


### PR DESCRIPTION
Five issues that need documentation or build metadata rather than behaviour changes. No runtime code is touched.

### Javadoc

- **#250** — `HtmlPolicyBuilder`'s thread-safety section said the class is not thread-safe, then discussed "the resulting policy" without distinguishing the three objects involved. Replaced with the three rules that actually apply: the builder is confined to one thread, the `PolicyFactory` from `toFactory()` is immutable and meant to be shared, the `Policy` from `build()` is per-sanitization. This is close to the rewording the reporter proposed.
- **#353** — `HtmlStreamEventProcessor` said nothing about threading, which is how the reporter ended up with a per-document flag in a processor field, interleaved across concurrent sanitizations. `wrap()` is called once per sanitization, so the returned receiver is the right home for that state; documented with the working shape (which is what the reporter arrived at on their own).
- **#323** — `allowTextIn`'s javadoc recommends it for `<style>` without noting that `CssSchema` guards the `style` *attribute* only. Verified against this branch: with `allowTextIn("style")`, `#a{background:url(javascript:alert(1))}` survives verbatim. Added a security note, since this method is what people get pointed at from #268 and #101.
- **#380 item 3** — `allowUrlsInStyles` runs *after* the protocol filter built from `allowUrlProtocols`, so with no `allowUrlProtocols` call the filter rejects every URL and the supplied policy is never consulted, making the call look like a no-op. Documented the ordering with the pairing that works.

### Build metadata

- **#146** — jsr305 gives some annotations `RUNTIME` retention, so bnd emitted `Import-Package: javax.annotation;version="[3.0,4)"` as mandatory and the bundle would not resolve in containers that do not export it (the SLING-7312 case). The annotations carry no runtime behaviour, so the import is now `resolution:=optional`. Verified in the built manifest:

  ```
  Import-Package: javax.annotation;resolution:=optional;version="[3.0,4)",
   org.owasp.html;version="[20000101.0,20000102)",
   javax.annotation.concurrent;resolution:=optional;version="[3.0,4)"
  ```

  The jsr305 *dependency* was already gone — annotations now come from `spotbugs-annotations` at `provided` scope — so this was the last piece.
- **#368** — bumped `jreleaser-maven-plugin` 1.22.0 to 1.26.0. Per the reporter's own follow-up, JReleaser 1.23.0 added lenient chronver parsing, which makes the current `YYYYMMDD.N` scheme parseable without changing it.

### Verification

Full CI matrix run locally — JDK 11, 17, 21 and 25, `mvn verify`, 393 tests, `BUILD SUCCESS` on all four. Standalone `javadoc:javadoc` reports the same 326 pre-existing warnings before and after, so no new javadoc problems were introduced.

Closes #250, closes #353, closes #323, closes #146, closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
