### PR TITLE
Keep text past the nesting limit, and report the tags it drops

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -82,7 +82,9 @@ public final class HtmlChangeReporter<T> {
    */
   public HtmlSanitizer.Policy getWrappedPolicy() { return input; }
 
-  private static final class InputChannel<T> implements HtmlSanitizer.Policy {
+  private static final class InputChannel<T>
+      implements HtmlSanitizer.Policy,
+                 TagBalancingHtmlStreamEventReceiver.NestingLimitListener {
     HtmlStreamEventReceiver policy;
     final OutputChannel output;
     final T context;
@@ -94,6 +96,15 @@ public final class HtmlChangeReporter<T> {
       this.output = output;
       this.context = context;
       this.listener = listener;
+    }
+
+    /**
+     * The tag balancer sits upstream of this channel, so a tag it drops for
+     * exceeding the nesting limit never reaches the policy and would otherwise
+     * go unreported.  It tells us directly instead.
+     */
+    public void nestingLimitReached(String elementName) {
+      listener.discardedTag(context, elementName);
     }
 
     public void openDocument() {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -57,6 +57,44 @@ public class TagBalancingHtmlStreamEventReceiver
   private static final boolean DEBUG = false;
 
   /**
+   * Receives notice of tags dropped because the output would otherwise nest
+   * deeper than {@link #setNestingLimit}.
+   *
+   * <p>This exists because the tag balancer runs upstream of the policy, and
+   * so upstream of {@link HtmlChangeReporter}, which notices a discarded tag
+   * by watching for one that goes into the policy and does not come out.  A
+   * tag the balancer drops never reaches the policy at all, so without this it
+   * is invisible to a listener.
+   */
+  interface NestingLimitListener {
+    /** @param elementName the tag that was not emitted. */
+    void nestingLimitReached(String elementName);
+  }
+
+  /**
+   * How many elements whose content the policy would suppress -- {@code
+   * <script>}, {@code <style>}, {@code <iframe>} and friends -- have been
+   * dropped for exceeding the nesting limit and not yet closed.
+   *
+   * <p>The policy decides to skip such an element's text when it sees the
+   * element's start tag.  A tag this receiver drops never reaches the policy,
+   * so the policy would render the content as ordinary text.  Counting them
+   * here keeps that content suppressed.
+   */
+  private int droppedSkippableDepth;
+
+  private static boolean contentIsSkippable(String canonElementName) {
+    return ElementAndAttributePolicyBasedSanitizerPolicy
+        .SKIPPABLE_ELEMENT_CONTENT.contains(canonElementName);
+  }
+
+  private void reportDroppedByNestingLimit(String elementName) {
+    if (underlying instanceof NestingLimitListener) {
+      ((NestingLimitListener) underlying).nestingLimitReached(elementName);
+    }
+  }
+
+  /**
    * @param underlying An event receiver that should receive a stream of
    *     balanced events that is as close as possible to the stream of events
    *     received by this.
@@ -77,6 +115,7 @@ public class TagBalancingHtmlStreamEventReceiver
   }
 
   public void openDocument() {
+    droppedSkippableDepth = 0;
     underlying.openDocument();
   }
 
@@ -102,6 +141,9 @@ public class TagBalancingHtmlStreamEventReceiver
     if (elIndex == UNRECOGNIZED_TAG) {
       if (openElements.size() < nestingLimit) {
         underlying.openTag(elementName, attrs);
+      } else {
+        if (contentIsSkippable(canonElementName)) { ++droppedSkippableDepth; }
+        reportDroppedByNestingLimit(elementName);
       }
       return;
     }
@@ -113,6 +155,9 @@ public class TagBalancingHtmlStreamEventReceiver
       if (!HtmlTextEscapingMode.isVoidElement(canonElementName)) {
         openElements.add(elIndex);
       }
+    } else {
+      if (contentIsSkippable(canonElementName)) { ++droppedSkippableDepth; }
+      reportDroppedByNestingLimit(METADATA.canonNameForIndex(elIndex));
     }
   }
 
@@ -249,6 +294,10 @@ public class TagBalancingHtmlStreamEventReceiver
     }
     String canonElementName = HtmlLexer.canonicalElementName(elementName);
 
+    if (droppedSkippableDepth != 0 && contentIsSkippable(canonElementName)) {
+      --droppedSkippableDepth;
+    }
+
     int elIndex = METADATA.indexForName(canonElementName);
     if (elIndex == UNRECOGNIZED_TAG) {  // Allow unrecognized end tags through.
       if (openElements.size() < nestingLimit) {
@@ -356,7 +405,18 @@ public class TagBalancingHtmlStreamEventReceiver
       prepareForContent(HtmlElementTables.TEXT_NODE);
     }
 
-    if (openElements.size() < nestingLimit) {
+    // The nesting limit bounds how deep the *output* nests; it is not a
+    // licence to drop content.  Suppressing the text here meant that markup
+    // nested past the limit came out as a well-formed stack of empty elements
+    // with the author's text deleted from the middle of it, silently.  Emit
+    // the text and let it flatten into the deepest element we did open, which
+    // is what a browser's own depth limit does.  Text is escaped downstream,
+    // so it cannot become markup.
+    //
+    // The exception is content the policy would have suppressed had it seen
+    // the start tag we dropped: a <script> body must not resurface as visible
+    // text just because it sat below the limit.
+    if (droppedSkippableDepth == 0) {
       underlying.text(text);
     }
   }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -27,18 +27,124 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
 class HtmlSanitizerTest {
+
+  private static String nest(String inner, int depth) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < depth; ++i) { sb.append("<div>"); }
+    sb.append(inner);
+    for (int i = 0; i < depth; ++i) { sb.append("</div>"); }
+    return sb.toString();
+  }
+
+  /**
+   * Issue #205.  The nesting limit bounds how deep the output nests; it is not
+   * a licence to delete content.  Markup nested past the limit used to come
+   * out as a well-formed stack of empty elements with the author's text
+   * removed from the middle, silently.  It should flatten instead.
+   */
+  @Test
+  void testTextSurvivesPastTheNestingLimit() {
+    PolicyFactory p = new HtmlPolicyBuilder().allowElements("div").toFactory();
+    for (int depth : new int[] { 100, 255, 256, 257, 300, 1000 }) {
+      assertTrue(
+          p.sanitize(nest("MARKER", depth)).contains("MARKER"),
+          "text should survive at depth " + depth);
+    }
+    // The output itself stays bounded; it is the text that is kept.
+    String deep = p.sanitize(nest("MARKER", 1000));
+    assertEquals(256, deep.split("<div>", -1).length - 1);
+    assertEquals(256, deep.split("</div>", -1).length - 1);
+  }
+
+  /**
+   * Issue #205.  Text kept past the limit is still text: it is escaped on the
+   * way out and cannot reintroduce markup.
+   */
+  @Test
+  void testTextKeptPastTheNestingLimitIsEscaped() {
+    PolicyFactory p = new HtmlPolicyBuilder().allowElements("div").toFactory();
+    String out = p.sanitize(nest("1<2 & <img src=x onerror=alert(1)>", 300));
+    assertTrue(out.contains("1&lt;2"), out);
+    assertFalse(out.contains("<img"), out);
+    assertFalse(out.contains("onerror"), out);
+  }
+
+  /**
+   * Keeping text past the limit must not resurface content the policy would
+   * have suppressed.  The policy decides to skip a script or style body when
+   * it sees the start tag; a tag the balancer drops never reaches it, so the
+   * balancer has to keep that content suppressed itself.
+   */
+  @Test
+  void testSuppressedContentDoesNotResurfacePastTheNestingLimit() {
+    PolicyFactory p = new HtmlPolicyBuilder().allowElements("div").toFactory();
+    for (String elementName : new String[] {
+        "script", "style", "noscript", "nostyle", "noembed", "noframes",
+        "iframe", "object", "title" }) {
+      String out = p.sanitize(
+          nest("<" + elementName + ">SECRET</" + elementName + ">", 300));
+      assertFalse(
+          out.contains("SECRET"),
+          elementName + " content should stay suppressed: " + out);
+    }
+    // Unbalanced input fails closed rather than open.
+    assertFalse(p.sanitize(nest("<script>SECRET", 300)).contains("SECRET"));
+    assertFalse(
+        p.sanitize(nest("<script><script>SECRET</script></script>", 300))
+            .contains("SECRET"));
+    // But ordinary text outside the suppressed element still comes through.
+    assertTrue(
+        p.sanitize(nest("<script>S</script>VISIBLE", 300)).contains("VISIBLE"));
+  }
+
+  /**
+   * Issue #205.  A tag dropped for exceeding the nesting limit is discarded
+   * from the input, so a listener should hear about it.  The tag balancer runs
+   * upstream of the policy, and so upstream of HtmlChangeReporter, so this
+   * previously went unreported and the loss was undetectable.
+   */
+  @Test
+  void testNestingLimitReportsDiscardedTags() {
+    final List<String> discarded = new ArrayList<>();
+    HtmlChangeListener<Object> listener = new HtmlChangeListener<Object>() {
+      public void discardedTag(@Nullable Object context, String elementName) {
+        discarded.add(elementName);
+      }
+      public void discardedAttributes(
+          @Nullable Object context, String tagName, String... attributeNames) {
+        // Not under test.
+      }
+    };
+    PolicyFactory p = new HtmlPolicyBuilder().allowElements("div").toFactory();
+
+    String out = p.sanitize(nest("MARKER", 300), listener, null);
+    assertTrue(out.contains("MARKER"));
+    // 300 requested, 256 emitted, so 44 were dropped by the limit.
+    assertEquals(44, discarded.size(), discarded.toString());
+    for (String name : discarded) {
+      assertEquals("div", name);
+    }
+
+    // Nothing to report when the input stays within the limit.
+    discarded.clear();
+    p.sanitize(nest("MARKER", 10), listener, null);
+    assertEquals(Arrays.asList(), discarded);
+  }
 
   @Test
   void testEmpty() {


### PR DESCRIPTION
#205 asks to make the 256-element nesting limit configurable. **The limit isn't really the problem** — past it, content was *deleted* rather than flattened, and silently, so raising it would only move the cliff.

```
300 nested divs around some text
before: 256 open tags, 256 close tags, and the text gone
after:  256 open tags, 256 close tags, and the text between them
```

That's exactly what the reporter described — *"sanitizer removes the tags which actually has the content"* — and why `setNestingLimit` didn't answer them.

The limit is a **browser-fidelity** number, not a safety one. Its own comment derives 256 from Opera's observed table nesting (lower bound ~90) and WebKit's `defaultMaximumHTMLParserDOMTreeDepth` of 512. And depth limits in parsers cap tree *depth*, not content: I ran 300 nested divs through validator.nu and it keeps both the full depth and the text. So the old behaviour diverged from the parsers the number was chosen to imitate, in the destructive direction.

## 1. Text survives

`text()` now forwards unconditionally — **with one exception that took a security regression to find.**

The tag balancer runs *upstream* of the policy, and the policy decides to skip a `<script>` or `<style>` body when it sees that element's start tag. A tag the balancer drops never reaches the policy. So forwarding text unconditionally made script and style bodies resurface as **visible text** past the limit:

```
300 nested divs around <script>alert(1)</script>
naive fix: "alert(1)" appears in the output as text
```

Escaped, so not markup and not XSS — but content the policy had been told to drop, and a way to smuggle attacker-controlled text into a page. The balancer now counts the skippable elements it drops and keeps their text suppressed until they close, failing closed on unbalanced input. Verified against baseline across all of `script`, `style`, `noscript`, `nostyle`, `noembed`, `noframes`, `iframe`, `object`, `title`.

(`frame`/`frameset` leak their content at depth both before and after this change — they can't nest inside `div`, so the balancer unwinds and the text is never deep. Pre-existing and unrelated; not touched here.)

## 2. Dropped tags are reported

`HtmlChangeReporter` notices a discarded tag by watching for one that goes *into* the policy and doesn't come *out*. A tag the balancer drops never goes in, so this was invisible — a caller couldn't detect the loss at all. The balancer now tells the reporter directly through a package-private interface. 300 nested divs reports exactly 44 discarded `div` tags. **No public API changes.**

## Not addressed

Making the limit configurable, which is what the issue literally asks for. With content no longer lost, that's a fidelity preference rather than a correctness fix, and worth deciding separately — including whether to cap how high it can go.

## Verification

Notably, **no existing test pinned the text-dropping behaviour**, which suggests it was never intentional. Full matrix locally — JDK 11, 17, 21, 25, `mvn verify`, **418 tests** (up from 414), exit 0 on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
