### PR TITLE
Define the modern CSS layout families as an opt-in, and widen decoration

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -426,6 +426,8 @@ public final class CssSchema {
       j8().mapEntry("radial-gradient(", "radial-gradient()"),
       j8().mapEntry("repeating-linear-gradient(", "repeating-linear-gradient()"),
       j8().mapEntry("repeating-radial-gradient(", "repeating-radial-gradient()"),
+      j8().mapEntry("conic-gradient(", "conic-gradient()"),
+      j8().mapEntry("repeating-conic-gradient(", "repeating-conic-gradient()"),
       j8().mapEntry("rgb(", "rgb()"), j8().mapEntry("rgba(", "rgba()"),
       j8().mapEntry("hsl(", "hsl()"), j8().mapEntry("hsla(", "hsla()"));
     Set<String> backgroundAttachmentLiterals0 =
@@ -440,7 +442,9 @@ public final class CssSchema {
         j8().mapEntry("linear-gradient(", "linear-gradient()"),
         j8().mapEntry("radial-gradient(", "radial-gradient()"),
         j8().mapEntry("repeating-linear-gradient(", "repeating-linear-gradient()"),
-        j8().mapEntry("repeating-radial-gradient(", "repeating-radial-gradient()"));
+        j8().mapEntry("repeating-radial-gradient(", "repeating-radial-gradient()"),
+        j8().mapEntry("conic-gradient(", "conic-gradient()"),
+        j8().mapEntry("repeating-conic-gradient(", "repeating-conic-gradient()"));
     Set<String> backgroundPositionLiterals0 = j8().setOf(
         ",", "center");
     Set<String> backgroundRepeatLiterals0 = j8().setOf(
@@ -480,7 +484,11 @@ public final class CssSchema {
         "inline-block", "inline-table", "list-item", "run-in", "table",
         "table-caption", "table-cell", "table-column", "table-column-group",
         "table-footer-group", "table-header-group", "table-row",
-        "table-row-group");
+        "table-row-group",
+        // Flexbox and grid formatting contexts.  "display" is not in
+        // DEFAULT_WHITELIST, so these only take effect for a policy that
+        // opts into layout; see the note above GRID/FLEX below.
+        "flex", "inline-flex", "grid", "inline-grid", "flow-root");
     Set<String> elevationLiterals0 = j8().setOf(
         "above", "below", "higher", "level", "lower");
     Set<String> emptyCellsLiterals0 = j8().setOf("hide", "show");
@@ -561,6 +569,13 @@ public final class CssSchema {
         "start", "left", "right", "initial", "revert", "revert-layer", "unset");
     Set<String> textDecorationLiterals0 = j8().setOf(
         "blink", "line-through", "overline", "underline");
