### PR TITLE
Make joining style policies narrow, so and() intersects as documented

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -322,6 +323,64 @@ public final class CssSchema {
   }
 
   /**
+   * A schema that allows only what every input schema allows.
+   *
+   * <p>Where the inputs define the same property differently, the definitions
+   * are themselves intersected: a token group is kept only if every input
+   * allows it, a value only if every input lists it, and a function only if
+   * every input maps it to the same argument schema.  So the result is never
+   * wider than any input, whatever the inputs disagree about -- unlike
+   * {@link #union}, which refuses to reconcile a disagreement at all.
+   *
+   * <p>This is what {@link PolicyFactory#and} needs: combining two policies
+   * narrows what either allows on its own.
+   *
+   * @param cssSchemas the schemas to intersect.  Intersecting none of them is
+   *     meaningless rather than universal, so at least one is required.
+   * @return a schema that allows a CSS property only if all of the inputs do.
+   */
+  public static CssSchema intersection(CssSchema... cssSchemas) {
+    if (cssSchemas.length == 0) {
+      throw new IllegalArgumentException("No schemas to intersect");
+    }
+    if (cssSchemas.length == 1) { return cssSchemas[0]; }
+    Map<String, Property> propertyMapBuilder =
+        new LinkedHashMap<>(cssSchemas[0].properties);
+    for (int i = 1; i < cssSchemas.length; ++i) {
+      Map<String, Property> other = cssSchemas[i].properties;
+      Iterator<Map.Entry<String, Property>> it =
+          propertyMapBuilder.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry<String, Property> e = it.next();
+        Property narrower = other.get(e.getKey());
+        if (narrower == null) {
+          it.remove();
+        } else {
+          e.setValue(intersectProperties(e.getValue(), narrower));
+        }
+      }
+    }
+    return new CssSchema(Collections.unmodifiableMap(propertyMapBuilder));
+  }
+
+  /** The definition allowing only what both of the inputs allow. */
+  private static Property intersectProperties(Property a, Property b) {
+    if (a.equals(b)) { return a; }
+    Set<String> literals = new HashSet<>(a.literals);
+    literals.retainAll(b.literals);
+    Map<String, String> fnKeys = new HashMap<>();
+    for (Map.Entry<String, String> e : a.fnKeys.entrySet()) {
+      // Keep a function only where both sides send its arguments to the same
+      // schema key; two different argument schemas cannot be reconciled here
+      // without inventing a third, so drop it.
+      if (e.getValue().equals(b.fnKeys.get(e.getKey()))) {
+        fnKeys.put(e.getKey(), e.getValue());
+      }
+    }
+    return new Property(a.bits & b.bits, literals, fnKeys);
+  }
+
+  /**
    * The set of CSS properties allowed by this schema.
    *
    * @return an immutable set.
@@ -470,8 +529,11 @@ public final class CssSchema {
    * }</pre>
    *
    * <p>If an element also gets a {@code style} policy from
-   * {@link HtmlPolicyBuilder#allowStyling()}, the two are joined: the schemas
-   * union, and both rewriters run in turn, so either one can drop a URL.
+   * {@link HtmlPolicyBuilder#allowStyling()}, the two are joined, and joining
+   * narrows: the schemas intersect, and both rewriters run in turn, so either
+   * one can drop a URL.  A policy attached here therefore restricts the
+   * element it is attached to; it cannot grant it a property the global
+   * schema withholds.
    *
    * @param urlRewriter receives the decoded content of a {@code url(...)}
    *     value and returns the URL to use, or {@code null} or the empty string

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
@@ -281,8 +281,12 @@ final class StylingPolicy implements JoinableAttributePolicy {
       Function<String, String> urlRewriter = identity;
       for (JoinableAttributePolicy p : toJoin) {
         StylingPolicy sp = (StylingPolicy) p;
+        // Joining narrows: a value has to satisfy every policy being joined,
+        // which is how every other joined attribute policy behaves and what
+        // PolicyFactory.and promises.  Unioning here let a.and(b) allow
+        // properties that neither a nor b allowed on its own.
         cssSchema = cssSchema == null
-            ? sp.cssSchema : CssSchema.union(cssSchema, sp.cssSchema);
+            ? sp.cssSchema : CssSchema.intersection(cssSchema, sp.cssSchema);
         urlRewriter = urlRewriter.equals(identity)
             || urlRewriter.equals(sp.urlRewriter)
             ? sp.urlRewriter

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaAttributePolicyTest.java
@@ -154,7 +154,9 @@ final class CssSchemaAttributePolicyTest {
 
   /**
    * A per-element schema and a global {@code allowStyling} schema join to the
-   * union of the two, on that element only.
+   * intersection of the two, on that element only.  Joining narrows, as it
+   * does for every other attribute policy, so attaching a per-element schema
+   * restricts that element rather than granting it extra properties.
    */
   @Test
   void testJoinsWithGlobalAllowStyling() {
@@ -166,18 +168,34 @@ final class CssSchemaAttributePolicyTest {
             .onElements("span")
         .toFactory();
 
+    // TEXT_SCHEMA and BOX_SCHEMA have no property in common, so a span that
+    // is subject to both keeps no style at all -- and a span left with no
+    // attributes is dropped, since span is in DEFAULT_SKIP_IF_EMPTY.
     assertEquals(
-        "<span style=\"color:red;width:10px\">x</span>",
+        "x",
         policy.sanitize("<span style=\"color: red; width: 10px\">x</span>"));
+    // Other elements see the global schema alone.
     assertEquals(
         "<div style=\"width:10px\">x</div>",
         policy.sanitize("<div style=\"color: red; width: 10px\">x</div>"));
+
+    // Where the two schemas do overlap, the shared property survives.
+    PolicyFactory overlapping = new HtmlPolicyBuilder()
+        .allowElements("span")
+        .allowStyling(CssSchema.withProperties(Arrays.asList("color", "width")))
+        .allowAttributes("style")
+            .matching(CssSchema.withProperties(Arrays.asList("color"))
+                          .toAttributePolicy())
+            .onElements("span")
+        .toFactory();
+    assertEquals(
+        "<span style=\"color:red\">x</span>",
+        overlapping.sanitize("<span style=\"color: red; width: 10px\">x</span>"));
   }
 
   /**
-   * Joining takes the union of the schemas but the intersection of the URL
-   * policies, so a URL-dropping per-element policy is not widened by a
-   * permissive global one.
+   * Joining intersects the schemas and runs both URL rewriters in turn, so a
+   * URL-dropping per-element policy is not widened by a permissive global one.
    */
   @Test
   void testJoiningDoesNotWidenUrlPolicy() {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/CssSchemaTest.java
@@ -351,6 +351,64 @@ final class CssSchemaTest {
     assertTrue(narrowed.literals().contains("blue"));
   }
 
+  /** #423: combining policies must narrow, never widen. */
+  @Test
+  void testIntersection() {
+    CssSchema color = CssSchema.withProperties(Arrays.asList("color"));
+    CssSchema width = CssSchema.withProperties(Arrays.asList("width"));
+    CssSchema both = CssSchema.withProperties(Arrays.asList("color", "width"));
+
+    assertEquals(
+        Collections.emptySet(),
+        CssSchema.intersection(color, width).allowedProperties());
+    assertEquals(
+        Collections.singleton("color"),
+        CssSchema.intersection(both, color).allowedProperties());
+    assertEquals(
+        Collections.singleton("color"),
+        CssSchema.intersection(color, both).allowedProperties());
+    // A single schema intersects to itself; none of them is an error rather
+    // than the universal schema.
+    assertSame(color, CssSchema.intersection(color));
+    try {
+      CssSchema.intersection();
+      throw new AssertionError("expected intersecting nothing to be rejected");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  /**
+   * Where two schemas define the same property differently, the definitions
+   * intersect too, so the result is never wider than either input.
+   */
+  @Test
+  void testIntersectionNarrowsAConflictingProperty() {
+    CssSchema.Property colorProp = CssSchema.DEFAULT.property("color");
+    CssSchema noRed = CssSchema.DEFAULT.withOverrides(
+        Collections.singletonMap("color", colorProp.withoutLiterals("red")));
+    CssSchema noBlue = CssSchema.DEFAULT.withOverrides(
+        Collections.singletonMap("color", colorProp.withoutLiterals("blue")));
+
+    CssSchema.Property merged =
+        CssSchema.intersection(noRed, noBlue).property("color");
+    assertFalse(merged.literals().contains("red"));
+    assertFalse(merged.literals().contains("blue"));
+    assertTrue(merged.literals().contains("green"));
+
+    // A function survives only where both sides agree on its argument schema.
+    CssSchema noRgb = CssSchema.DEFAULT.withOverrides(
+        Collections.singletonMap(
+            "color",
+            new CssSchema.Property(
+                colorProp.bits(), colorProp.literals(),
+                Collections.<String, String>emptyMap())));
+    assertTrue(CssSchema.DEFAULT.property("color").fnKeys().containsKey("rgb("));
+    assertFalse(
+        CssSchema.intersection(CssSchema.DEFAULT, noRgb)
+            .property("color").fnKeys().containsKey("rgb("));
+  }
+
   @Test
   void testCustom() {
     CssSchema custom = CssSchema.union(

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
@@ -38,6 +38,65 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class PolicyFactoryTest {
 
+  /**
+   * Issue #423.  and() is documented to intersect policies where they overlap.
+   * For the style attribute it used to union the CSS schemas, so combining two
+   * factories allowed properties that neither one allowed on its own.
+   */
+  @Test
+  void testAndIntersectsCssSchemas() {
+    String css = "color: red; width: 10px";
+    String html = "<div style=\"" + css + "\">x</div>";
+
+    PolicyFactory colorOnly = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(CssSchema.withProperties(Arrays.asList("color")))
+        .toFactory();
+    PolicyFactory widthOnly = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(CssSchema.withProperties(Arrays.asList("width")))
+        .toFactory();
+    PolicyFactory both = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(CssSchema.withProperties(Arrays.asList("color", "width")))
+        .toFactory();
+
+    assertEquals("<div style=\"color:red\">x</div>", colorOnly.sanitize(html));
+    assertEquals("<div style=\"width:10px\">x</div>", widthOnly.sanitize(html));
+
+    // Neither allows the other's property, so together they allow neither.
+    assertEquals("<div>x</div>", colorOnly.and(widthOnly).sanitize(html));
+    assertEquals("<div>x</div>", widthOnly.and(colorOnly).sanitize(html));
+
+    // Where they overlap, the shared property survives, and the order of the
+    // operands does not matter.
+    assertEquals(
+        "<div style=\"color:red\">x</div>", both.and(colorOnly).sanitize(html));
+    assertEquals(
+        "<div style=\"color:red\">x</div>", colorOnly.and(both).sanitize(html));
+  }
+
+  /**
+   * Two allowStyling calls on one builder still accumulate: the builder unions
+   * them into a single schema before any joining happens, so making the join
+   * narrow does not change this.
+   */
+  @Test
+  void testTwoAllowStylingCallsStillAccumulate() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(CssSchema.withProperties(Arrays.asList("color")))
+        .allowStyling(CssSchema.withProperties(Arrays.asList("width")))
+        .toFactory();
+    assertEquals(
+        "<div style=\"color:red;width:10px\">x</div>",
+        p.sanitize("<div style=\"color: red; width: 10px\">x</div>"));
+  }
+
   @Test
   void testAnd() {
     // Filters srcset to only contain URLs with the substring "foo"


### PR DESCRIPTION
`PolicyFactory.and` is documented to "allow the union of the grants, and **intersect** policies where they overlap." For the `style` attribute it unioned the CSS schemas instead:

```java
colorOnly.and(widthOnly).sanitize("<div style='color:red;width:10px'>x</div>")
//  before: <div style="color:red;width:10px">x</div>   <- neither input allows both
//  after:  <div>x</div>
```

Wrong direction for a method whose job is to combine two policies into a stricter one — and `StylingPolicy` was the only joined attribute policy that widened. Every other one chains, so a value has to satisfy all of them.

## The fix

`StylingPolicyJoinStrategy` now intersects, via a new `CssSchema.intersection`. Where two schemas define the same property differently, the *definitions* intersect too: token groups by bitwise and, values by set intersection, and a function kept only where both sides send its arguments to the same schema key. So the result is never wider than any input. `union` throws on such a disagreement; `intersection` never has to, since narrowing is always well-defined.

## The blocker in the issue turned out not to exist

#423 predicted this would be hard because making the join intersect "would silently change what two `allowStyling` calls on one builder mean." It doesn't. `HtmlPolicyBuilder.allowStyling` unions the schemas *itself* and stores one, so a single builder only ever produces one `StylingPolicy` and the join strategy never sees that case. Verified and now pinned by `testTwoAllowStylingCallsStillAccumulate`:

```
allowStyling(color).allowStyling(width)  ->  color:red;width:10px   (unchanged)
```

So no special-casing inside `and()` was needed — one rule covers everything.

## One deliberate behaviour change

This changes the per-element case from #422: a schema attached with `matching(schema.toAttributePolicy())` alongside a global `allowStyling()` now **narrows** that element instead of widening it.

That's the better rule. It's what `matching()` means everywhere else in the builder, and the old behaviour meant attaching a restrictive-*looking* per-element schema made that element accept *more* than its neighbours — the same footgun shape as the `globally()` bug fixed in #428. The #422 test and the `toAttributePolicy` javadoc are updated to match.

## Verification

Full matrix locally — JDK 11, 17, 21, 25, `mvn verify`, **422 tests** (up from 418), exit 0 on all four.

Closes #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
