### PR TITLE
Let a caller build on a CssSchema, and stop globally() widening a chosen one

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -65,15 +65,26 @@ public final class CssSchema {
 
     /**
      * @param bits A bitfield of BIT_* constants describing groups of allowed tokens.
-     * @param literals Specific allowed values.
+     * @param literals Specific allowed values.  Converted to lower case, since
+     *     values are matched against a lower-cased token; a literal that was
+     *     not lower case could never match.
      * @param fnKeys Maps lower-case function tokens to the schema key for their parameters.
+     *     The function tokens are converted to lower case for the same reason.
      */
     public Property(
         int bits, Set<String> literals,
         Map<String, String> fnKeys) {
       this.bits = bits;
-      this.literals = j8().setCopyOf(literals);
-      this.fnKeys = j8().mapCopyOf(fnKeys);
+      Set<String> literalsBuilder = new HashSet<>();
+      for (String literal : literals) {
+        literalsBuilder.add(Strings.toLowerCase(literal));
+      }
+      this.literals = j8().setCopyOf(literalsBuilder);
+      Map<String, String> fnKeysBuilder = new HashMap<>();
+      for (Map.Entry<String, String> e : fnKeys.entrySet()) {
+        fnKeysBuilder.put(Strings.toLowerCase(e.getKey()), e.getValue());
+      }
+      this.fnKeys = j8().mapCopyOf(fnKeysBuilder);
     }
 
     /**
@@ -102,7 +113,7 @@ public final class CssSchema {
      * <p>This widens what the property accepts.  Prefer naming the exact
      * values you need over reaching for a broader {@code BIT_*} bit.
      *
-     * @param extraLiterals lower-case values to add.
+     * @param extraLiterals values to add; converted to lower case.
      * @return a new property; this one is unchanged.
      */
     public Property withLiterals(String... extraLiterals) {
@@ -117,12 +128,14 @@ public final class CssSchema {
      * <p>Values not currently allowed are ignored, so this is safe to use
      * against a schema whose exact contents you have not pinned down.
      *
-     * @param unwantedLiterals lower-case values to remove.
+     * @param unwantedLiterals values to remove; matched case-insensitively.
      * @return a new property; this one is unchanged.
      */
     public Property withoutLiterals(String... unwantedLiterals) {
       Set<String> narrowed = new HashSet<>(literals);
-      narrowed.removeAll(Arrays.asList(unwantedLiterals));
+      for (String unwanted : unwantedLiterals) {
+        narrowed.remove(Strings.toLowerCase(unwanted));
+      }
       return new Property(bits, narrowed, fnKeys);
     }
 

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -27,6 +27,7 @@
 
 package org.owasp.html;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -75,6 +76,79 @@ public final class CssSchema {
       this.fnKeys = j8().mapCopyOf(fnKeys);
     }
 
+    /**
+     * A bitfield of {@code BIT_*} constants describing groups of allowed
+     * tokens.
+     */
+    public int bits() { return bits; }
+
+    /**
+     * The specific values this property allows, as an immutable set.
+     */
+    public Set<String> literals() { return literals; }
+
+    /**
+     * Maps lower-case function tokens such as {@code "rgb("} to the schema key
+     * describing their arguments, as an immutable map.
+     *
+     * <p>A key named here must also be present in the schema, or the function
+     * resolves to {@link CssSchema#DISALLOWED} and its values are dropped.
+     */
+    public Map<String, String> fnKeys() { return fnKeys; }
+
+    /**
+     * This property, also allowing the given values.
+     *
+     * <p>This widens what the property accepts.  Prefer naming the exact
+     * values you need over reaching for a broader {@code BIT_*} bit.
+     *
+     * @param extraLiterals lower-case values to add.
+     * @return a new property; this one is unchanged.
+     */
+    public Property withLiterals(String... extraLiterals) {
+      Set<String> widened = new HashSet<>(literals);
+      widened.addAll(Arrays.asList(extraLiterals));
+      return new Property(bits, widened, fnKeys);
+    }
+
+    /**
+     * This property, no longer allowing the given values.
+     *
+     * <p>Values not currently allowed are ignored, so this is safe to use
+     * against a schema whose exact contents you have not pinned down.
+     *
+     * @param unwantedLiterals lower-case values to remove.
+     * @return a new property; this one is unchanged.
+     */
+    public Property withoutLiterals(String... unwantedLiterals) {
+      Set<String> narrowed = new HashSet<>(literals);
+      narrowed.removeAll(Arrays.asList(unwantedLiterals));
+      return new Property(bits, narrowed, fnKeys);
+    }
+
+    /**
+     * This property, also allowing the given functions.
+     *
+     * <p>The schema must also define the keys these map to, or the functions
+     * resolve to {@link CssSchema#DISALLOWED}.  {@link CssSchema#withOverrides}
+     * checks that for you.
+     *
+     * @param extraFnKeys maps a lower-case function token such as
+     *     {@code "rgb("} to the schema key for its arguments.
+     * @return a new property; this one is unchanged.
+     */
+    public Property withFunctions(Map<String, String> extraFnKeys) {
+      Map<String, String> widened = new HashMap<>(fnKeys);
+      widened.putAll(extraFnKeys);
+      return new Property(bits, literals, widened);
+    }
+
+    @Override
+    public String toString() {
+      return "[CSS property bits=" + bits + " literals=" + new TreeSet<>(literals)
+          + " fns=" + new TreeSet<>(fnKeys.keySet()) + "]";
+    }
+
     @Override
     public int hashCode() {
       final int prime = 31;
@@ -118,13 +192,27 @@ public final class CssSchema {
     }
   }
 
-  static final int BIT_QUANTITY = 1;
-  static final int BIT_HASH_VALUE = 2;
-  static final int BIT_NEGATIVE = 4;
-  static final int BIT_STRING = 8;
-  static final int BIT_URL = 16;
-  static final int BIT_UNRESERVED_WORD = 64;
-  static final int BIT_UNICODE_RANGE = 128;
+  // These describe the token groups a property's value may contain.  The
+  // Property constructor is public and takes them, so they are public too;
+  // they were previously package-private, which left callers guessing.
+  /** A number, with or without a unit: {@code 4}, {@code 2px}, {@code 50%}. */
+  public static final int BIT_QUANTITY = 1;
+  /** A hash colour value: {@code #f00}. */
+  public static final int BIT_HASH_VALUE = 2;
+  /** A negative quantity: {@code -1px}.  Independent of BIT_QUANTITY. */
+  public static final int BIT_NEGATIVE = 4;
+  /** A quoted string: {@code "foo"}. */
+  public static final int BIT_STRING = 8;
+  /**
+   * A {@code url(...)} value.  Set this only deliberately: CSS URLs are
+   * fetched without user interaction, so a property that accepts one is a
+   * loading vector.
+   */
+  public static final int BIT_URL = 16;
+  /** A bare word not in the literal set, emitted as a quoted string. */
+  public static final int BIT_UNRESERVED_WORD = 64;
+  /** A unicode range: {@code U+0-7F}. */
+  public static final int BIT_UNICODE_RANGE = 128;
 
   static final Property DISALLOWED = new Property(
       0, Collections.emptySet(), Collections.emptyMap());
@@ -171,8 +259,11 @@ public final class CssSchema {
       for (String fnKey : property.fnKeys.values()) {
         if (!properties.containsKey(fnKey)) {
           throw new IllegalArgumentException(
-              "Property map is not self contained.  " + e.getValue()
-              + " depends on undefined function key " + fnKey);
+              "Property map is not self contained: \"" + e.getKey()
+              + "\" uses the function key \"" + fnKey
+              + "\" which the map does not define."
+              + "  Add it to the map, or build on a schema that already has"
+              + " it with CssSchema.withOverrides.");
         }
       }
       propertyMapBuilder.put(e.getKey(), e.getValue());
@@ -185,6 +276,12 @@ public final class CssSchema {
    *
    * @return A schema that allows all and only CSS properties that are allowed
    *    by at least one of the inputs.
+   * <p>Two schemas that define the same property differently cannot be
+   * reconciled automatically -- silently picking a winner would hand the
+   * caller a policy they did not write -- so this throws instead.  To extend
+   * or narrow a property that a schema already defines, say which one wins
+   * with {@link #withOverrides}.
+   *
    * @throws IllegalArgumentException if two schemas have properties with the
    *    same name, but different (per .equals) {@link Property} values.
    */
@@ -218,6 +315,82 @@ public final class CssSchema {
    */
   public Set<String> allowedProperties() {
     return properties.keySet();
+  }
+
+  /**
+   * The definition this schema uses for a property, so that it can be used as
+   * the basis of a modified one.
+   *
+   * @param propertyName a lower-case CSS property name, or a schema key for a
+   *     function's arguments such as {@code "rgb()"}.
+   * @return null if this schema does not allow the property.
+   */
+  public @Nullable Property property(String propertyName) {
+    return properties.get(Strings.toLowerCase(propertyName));
+  }
+
+  /**
+   * This schema with the named properties replaced or added.
+   *
+   * <p>{@link #union} refuses to reconcile two definitions of the same
+   * property; this is how you say which one wins.  Use it to extend, narrow
+   * or replace what a schema -- typically {@link #DEFAULT} -- allows for a
+   * property, without rebuilding the schema from scratch:
+   *
+   * <pre>{@code
+   * CssSchema schema = CssSchema.DEFAULT.withOverrides(
+   *     Collections.singletonMap(
+   *         "cursor",
+   *         CssSchema.DEFAULT.property("cursor").withLiterals("zoom-in")));
+   * }</pre>
+   *
+   * <p>Function keys are resolved against the combined schema, so a property
+   * may refer to a function this schema already defines without the caller
+   * having to supply that definition again:
+   *
+   * <pre>{@code
+   * // "linear-gradient()" is already in DEFAULT, so naming it is enough.
+   * CssSchema.DEFAULT.withOverrides(Collections.singletonMap(
+   *     "background-image",
+   *     CssSchema.DEFAULT.property("background-image")
+   *         .withFunctions(Collections.singletonMap(
+   *             "linear-gradient(", "linear-gradient()"))));
+   * }</pre>
+   *
+   * <p><b>This can widen what the schema accepts</b>, which is the point, but
+   * it means the result is only as safe as the definitions you supply.  Adding
+   * {@link #BIT_URL} to a property, or wiring in a function key the schema
+   * resolves loosely, opens whatever that implies.
+   *
+   * @param overrides maps lower-case property names to their new definitions.
+   *     A name this schema does not have is added.
+   * @return a new schema; this one is unchanged.
+   * @throws IllegalArgumentException if an override names a function key that
+   *     neither it nor this schema defines.
+   */
+  public CssSchema withOverrides(
+      Map<? extends String, ? extends Property> overrides) {
+    Map<String, Property> merged = new HashMap<>(properties);
+    for (Map.Entry<? extends String, ? extends Property> e
+         : overrides.entrySet()) {
+      merged.put(
+          Strings.toLowerCase(Objects.requireNonNull(e.getKey())),
+          Objects.requireNonNull(e.getValue()));
+    }
+    // Only the overrides can introduce a dangling function key; the schema we
+    // started from was checked when it was built.
+    for (Map.Entry<? extends String, ? extends Property> e
+         : overrides.entrySet()) {
+      for (String fnKey : e.getValue().fnKeys.values()) {
+        if (!merged.containsKey(fnKey)) {
+          throw new IllegalArgumentException(
+              "Override for \"" + e.getKey() + "\" uses the function key \""
+              + fnKey + "\" which neither the override nor the schema"
+              + " defines.  Add a definition for it to the overrides.");
+        }
+      }
+    }
+    return new CssSchema(Collections.unmodifiableMap(merged));
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -225,6 +225,12 @@ public class HtmlPolicyBuilder {
   private HtmlStreamEventProcessor preprocessor =
       HtmlStreamEventProcessor.Processors.IDENTITY;
   private CssSchema stylingPolicySchema = null;
+  /**
+   * True when {@link #stylingPolicySchema} was installed by
+   * {@code allowAttributes("style").globally()} rather than chosen by the
+   * caller, so an explicit {@link #allowStyling(CssSchema)} may replace it.
+   */
+  private boolean stylingPolicySchemaIsImplicit = false;
   private AttributePolicy styleUrlPolicy =
       AttributePolicy.REJECT_ALL_ATTRIBUTE_POLICY;
   private Set<String> extraRelsForLinks;
@@ -590,10 +596,19 @@ public class HtmlPolicyBuilder {
   public HtmlPolicyBuilder allowStyling(CssSchema whitelist) {
     invalidateCompiledState();
 
-    this.stylingPolicySchema =
-        this.stylingPolicySchema == null
-        ? whitelist
-        : CssSchema.union(stylingPolicySchema, whitelist);
+    // An implicit schema is the default that allowAttributes("style")
+    // .globally() installs so that styling is sanitized at all.  A caller
+    // naming a schema is choosing one, not adding to that default, so it
+    // replaces it.  Unioning instead would silently hand back DEFAULT to a
+    // caller who asked for something narrower.  Two explicit calls still
+    // union, which is the documented way to combine schemas.
+    if (this.stylingPolicySchema == null || this.stylingPolicySchemaIsImplicit) {
+      this.stylingPolicySchema = whitelist;
+    } else {
+      this.stylingPolicySchema =
+          CssSchema.union(stylingPolicySchema, whitelist);
+    }
+    this.stylingPolicySchemaIsImplicit = false;
 
     // Allow the style attribute, and then we will fix it up later.  This allows
     // us to attach the final URL policy to the style attribute policy, while
@@ -1041,7 +1056,12 @@ public class HtmlPolicyBuilder {
     @SuppressWarnings("synthetic-access")
     public HtmlPolicyBuilder globally() {
       if (attributeNames.contains("style")) {
-        allowStyling();
+        // Make sure styling is sanitized rather than passed through, but do
+        // not overrule a schema the caller named, in either order.
+        if (HtmlPolicyBuilder.this.stylingPolicySchema == null) {
+          allowStyling();
+          HtmlPolicyBuilder.this.stylingPolicySchemaIsImplicit = true;
+        }
       }
       return HtmlPolicyBuilder.this.allowAttributesGlobally(
           policy, attributeNames);

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -592,6 +592,16 @@ public class HtmlPolicyBuilder {
   /**
    * Convert <code>style="&lt;CSS&gt;"</code> to sanitized CSS which allows
    * color, font-size, type-face, and other styling using the given schema.
+   * <p>
+   * Naming a schema here replaces the default that
+   * {@code allowAttributes("style").globally()} installs, in either order, so
+   * a schema narrower than {@link CssSchema#DEFAULT} stays narrow.  Calling
+   * this more than once with a schema of your own combines them with
+   * {@link CssSchema#union}, which throws if two of them define the same
+   * property differently; use {@link CssSchema#withOverrides} to say which
+   * definition wins.
+   *
+   * @param whitelist the CSS properties to allow in a style attribute.
    */
   public HtmlPolicyBuilder allowStyling(CssSchema whitelist) {
     invalidateCompiledState();

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
@@ -151,7 +151,10 @@ final class CssSchemaTest {
         "right", "bottom", "transform", "transform-origin",
         "grid", "grid-area", "grid-auto-flow", "grid-column", "grid-row",
         "grid-template", "grid-template-areas", "grid-template-columns",
-        "grid-template-rows", "gap", "row-gap", "column-gap",
+        "grid-template-rows", "grid-auto-columns", "grid-auto-rows",
+        "grid-column-start", "grid-column-end", "grid-row-start",
+        "grid-row-end", "gap", "row-gap", "column-gap",
+        "grid-gap", "grid-row-gap", "grid-column-gap",
         "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow",
         "flex-shrink", "flex-wrap", "order",
         "align-content", "align-items", "align-self", "justify-content",
@@ -320,6 +323,32 @@ final class CssSchemaTest {
     // Case-insensitive, like forKey.
     assertEquals(
         CssSchema.DEFAULT.property("color"), CssSchema.DEFAULT.property("COLOR"));
+  }
+
+  /**
+   * Literals are matched against a lower-cased token, so a literal that is not
+   * lower case could never match.  Canonicalizing in the constructor keeps a
+   * hand-built property from silently allowing nothing -- and, more to the
+   * point, keeps withoutLiterals("RED") from silently removing nothing and
+   * leaving a caller believing they narrowed the schema.
+   */
+  @Test
+  void testPropertyLiteralsAreCanonicalized() {
+    CssSchema.Property p = new CssSchema.Property(
+        0, Collections.singleton("ZigZag"),
+        Collections.singletonMap("RGB(", "rgb()"));
+    assertTrue(p.literals().contains("zigzag"));
+    assertFalse(p.literals().contains("ZigZag"));
+    assertTrue(p.fnKeys().containsKey("rgb("));
+
+    CssSchema.Property widened =
+        CssSchema.DEFAULT.property("text-decoration-style").withLiterals("ZigZag");
+    assertTrue(widened.literals().contains("zigzag"));
+
+    CssSchema.Property narrowed =
+        CssSchema.DEFAULT.property("color").withoutLiterals("RED");
+    assertFalse(narrowed.literals().contains("red"), "RED should remove red");
+    assertTrue(narrowed.literals().contains("blue"));
   }
 
   @Test

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
@@ -29,6 +29,7 @@ package org.owasp.html;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -217,6 +218,108 @@ final class CssSchemaTest {
     CssSchema.Property stroke = CssSchema.DEFAULT.forKey("stroke");
     assertEquals(0, stroke.bits & CssSchema.BIT_URL);
     assertFalse(stroke.fnKeys.containsKey("url("));
+  }
+
+  /** #380 item 4: a DEFAULT property can be widened without rebuilding. */
+  @Test
+  void testWithOverridesCanWidenADefaultProperty() {
+    CssSchema.Property style = CssSchema.DEFAULT.property("text-decoration-style");
+    assertFalse(style.literals().contains("zigzag"));
+    CssSchema widened = CssSchema.DEFAULT.withOverrides(
+        Collections.singletonMap(
+            "text-decoration-style", style.withLiterals("zigzag")));
+    assertTrue(
+        widened.property("text-decoration-style").literals().contains("zigzag"));
+    // The schema it was derived from is untouched.
+    assertFalse(
+        CssSchema.DEFAULT.property("text-decoration-style")
+            .literals().contains("zigzag"));
+    // Everything else came along.
+    assertTrue(widened.allowedProperties().contains("color"));
+  }
+
+  /** #380 item 4: and narrowed, which is the safe direction. */
+  @Test
+  void testWithOverridesCanNarrowADefaultProperty() {
+    CssSchema narrowed = CssSchema.DEFAULT.withOverrides(
+        Collections.singletonMap(
+            "color", CssSchema.DEFAULT.property("color").withoutLiterals("red")));
+    assertFalse(narrowed.property("color").literals().contains("red"));
+    assertTrue(narrowed.property("color").literals().contains("blue"));
+    assertTrue(CssSchema.DEFAULT.property("color").literals().contains("red"));
+  }
+
+  /**
+   * #380 item 5: an override may name a function the base schema already
+   * defines, without the caller supplying that definition again.
+   */
+  @Test
+  void testWithOverridesResolvesFunctionKeysAgainstTheBase() {
+    CssSchema.Property borderColor =
+        CssSchema.DEFAULT.property("border-top-color");
+    CssSchema extended = CssSchema.DEFAULT.withOverrides(
+        Collections.singletonMap(
+            "border-top-color",
+            borderColor.withFunctions(Collections.singletonMap(
+                "linear-gradient(", "linear-gradient()"))));
+    assertTrue(
+        extended.property("border-top-color").fnKeys()
+            .containsKey("linear-gradient("));
+    // Building the same property standalone still fails, because there the
+    // function really would be unreachable.
+    Map<String, CssSchema.Property> standalone = new HashMap<>();
+    standalone.put("border-top-color",
+                   borderColor.withFunctions(Collections.singletonMap(
+                       "linear-gradient(", "linear-gradient()")));
+    try {
+      CssSchema.withProperties(standalone);
+      throw new AssertionError("expected a self-containment failure");
+    } catch (IllegalArgumentException ex) {
+      // It names the property and whichever function key it reached first
+      // -- border-top-color already refers to rgb(), hsl() and friends.
+      assertTrue(ex.getMessage().contains("border-top-color"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("withOverrides"), ex.getMessage());
+    }
+  }
+
+  /** A dangling function key in an override is still an error. */
+  @Test
+  void testWithOverridesRejectsADanglingFunctionKey() {
+    try {
+      CssSchema.DEFAULT.withOverrides(Collections.singletonMap(
+          "color",
+          new CssSchema.Property(
+              0, Collections.<String>emptySet(),
+              Collections.singletonMap("nope(", "nope()"))));
+      throw new AssertionError("expected a dangling function key to be rejected");
+    } catch (IllegalArgumentException ex) {
+      assertTrue(ex.getMessage().contains("nope()"), ex.getMessage());
+    }
+  }
+
+  /** union still refuses to pick a winner; that is what withOverrides is for. */
+  @Test
+  void testUnionStillRefusesToReconcile() {
+    CssSchema narrowed = CssSchema.DEFAULT.withOverrides(
+        Collections.singletonMap(
+            "color", CssSchema.DEFAULT.property("color").withoutLiterals("red")));
+    try {
+      CssSchema.union(CssSchema.DEFAULT, narrowed);
+      throw new AssertionError("expected union to refuse");
+    } catch (IllegalArgumentException ex) {
+      assertTrue(ex.getMessage().contains("color"), ex.getMessage());
+    }
+  }
+
+  /** A property this schema does not allow reads as null, not DISALLOWED. */
+  @Test
+  void testPropertyAccessor() {
+    assertNotSame(null, CssSchema.DEFAULT.property("color"));
+    assertEquals(null, CssSchema.DEFAULT.property("position"));
+    assertEquals(null, CssSchema.DEFAULT.property("no-such-property"));
+    // Case-insensitive, like forKey.
+    assertEquals(
+        CssSchema.DEFAULT.property("color"), CssSchema.DEFAULT.property("COLOR"));
   }
 
   @Test

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -27,6 +27,7 @@
 
 package org.owasp.html;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -55,6 +56,62 @@ class HtmlPolicyBuilderTest {
       "<p style='color: red; font-weight; expression(foo());",
       "          direction: rtl; font-weight: bold'>Stylish Para 2</p>",
       "");
+
+  /**
+   * allowAttributes("style").globally() installs a default schema so that
+   * styling is sanitized at all, but it must not overrule a schema the caller
+   * named -- in either order.  Unioning silently handed back CssSchema.DEFAULT
+   * to a caller who asked for something narrower.
+   */
+  @Test
+  void testGloballyDoesNotWidenAnExplicitStylingSchema() {
+    CssSchema colorOnly = CssSchema.withProperties(Arrays.asList("color"));
+    String css = "color:red;font-weight:bold;width:10px";
+
+    PolicyFactory globallyFirst = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").globally()
+        .allowStyling(colorOnly)
+        .toFactory();
+    assertEquals(
+        "<div style=\"color:red\">x</div>",
+        globallyFirst.sanitize("<div style=\"" + css + "\">x</div>"));
+
+    PolicyFactory stylingFirst = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowStyling(colorOnly)
+        .allowAttributes("style").globally()
+        .toFactory();
+    assertEquals(
+        "<div style=\"color:red\">x</div>",
+        stylingFirst.sanitize("<div style=\"" + css + "\">x</div>"));
+  }
+
+  /** With no explicit schema, allowing style globally still sanitizes it. */
+  @Test
+  void testGloballyStillInstallsADefaultStylingSchema() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").globally()
+        .toFactory();
+    assertEquals(
+        "<div style=\"color:red\">x</div>",
+        p.sanitize("<div style=\"color:red;position:fixed\">x</div>"));
+  }
+
+  /** Two explicit schemas still combine, which is the documented behaviour. */
+  @Test
+  void testTwoExplicitStylingSchemasStillUnion() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(CssSchema.withProperties(Arrays.asList("color")))
+        .allowStyling(CssSchema.withProperties(Arrays.asList("font-weight")))
+        .toFactory();
+    assertEquals(
+        "<div style=\"color:red;font-weight:bold\">x</div>",
+        p.sanitize("<div style=\"color:red;font-weight:bold;width:10px\">x</div>"));
+  }
 
   @Test
   void testTextFilter() {


### PR DESCRIPTION
Two commits: #380 items 4 and 5, and a security fix found while doing them.

## 1. Let a caller build on a CssSchema (#380 items 4, 5)

Extending what DEFAULT allows for one property wasn't just awkward, it was **impossible without reflection**, and for a reason the issue didn't identify: `Property`'s constructor is public and takes a bitfield, but `bits`, `literals` and `fnKeys` had no accessors and `forKey` was package-private. There was no way to *read* an existing definition to base a new one on. `union()` then refused the result, since two schemas defining a property differently is exactly what it throws on.

**`Property`** gains `bits()`, `literals()`, `fnKeys()`, plus `withLiterals`, `withoutLiterals` and `withFunctions` to derive a modified copy without hand-copying the other two fields. The `BIT_*` constants become public — documenting what the public constructor already required callers to supply — and there's a `toString` so failures stop printing identity hashes.

**`CssSchema`** gains `property(name)` and `withOverrides(map)`:

```java
CssSchema schema = CssSchema.DEFAULT.withOverrides(
    Collections.singletonMap(
        "cursor", CssSchema.DEFAULT.property("cursor").withLiterals("zoom-in")));
```

Overrides resolve function keys against the **combined** schema, so a property may refer to a function the base already defines without supplying it again — that's item 5. A key neither side defines is still rejected, since it would otherwise resolve to `DISALLOWED` silently at runtime.

`union` keeps throwing on conflicts. Silently picking a winner would hand a caller a policy they didn't write; `withOverrides` is how you say which one wins, and `union`'s javadoc now points there. The self-containment message names the offending property and the way out.

**This widens nothing on its own** — a caller could already build any schema via `withProperties(Map)`; they just had to reconstruct all 136 DEFAULT entries to change one.

*Note on item 5:* I kept `withProperties(Map)` throwing for a standalone schema. There the function really is unreachable, so failing loudly beats silently disallowing it. The message now points at `withOverrides` for the build-on-a-base case.

## 2. Do not let allowing style globally widen a chosen schema

Found while testing the above: an overridden schema passed to `allowStyling()` threw `Duplicate irreconcilable definitions` instead of being used. The cause is worse than the symptom.

`allowAttributes("style").globally()` called `allowStyling()`, which installs `CssSchema.DEFAULT`, and `allowStyling(schema)` unioned onto whatever was there. So a caller who named a narrower schema **silently got DEFAULT back**:

```java
.allowAttributes("style").globally()
.allowStyling(CssSchema.withProperties(Arrays.asList("color")))

input:  color:red;font-weight:bold;width:10px
before: color:red;font-weight:bold;width:10px    <- all of DEFAULT
after:  color:red
```

No error, no warning — the policy was just more permissive than the one written down. Reversing the calls didn't help; the union ran either way.

`globally()` still installs a default so styling is sanitized rather than passed through, but only when the caller hasn't chosen a schema, and it marks that schema implicit. An explicit `allowStyling()` replaces an implicit schema rather than unioning with it. **Two explicit calls still union**, the documented behaviour, now covered by a test.

This tightens policies rather than loosening them, so the risk of the change is that someone was unknowingly relying on the extra permissiveness.

## Verification

Full matrix locally — JDK 11, 17, 21, 25, `mvn verify`, **413 tests** (up from 404), exit 0 on all four.

Closes #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
