### PR TITLE
Do not advertise a javax.annotation.concurrent import the bundle does not have

### DIFF
--- a/owasp-java-html-sanitizer/pom.xml
+++ b/owasp-java-html-sanitizer/pom.xml
@@ -65,13 +65,17 @@
                  written this manifest.  Tell bnd not to import
                  org.owasp.shim so the bundled copy always wins over any
                  stray shim bundle installed alongside. -->
-            <!-- The nullability/concurrency annotations are compile-time
-                 documentation with no runtime behaviour, but jsr305 gives some
-                 of them RUNTIME retention, so bnd sees them in the class files
-                 and would otherwise emit a mandatory javax.annotation import.
-                 Marking it optional keeps the bundle resolvable in containers
-                 that do not export javax.annotation.  See issue #146. -->
-            <Import-Package>!org.owasp.shim,javax.annotation;resolution:=optional,javax.annotation.concurrent;resolution:=optional,*</Import-Package>
+            <!-- The nullability annotations are compile-time documentation
+                 with no runtime behaviour, but jsr305 gives them RUNTIME
+                 retention, so bnd sees them in the class files and would
+                 otherwise emit a mandatory javax.annotation import.  Marking
+                 it optional keeps the bundle resolvable in containers that do
+                 not export javax.annotation.  See issue #146.
+                 Do not list javax.annotation.concurrent here: those
+                 annotations are CLASS-retention, so bnd does not import the
+                 package unless we name it, and naming it advertises a
+                 dependency the bundle does not have. -->
+            <Import-Package>!org.owasp.shim,javax.annotation;resolution:=optional,*</Import-Package>
             <!-- Explicit JPMS automatic module name so consumers using the
                  module path can require this module by a stable name that
                  is independent of the JAR filename. -->


### PR DESCRIPTION
Follow-up to #425, fixing a mistake I made there.

#425 marked `javax.annotation` optional so the bundle resolves in containers that do not export it (#146), and named `javax.annotation.concurrent` alongside it on the assumption it was imported for the same reason. It wasn't. Those annotations are CLASS-retention, so bnd never saw them and never emitted the import — **naming the package explicitly is what put it in the manifest.**

Verified by removing only that clause and rebuilding:

```
with the clause:     javax.annotation (optional), org.owasp.html, javax.annotation.concurrent (optional)
without the clause:  javax.annotation (optional), org.owasp.html
```

An optional import cannot block resolution, so the effect was harmless — but it advertised a dependency the bundle does not have, which is the opposite of what #146 was about. Dropped, with a comment on why it should not come back.

No behaviour change and no source change; the only edit is the bnd instruction and its comment.

### Verification

Full matrix locally — JDK 11, 17, 21, 25, `mvn verify`, 393 tests, `BUILD SUCCESS` on all four. Resulting manifest:

```
Import-Package: javax.annotation;resolution:=optional;version="[3.0,4)",
 org.owasp.html;version="[20000101.0,20000102)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