+    Set<String> textDecorationStyleLiterals0 = j8().setOf(
+        "dashed", "dotted", "double", "solid", "wavy");
+    Set<String> textDecorationLineLiterals0 = j8().setOf(
+        "blink", "grammar-error", "line-through", "none", "overline",
+        "spelling-error", "underline");
+    Set<String> textDecorationThicknessLiterals0 = j8().setOf(
+        "auto", "from-font");
     Set<String> textTransformLiterals0 = j8().setOf(
         "capitalize", "lowercase", "uppercase");
     Set<String> textWrapLiterals0 = j8().setOf(
@@ -827,8 +842,13 @@ public final class CssSchema {
         0, union(azimuthLiterals1, textAlignLiterals0), zeroFns);
     builder.put("text-align", textAlign);
     @SuppressWarnings("unchecked")
+    // The shorthand takes a line, a style and a colour in any order, so it
+    // admits everything the three longhands below do.
     Property textDecoration = new Property(
-        0, union(cueLiterals0, textDecorationLiterals0), zeroFns);
+        2,
+        union(cueLiterals0, textDecorationLiterals0,
+              textDecorationStyleLiterals0, mozOutlineLiterals0),
+        mozOutlineFunctions);
     builder.put("text-decoration", textDecoration);
     @SuppressWarnings("unchecked")
     Property textTransform = new Property(
@@ -965,6 +985,168 @@ public final class CssSchema {
     builder.put("z-index", bottom);
     builder.put("repeating-linear-gradient()", linearGradient$Fun);
     builder.put("repeating-radial-gradient()", radialGradient$Fun);
+    // ---- Decorative additions (safe for DEFAULT) -------------------------
+    // These only change how an element paints itself.  They cannot move it,
+    // hide it, or change how it participates in layout, so they go in
+    // DEFAULT_WHITELIST alongside the properties they complement.
+
+    builder.put("text-decoration-line",
+                new Property(0, textDecorationLineLiterals0, zeroFns));
+    builder.put("text-decoration-style",
+                new Property(0, textDecorationStyleLiterals0, zeroFns));
+    // Same shape as "color": a hash value, a named colour, or rgb()/hsl().
+    builder.put("text-decoration-color", color);
+    builder.put("text-decoration-thickness",
+                new Property(1, textDecorationThicknessLiterals0, zeroFns));
+
+    // SVG paint.  BIT_URL is deliberately not set: "stroke: url(#gradient)"
+    // would be a URL vector, and a paint server reference is not worth one.
+    @SuppressWarnings("unchecked")
+    Set<String> strokeLiterals0 = union(
+        mozOutlineLiterals0, j8().setOf("currentcolor", "none", "transparent"));
+    builder.put("stroke", new Property(2, strokeLiterals0, mozOutlineFunctions));
+    builder.put("stroke-width", new Property(1, j8().setOf(), zeroFns));
+
+    // conic-gradient is an <image> like its linear and radial siblings, so it
+    // takes the same shape as radial-gradient().
+    @SuppressWarnings("unchecked")
+    Property conicGradient$Fun = new Property(
+        7,
+        union(azimuthLiterals1, backgroundLiterals2, mozOutlineLiterals0,
+              j8().setOf(",", "at", "from")),
+        mozOutlineFunctions);
+    builder.put("conic-gradient()", conicGradient$Fun);
+    builder.put("repeating-conic-gradient()", conicGradient$Fun);
+
+    // ---- Layout and transforms (definitions only, NOT in DEFAULT) --------
+    // DEFAULT deliberately withholds every property that changes how an
+    // element takes part in page layout -- display, position, float, clear,
+    // overflow, z-index, opacity, visibility and the offsets -- so that a
+    // style attribute can restyle content but cannot reposition it, overlay
+    // something else, or hide it.  The families below are the modern
+    // equivalents and are withheld on the same grounds.
+    //
+    // They are defined here so that a policy that wants them can opt in:
+    //
+    //   CssSchema layout = CssSchema.withProperties(Arrays.asList(
+    //       "display", "grid-template-columns", "gap", "repeat()", "minmax()"));
+    //   CssSchema schema = CssSchema.union(CssSchema.DEFAULT, layout);
+    //
+    // Note the "repeat()" and "minmax()" entries: a function is reached
+    // through a schema key, and a key the schema does not contain resolves to
+    // DISALLOWED, so a property must be opted into together with the
+    // functions its values use.
+
+    Set<String> gridTrackLiterals0 = j8().setOf(
+        ",", "/", "auto", "auto-fill", "auto-fit", "max-content", "min-content",
+        "none", "span", "masonry", "subgrid");
+    Map<String, String> gridTrackFunctions = j8().mapOfEntries(
+        j8().mapEntry("repeat(", "repeat()"),
+        j8().mapEntry("minmax(", "minmax()"),
+        j8().mapEntry("fit-content(", "fit-content()"),
+        j8().mapEntry("calc(", "calc()"));
+
+    Property minmax$Fun = new Property(1, gridTrackLiterals0, zeroFns);
+    builder.put("minmax()", minmax$Fun);
+    builder.put("fit-content()", new Property(1, j8().setOf(","), zeroFns));
+    // repeat() may nest minmax() and fit-content().
+    builder.put("repeat()",
+                new Property(1, gridTrackLiterals0, gridTrackFunctions));
+
+    Property gridTemplate = new Property(1, gridTrackLiterals0, gridTrackFunctions);
+    for (String name : new String[] {
+        "grid", "grid-template", "grid-template-columns", "grid-template-rows",
+        "grid-auto-columns", "grid-auto-rows" }) {
+      builder.put(name, gridTemplate);
+    }
+    // Area names are quoted strings; they are never rendered as text.
+    builder.put("grid-template-areas", new Property(8, j8().setOf("none"), zeroFns));
+    builder.put("grid-auto-flow",
+                new Property(0, j8().setOf("column", "dense", "row"), zeroFns));
+    // Line-based placement: integers (which may be negative), "span", "auto"
+    // and the "/" that separates start from end.
+    Property gridLine = new Property(
+        5, j8().setOf(",", "/", "auto", "span"), zeroFns);
+    for (String name : new String[] {
+        "grid-area", "grid-column", "grid-column-end", "grid-column-start",
+        "grid-row", "grid-row-end", "grid-row-start" }) {
+      builder.put(name, gridLine);
+    }
+    Property gap = new Property(1, j8().setOf("normal"), zeroFns);
+    for (String name : new String[] {
+        "gap", "row-gap", "column-gap",
+        "grid-gap", "grid-row-gap", "grid-column-gap" }) {
+      builder.put(name, gap);
+    }
+
+    Set<String> flexWrapLiterals0 = j8().setOf(
+        "nowrap", "wrap", "wrap-reverse");
+    Set<String> flexDirectionLiterals0 = j8().setOf(
+        "column", "column-reverse", "row", "row-reverse");
+    Set<String> flexBasisLiterals0 = j8().setOf(
+        "auto", "content", "fit-content", "max-content", "min-content");
+    builder.put("flex-direction", new Property(0, flexDirectionLiterals0, zeroFns));
+    builder.put("flex-wrap", new Property(0, flexWrapLiterals0, zeroFns));
+    @SuppressWarnings("unchecked")
+    Property flexFlow = new Property(
+        0, union(flexDirectionLiterals0, flexWrapLiterals0), zeroFns);
+    builder.put("flex-flow", flexFlow);
+    builder.put("flex-grow", new Property(1, j8().setOf(), zeroFns));
+    builder.put("flex-shrink", new Property(1, j8().setOf(), zeroFns));
+    @SuppressWarnings("unchecked")
+    Property flexBasis = new Property(
+        1, union(flexBasisLiterals0, j8().setOf("none")), zeroFns);
+    builder.put("flex-basis", flexBasis);
+    @SuppressWarnings("unchecked")
+    Property flex = new Property(
+        1, union(flexBasisLiterals0, j8().setOf("none", "initial")), zeroFns);
+    builder.put("flex", flex);
+    // "order" is one of the few layout properties that takes a negative.
+    builder.put("order", new Property(5, j8().setOf(), zeroFns));
+
+    Set<String> alignmentLiterals0 = j8().setOf(
+        "baseline", "center", "end", "first", "flex-end", "flex-start", "last",
+        "left", "normal", "right", "safe", "self-end", "self-start",
+        "space-around", "space-between", "space-evenly", "start", "stretch",
+        "unsafe");
+    Property alignment = new Property(0, alignmentLiterals0, zeroFns);
+    @SuppressWarnings("unchecked")
+    Property alignmentOrAuto = new Property(
+        0, union(alignmentLiterals0, j8().setOf("auto")), zeroFns);
+    for (String name : new String[] {
+        "align-content", "align-items", "justify-content", "justify-items",
+        "place-content", "place-items" }) {
+      builder.put(name, alignment);
+    }
+    for (String name : new String[] {
+        "align-self", "justify-self", "place-self" }) {
+      builder.put(name, alignmentOrAuto);
+    }
+
+    // Transforms can move, scale and rotate an element, which is why they are
+    // withheld from DEFAULT for the same reason "position" is.
+    Property transform$Fun = new Property(5, j8().setOf(","), zeroFns);
+    builder.put("transform-function()", transform$Fun);
+    Map<String, String> transformFunctions;
+    {
+      Map<String, String> fns = new HashMap<>();
+      for (String fn : new String[] {
+          "translate", "translatex", "translatey", "translatez", "translate3d",
+          "rotate", "rotatex", "rotatey", "rotatez", "rotate3d",
+          "scale", "scalex", "scaley", "scalez", "scale3d",
+          "skew", "skewx", "skewy",
+          "matrix", "matrix3d", "perspective" }) {
+        fns.put(fn + "(", "transform-function()");
+      }
+      transformFunctions = Collections.unmodifiableMap(fns);
+    }
+    builder.put("transform",
+                new Property(0, j8().setOf("none"), transformFunctions));
+    builder.put("transform-origin", new Property(
+        5,
+        j8().setOf("bottom", "center", "left", "right", "top"),
+        zeroFns));
+
     // Fold the CSS-wide keywords into every property, rather than repeating
     // them in each literal set above.  Keys ending in "()" describe the
     // arguments of a function, not a property, and are left alone: "initial"
@@ -1103,6 +1285,8 @@ public final class CssSchema {
       "pitch-range",
       "quotes",
       "radial-gradient()",
+      "conic-gradient()",
+      "repeating-conic-gradient()",
       "rect()",
       "repeating-linear-gradient()",
       "repeating-radial-gradient()",
@@ -1117,9 +1301,15 @@ public final class CssSchema {
       "speak-punctuation",
       "speech-rate",
       "stress",
+      "stroke",
+      "stroke-width",
       "table-layout",
       "text-align",
       "text-decoration",
+      "text-decoration-color",
+      "text-decoration-line",
+      "text-decoration-style",
+      "text-decoration-thickness",
       "text-indent",
       "text-overflow",
       "text-shadow",

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssTokens.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssTokens.java
@@ -1474,6 +1474,10 @@ final class CssTokens implements Iterable<String> {
         j8().mapEntry("vw", LENGTH_UNIT_TYPE),
         j8().mapEntry("vmin", LENGTH_UNIT_TYPE),
         j8().mapEntry("vmax", LENGTH_UNIT_TYPE),
+        // Grid track flex factor.  Only meaningful in grid-template-* values,
+        // which are not in DEFAULT, but the lexer has to recognize the unit
+        // for a policy that opts into grid to see "1fr" at all.
+        j8().mapEntry("fr", LENGTH_UNIT_TYPE),
         j8().mapEntry("px", LENGTH_UNIT_TYPE),
         j8().mapEntry("mm", LENGTH_UNIT_TYPE),
         j8().mapEntry("cm", LENGTH_UNIT_TYPE),

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -549,6 +549,34 @@ public class HtmlPolicyBuilder {
    * Convert <code>style="&lt;CSS&gt;"</code> to sanitized CSS which allows
    * color, font-size, type-face, and other styling using the default schema;
    * but which does not allow content to escape its clipping context.
+   * <p>
+   * "Does not allow content to escape its clipping context" is the reason
+   * {@link CssSchema#DEFAULT} withholds every property that changes how an
+   * element takes part in page layout: {@code display}, {@code position},
+   * {@code float}, {@code clear}, {@code overflow}, {@code z-index},
+   * {@code opacity}, {@code visibility}, the offsets, and the flexbox, grid
+   * and {@code transform} families.  A style attribute can restyle content,
+   * but it cannot reposition it, lay something over the top of it, or hide
+   * it.  Note that this excludes {@code display:block} just as it excludes
+   * {@code display:none} -- the whole property is withheld, not a few values.
+   * <p>
+   * A policy that needs layout control can opt in with
+   * {@link CssSchema#union}, which is the supported way to widen the default
+   * schema:
+   *
+   * <pre>{@code
+   * CssSchema layout = CssSchema.withProperties(Arrays.asList(
+   *     "display", "grid-template-columns", "gap",
+   *     "repeat()", "minmax()"));   // functions need listing too
+   * builder.allowStyling(CssSchema.union(CssSchema.DEFAULT, layout));
+   * }</pre>
+   *
+   * Weigh that against the content you are sanitizing: layout control is what
+   * lets untrusted markup cover or hide the page around it.  Note that
+   * {@code position:fixed} and {@code position:sticky} are withheld even
+   * then, because they escape a scrolling container entirely.
+   *
+   * @see CssSchema#union
    */
   public HtmlPolicyBuilder allowStyling() {
     allowStyling(CssSchema.DEFAULT);

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
@@ -29,6 +29,7 @@ package org.owasp.html;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -99,8 +100,14 @@ final class CssSchemaTest {
     }
     assertEquals(
         new TreeSet<>(Arrays.asList(
+            // Sizing properties, which are in DEFAULT.
             "height", "max-height", "max-width",
-            "min-height", "min-width", "width")),
+            "min-height", "min-width", "width",
+            // Grid track sizing, where calc() is equally valid CSS.  These
+            // are definitions only -- none of them is in DEFAULT_WHITELIST --
+            // so this does not widen what a bare allowStyling() accepts.
+            "grid", "grid-auto-columns", "grid-auto-rows", "grid-template",
+            "grid-template-columns", "grid-template-rows", "repeat()")),
         withCalc);
     assertTrue(CssSchema.DEFAULT_WHITELIST.contains("calc()"));
     CssSchema.Property calc = CssSchema.DEFAULT.forKey("calc()");
@@ -127,6 +134,89 @@ final class CssSchemaTest {
             key + " should" + (isFunction ? " not" : "") + " allow " + keyword);
       }
     }
+  }
+
+  /**
+   * DEFAULT withholds every property that changes how an element takes part
+   * in page layout, so that a style attribute can restyle content but cannot
+   * reposition it, overlay something else, or hide it.  Adding the modern
+   * layout families to the definitions must not erode that.
+   */
+  @Test
+  void testDefaultGrantsNoLayoutControl() {
+    List<String> layoutProperties = Arrays.asList(
+        "display", "position", "float", "clear", "overflow", "overflow-x",
+        "overflow-y", "z-index", "opacity", "visibility", "top", "left",
+        "right", "bottom", "transform", "transform-origin",
+        "grid", "grid-area", "grid-auto-flow", "grid-column", "grid-row",
+        "grid-template", "grid-template-areas", "grid-template-columns",
+        "grid-template-rows", "gap", "row-gap", "column-gap",
+        "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow",
+        "flex-shrink", "flex-wrap", "order",
+        "align-content", "align-items", "align-self", "justify-content",
+        "justify-items", "justify-self", "place-content", "place-items",
+        "place-self");
+    for (String propName : layoutProperties) {
+      assertFalse(
+          CssSchema.DEFAULT_WHITELIST.contains(propName),
+          propName + " must not be in DEFAULT");
+      assertSame(
+          CssSchema.DISALLOWED, CssSchema.DEFAULT.forKey(propName),
+          propName + " must be disallowed by DEFAULT");
+    }
+  }
+
+  /**
+   * position:fixed and position:sticky escape a scrolling container, so they
+   * are withheld even from a policy that opts into layout.  That floor lives
+   * in the literal set rather than the whitelist, so opting in must not
+   * reach it.
+   */
+  @Test
+  void testFixedPositioningIsWithheldEvenWhenOptingIn() {
+    CssSchema.Property position = CssSchema.DEFINITIONS.get("position");
+    assertTrue(position.literals.contains("absolute"));
+    assertTrue(position.literals.contains("relative"));
+    assertTrue(position.literals.contains("static"));
+    assertFalse(position.literals.contains("fixed"));
+    assertFalse(position.literals.contains("sticky"));
+  }
+
+  /** The layout families are defined, so a caller can union them into DEFAULT. */
+  @Test
+  void testLayoutFamiliesAreDefinedForOptIn() {
+    for (String propName : Arrays.asList(
+        "grid-template-columns", "grid-column", "gap", "flex",
+        "flex-direction", "order", "justify-content", "align-items",
+        "transform", "repeat()", "minmax()", "fit-content()")) {
+      assertNotSame(
+          CssSchema.DISALLOWED, CssSchema.DEFINITIONS.get(propName),
+          propName);
+    }
+    CssSchema.Property display = CssSchema.DEFINITIONS.get("display");
+    assertTrue(display.literals.contains("flex"), "display:flex");
+    assertTrue(display.literals.contains("grid"), "display:grid");
+  }
+
+  /**
+   * The decorative additions do go into DEFAULT, but stroke must not become a
+   * URL vector: "stroke: url(#paintserver)" is valid CSS we deliberately
+   * decline to support.
+   */
+  @Test
+  void testDecorativeAdditionsAreInDefaultAndTakeNoUrl() {
+    for (String propName : Arrays.asList(
+        "text-decoration-line", "text-decoration-style", "text-decoration-color",
+        "text-decoration-thickness", "stroke", "stroke-width",
+        "conic-gradient()", "repeating-conic-gradient()")) {
+      assertTrue(
+          CssSchema.DEFAULT_WHITELIST.contains(propName), propName);
+      assertNotSame(
+          CssSchema.DISALLOWED, CssSchema.DEFAULT.forKey(propName), propName);
+    }
+    CssSchema.Property stroke = CssSchema.DEFAULT.forKey("stroke");
+    assertEquals(0, stroke.bits & CssSchema.BIT_URL);
+    assertFalse(stroke.fnKeys.containsKey("url("));
   }
 
   @Test

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/StylingPolicyTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/StylingPolicyTest.java
@@ -422,6 +422,135 @@ class StylingPolicyTest {
     assertSanitizedCss("font-family:'a b'", "font-family: a<!--b");
   }
 
+  /** A schema that opts into the layout families the way callers would. */
+  private static final CssSchema LAYOUT = CssSchema.union(
+      CssSchema.DEFAULT,
+      CssSchema.withProperties(Arrays.asList(
+          "display", "grid-template-columns", "grid-template-rows",
+          "grid-auto-flow", "grid-column", "grid-row", "gap", "row-gap",
+          "column-gap", "flex", "flex-direction", "flex-wrap", "flex-grow",
+          "flex-basis", "order", "justify-content", "align-items",
+          "align-self", "transform", "transform-origin",
+          "repeat()", "minmax()", "fit-content()", "transform-function()",
+          "calc()")));
+
+  /** Issue #228: the text-decoration longhands and a richer shorthand. */
+  @Test
+  void testTextDecorationLonghands() {
+    assertSanitizedCss(
+        "text-decoration-line:line-through", "text-decoration-line: line-through");
+    assertSanitizedCss("text-decoration-style:wavy", "text-decoration-style: wavy");
+    assertSanitizedCss("text-decoration-color:red", "text-decoration-color: red");
+    assertSanitizedCss(
+        "text-decoration-thickness:2px", "text-decoration-thickness: 2px");
+    assertSanitizedCss(
+        "text-decoration:underline dotted red",
+        "text-decoration: underline dotted red");
+    assertSanitizedCss(null, "text-decoration-line: url(javascript:alert(1))");
+  }
+
+  /** Issue #265: SVG stroke paint, but never a paint-server URL. */
+  @Test
+  void testStroke() {
+    assertSanitizedCss(
+        "stroke-width:4;stroke:rgb( 138 , 232 , 242 )",
+        "stroke-width: 4; stroke: rgb(138,232,242)");
+    assertSanitizedCss("stroke:none", "stroke: none");
+    assertSanitizedCss(null, "stroke: url(#paintserver)");
+    assertSanitizedCss(null, "stroke: url('javascript:alert%281337%29')");
+  }
+
+  /** Issue #380 item 6: conic gradients alongside linear and radial. */
+  @Test
+  void testConicGradient() {
+    assertSanitizedCss(
+        "background:conic-gradient( red , blue )",
+        "background: conic-gradient(red, blue)");
+    assertSanitizedCss(
+        "background-image:repeating-conic-gradient( red , blue )",
+        "background-image: repeating-conic-gradient(red, blue)");
+  }
+
+  /**
+   * DEFAULT withholds layout control, so none of the modern layout families
+   * are reachable without opting in.  This is the security-relevant half of
+   * the change and it must keep failing closed.
+   */
+  @Test
+  void testLayoutRequiresOptIn() {
+    assertSanitizedCss(null, "display: block");
+    assertSanitizedCss(null, "display: none");
+    assertSanitizedCss(null, "display: flex");
+    assertSanitizedCss(null, "display: grid");
+    assertSanitizedCss(null, "grid-template-columns: 1fr 280px");
+    assertSanitizedCss(null, "gap: 10px");
+    assertSanitizedCss(null, "flex: 1 1 auto");
+    assertSanitizedCss(null, "order: -5");
+    assertSanitizedCss(null, "justify-content: center");
+    assertSanitizedCss(null, "transform: translate(-9999px, 0)");
+  }
+
+  /** Issues #242 and #234: flex and grid for a policy that opts in. */
+  @Test
+  void testFlexAndGridWhenOptedIn() {
+    assertSanitizedCss(LAYOUT, "display:flex", "display: flex");
+    assertSanitizedCss(
+        LAYOUT, "display:flex;flex-direction:column",
+        "display: flex; flex-direction: column");
+    assertSanitizedCss(LAYOUT, "flex:1 1 auto", "flex: 1 1 auto");
+    assertSanitizedCss(LAYOUT, "order:-1", "order: -1");
+    assertSanitizedCss(
+        LAYOUT, "justify-content:space-between", "justify-content: space-between");
+    assertSanitizedCss(LAYOUT, "display:grid", "display: grid");
+    // The exact value from issue #234.
+    assertSanitizedCss(
+        LAYOUT,
+        "display:grid;grid-template-columns:repeat( auto-fit , minmax( 160px , 1fr ) )",
+        "display: grid; grid-template-columns: repeat( auto-fit, minmax(160px, 1fr) )");
+    // The exact value from issue #380 item 1.
+    assertSanitizedCss(
+        LAYOUT, "grid-template-columns:1fr 280px",
+        "grid-template-columns: 1fr 280px");
+    assertSanitizedCss(LAYOUT, "gap:10px 20px", "gap: 10px 20px");
+    assertSanitizedCss(LAYOUT, "grid-column:1 / 3", "grid-column: 1 / 3");
+  }
+
+  /** Issue #71: transform functions for a policy that opts in. */
+  @Test
+  void testTransformWhenOptedIn() {
+    assertSanitizedCss(
+        LAYOUT, "transform:rotate( 30deg ) translate( 10px , 20px )",
+        "transform: rotate(30deg) translate(10px, 20px)");
+    assertSanitizedCss(
+        LAYOUT, "transform:matrix( 1 , 0 , 0 , 1 , 10 , 20 )",
+        "transform: matrix(1, 0, 0, 1, 10, 20)");
+    assertSanitizedCss(LAYOUT, "transform:none", "transform: none");
+    assertSanitizedCss(LAYOUT, "transform-origin:top left", "transform-origin: top left");
+    // A transform function is not a way to smuggle a URL or a script.  The
+    // payload is dropped and an empty function shell is left behind, which is
+    // how rgb(), linear-gradient() and calc() have always behaved.
+    assertSanitizedCss(
+        LAYOUT, "transform:translate( )",
+        "transform: translate(url(javascript:alert(1)))");
+    assertSanitizedCss(LAYOUT, null, "transform: expression(alert(1))");
+    assertSanitizedCss(
+        LAYOUT, "transform:translate( )",
+        "transform: translate(expression(alert(1)))");
+  }
+
+  /**
+   * position:fixed escapes a scrolling container, so opting into layout must
+   * not bring it along.
+   */
+  @Test
+  void testFixedPositioningStaysBlockedWhenOptedIn() {
+    CssSchema withPosition = CssSchema.union(
+        CssSchema.DEFAULT, CssSchema.withProperties(Arrays.asList("position")));
+    assertSanitizedCss(withPosition, "position:absolute", "position: absolute");
+    assertSanitizedCss(withPosition, null, "position: fixed");
+    assertSanitizedCss(withPosition, null, "position: sticky");
+  }
+
   private static void assertSanitizedCss(
       @Nullable String expectedCss, String css) {
     assertSanitizedCss(CssSchema.DEFAULT, expectedCss, css);


### PR DESCRIPTION
Five issues ask for CSS that `CssSchema.DEFAULT` rejects: flexbox (#242), grid (#234), transforms (#71), the `text-decoration` longhands (#228), SVG `stroke` (#265), plus items 1 and 6 of #380.

**They are not one kind of request, and that determined the design.**

While investigating I found that DEFAULT withholds *the entire layout family* — `display`, `position`, `float`, `clear`, `overflow`, `z-index`, `opacity`, `visibility` and the offsets. Not a few missing literals: `display:block` is dropped exactly as `display:none` is. That is a deliberate boundary — a style attribute can restyle content, but cannot reposition it, cover the page around it, or hide it. Flexbox, grid and `transform` belong to that family. `text-decoration` and `stroke` do not.

So the two groups are handled differently.

### Decoration → into DEFAULT

These only change how an element paints itself:

- `text-decoration-line`, `-style`, `-color`, `-thickness` (#228), and the shorthand now takes a style and a colour rather than only a line, so `text-decoration: underline dotted red` survives intact.
- `stroke`, `stroke-width` (#265). **`stroke` deliberately does not set `BIT_URL`** — `stroke: url(#paintserver)` is valid CSS that we decline to support rather than open a URL vector.
- `conic-gradient()` and `repeating-conic-gradient()` (#380 item 6), beside the linear and radial siblings already present.

### Layout → defined, but opt-in only

Added to `DEFINITIONS` and deliberately **not** to `DEFAULT_WHITELIST`: `display`'s `flex`/`grid`/`inline-flex`/`inline-grid`/`flow-root` values, the grid and flexbox families, `gap`, the alignment properties, `transform` with its function set, `repeat()`/`minmax()`/`fit-content()`, and the `fr` unit in the lexer.

They reach only a policy that opts in:

```java
CssSchema layout = CssSchema.withProperties(Arrays.asList(
    "display", "grid-template-columns", "gap", "repeat()", "minmax()"));
builder.allowStyling(CssSchema.union(CssSchema.DEFAULT, layout));
```

`CssSchema.union` already supported this; it was documented nowhere. `allowStyling()`'s javadoc now explains the boundary and shows the opt-in.

**`position:fixed` and `position:sticky` stay withheld even when opted in**, since they escape a scrolling container outright. That floor lives in the literal set, and there's a test pinning it.

### That a bare `allowStyling()` is unchanged is the point

`testDefaultGrantsNoLayoutControl` asserts over all 45 layout properties that each is absent from `DEFAULT_WHITELIST` and resolves to `DISALLOWED`, so the boundary fails closed if someone later adds one by reflex. `testLayoutRequiresOptIn` does the same end-to-end through `sanitize`.

### Note on `calc()`

`calc()` now reaches the grid track properties, where it is equally valid CSS. That tripped `testCalcIsScopedToSizingProperties`, a guard from the recent calc work doing its job. I updated its scope inventory and said why; **the security half of that test — calc operands are quantities only, no strings, URLs, colours or nested functions — is untouched**, and none of the newly-reached properties is in DEFAULT.

### On #380 item 1

Worth recording: the reporter's stated "Actual" output shows `display:grid` surviving with only `1fr` stripped. That is not reproducible — the whole declaration is dropped, because neither `display` nor `grid-template-columns` is in DEFAULT. Their proposed one-line `UNIT_TRIE` fix would have changed nothing on its own. `fr` is added here, but it only matters together with the grid properties.

### Verification

Full matrix locally — JDK 11, 17, 21, 25, `mvn verify`, **404 tests** (up from 393), `BUILD SUCCESS` and exit 0 on all four.

Closes #242, closes #234, closes #71, closes #228, closes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
