### PR TITLE
Fix font-family round-tripping, generic families, and name casing

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/CssSchema.java
@@ -752,7 +752,15 @@ public final class CssSchema {
         "caption", "icon", "menu", "message-box", "small-caption",
         "status-bar");
     Set<String> fontLiterals3 = j8().setOf(
-        "cursive", "fantasy", "monospace", "sans-serif", "serif");
+        "cursive", "fantasy", "monospace", "sans-serif", "serif",
+        // The rest of the generic families from CSS Fonts.  A generic family
+        // is a keyword, so it must not be quoted; without these they fell
+        // through to the quoted-name path and stopped working.
+        "system-ui", "ui-serif", "ui-sans-serif", "ui-monospace", "ui-rounded",
+        "math", "emoji", "fangsong",
+        // Not in the spec, but keyword-like in practice and broken by
+        // quoting, so treated the same way.
+        "-apple-system");
     Set<String> fontLiterals4 = j8().setOf("italic", "oblique");
     Set<String> fontLiterals5 = j8().setOf(
         ",", "/", "inherit", "medium", "normal", "small-caps");

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
@@ -151,8 +151,11 @@ final class StylingPolicy implements JoinableAttributePolicy {
         if ((meaning & (meaning - 1)) == 0) {  // meaning is unambiguous
           if (meaning == CssSchema.BIT_UNRESERVED_WORD
               && token.length() > 2
-              && isAlphanumericOrSpaceOrHyphen(token, 1, token.length() - 1)) {
-            emitToken(Strings.toLowerCase(token));
+              && isSafeQuotedIdentifier(token, 1, token.length() - 1)) {
+            // Emit as written: a font name is a name, not a keyword, so its
+            // case matters to the reader even though CSS matches it
+            // case-insensitively.
+            emitToken(token);
           } else if (meaning == CssSchema.BIT_URL) {
             // convert to a URL token and hand-off to the appropriate method
             sanitizeAndAppendUrl(CssGrammar.cssContent(token));
@@ -188,7 +191,13 @@ final class StylingPolicy implements JoinableAttributePolicy {
           emitToken("!important");
         } else if (cssProperty.literals.contains(token)) {
           emitToken(token);
-        } else if ((cssProperty.bits & IDENT_TO_STRING) == IDENT_TO_STRING) {
+        } else if ((cssProperty.bits & IDENT_TO_STRING) == IDENT_TO_STRING
+                   && isSafeQuotedIdentifier(
+                       uncanonToken, 0, uncanonToken.length())) {
+          // Same test as the quoted path.  This path had none at all, so a
+          // bare name could carry a format character -- a bidi override, say
+          // -- into the output, and a name the quoted path would reject
+          // survived one pass and vanished on the next.
           if (!inQuotedIdents) {
             inQuotedIdents = true;
             if (hasTokens) { sanitizedCss.append(' '); }
@@ -197,7 +206,9 @@ final class StylingPolicy implements JoinableAttributePolicy {
           } else {
             sanitizedCss.append(' ');
           }
-          sanitizedCss.append(Strings.toLowerCase(token));
+          // As above: emit the name as the author wrote it.  Matching against
+          // the schema is case-insensitive, but the output is a name.
+          sanitizedCss.append(uncanonToken);
         }
         lastToken = token;
       }
@@ -228,7 +239,26 @@ final class StylingPolicy implements JoinableAttributePolicy {
     return sanitizedCss.length() == 0 ? null : sanitizedCss.toString();
   }
 
-  static boolean isAlphanumericOrSpaceOrHyphen(
+  /**
+   * True if the given range of a quoted token can be re-emitted between single
+   * quotes without any further escaping.
+   *
+   * <p>This is deliberately a small set.  The CSS lexer normalizes a string's
+   * contents, so a quote or a backslash reaches us already escaped -- {@code
+   * 'it\27s'}, {@code 'a\5c b'} -- and re-emitting an escape verbatim would
+   * mean reasoning about escape parity to be sure the closing quote is still
+   * the closing quote.  Rejecting the backslash outright avoids that question
+   * entirely, at the cost of dropping the rare font name that needs one.
+   *
+   * <p>What it does allow is everything a font name legitimately contains and
+   * that carries no meaning inside a CSS string: letters and digits in any
+   * script, spaces, and the hyphen, underscore and period that appear in names
+   * like {@code Foo_Bar} and {@code Helvetica Neue LT Std.55 Roman}.  The
+   * underscore matters in practice because Word emits font names containing
+   * one, and because the unquoted path already accepted it -- so a name would
+   * survive sanitization once and be dropped on the way back in.
+   */
+  static boolean isSafeQuotedIdentifier(
       String token, int start, int end) {
     for (int i = start; i < end; ++i) {
       char ch = token.charAt(i);
@@ -236,13 +266,18 @@ final class StylingPolicy implements JoinableAttributePolicy {
         if (ch != '\t' && ch != ' ') {
           return false;
         }
-      } else {
+      } else if (ch < 0x80) {
         int chLower = ch | 32;
         if (!(('0' <= chLower && chLower <= '9')
               || ('a' <= chLower && chLower <= 'z')
-              || ('-' == ch))) {
+              || '-' == ch || '_' == ch || '.' == ch)) {
           return false;
         }
+      } else if (!Character.isLetterOrDigit(ch)) {
+        // Non-ASCII font names are ordinary -- CJK families, for instance --
+        // but only letters and digits, so that format and control characters
+        // cannot ride along.
+        return false;
       }
     }
     return true;

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/SanitizersTest.java
@@ -412,7 +412,7 @@ class SanitizersTest {
         .toFactory();
     String sanitized = ""
         + "<table style=\"color:rgb( 0 , 0 , 0 );"
-        + "font-family:&#39;arial&#39; , &#39;geneva&#39; , sans-serif\">"
+        + "font-family:&#39;Arial&#39; , &#39;Geneva&#39; , sans-serif\">"
         + "<tbody>"
         + "<tr>"
         + "<th>Column One</th><th>Column Two</th>"

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/StylingPolicyTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/StylingPolicyTest.java
@@ -103,41 +103,125 @@ class StylingPolicyTest {
 
   @Test
   void testFontFace() {
+    // A font name is a name, not a keyword: it is emitted as the author wrote
+    // it, even though the schema matches it case-insensitively.  See #289.
     assertSanitizedCss(
-        "font:'arial' , 'helvetica'", "font: Arial, Helvetica");
+        "font:'Arial' , 'Helvetica'", "font: Arial, Helvetica");
     assertSanitizedCss(
-        "font-family:'arial' , 'helvetica' , sans-serif",
+        "font-family:'Arial' , 'Helvetica' , sans-serif",
         "Font-family: Arial, Helvetica, sans-serif");
+    // A quoted "Monospace" is a font name, not the generic family keyword, so
+    // it stays quoted; the bare keyword below does not.
     assertSanitizedCss(
-        "font-family:'monospace' , sans-serif",
+        "font-family:'Monospace' , sans-serif",
         "Font-family: \"Monospace\", Sans-serif");
     assertSanitizedCss(
-        "font:'arial bold' , 'helvetica' , monospace",
+        "font:'Arial Bold' , 'Helvetica' , monospace",
         "FONT: \"Arial Bold\", Helvetica, monospace");
     assertSanitizedCss(
-        "font-family:'arial bold' , 'helvetica'",
+        "font-family:'Arial Bold' , 'Helvetica'",
         "font-family: \"Arial Bold\", Helvetica");
     assertSanitizedCss(
-        "font-family:'arial bold' , 'helvetica'",
+        "font-family:'Arial Bold' , 'Helvetica'",
         "font-family: 'Arial Bold', Helvetica");
     assertSanitizedCss(
         "font-family:'evil'",
         "font-family: 3execute evil");
+    // An empty name really is empty, so it drops and leaves the separators.
     assertSanitizedCss(
-        "font-family:'arial bold' , , , 'helvetica' , sans-serif",
+        "font-family:'Arial Bold' , , , 'Helvetica' , sans-serif",
         "font-family: 'Arial Bold',,\"\",Helvetica,sans-serif");
     assertSanitizedCss(
-        "font:'chalkboardse-light' , 'helvetica' , monospace",
+        "font:'ChalkboardSE-Light' , 'Helvetica' , monospace",
         "FONT: \"ChalkboardSE-Light\", Helvetica, monospace");
+  }
+
+  /**
+   * Issue #232.  Sanitizing twice must not change the result.  A font name
+   * containing an underscore -- which is what Word emits -- was accepted
+   * unquoted but rejected once quoted, so the first pass produced a name the
+   * second pass dropped, leaving a stray comma and invalid CSS.
+   */
+  @Test
+  void testFontFamilyIsIdempotent() {
+    String once = "font-family:'WordVisi_MSFontService' , 'Algerian' ,"
+        + " 'Algerian_EmbeddedFont' , sans-serif";
+    assertSanitizedCss(
+        once,
+        "font-family: WordVisi_MSFontService, Algerian,"
+        + " Algerian_EmbeddedFont, sans-serif");
+    // The output of the first pass survives a second unchanged.
+    assertSanitizedCss(once, once);
+    // Periods and non-ASCII names round-trip too.
+    assertSanitizedCss("font-family:'Foo.Bar_1'", "font-family: 'Foo.Bar_1'");
+    assertSanitizedCss("font-family:'\u4e2d\u6587\u5b57\u4f53'",
+                       "font-family: '\u4e2d\u6587\u5b57\u4f53'");
+  }
+
+  /**
+   * Issue #229.  A generic family is a keyword and must not be quoted, or the
+   * declaration stops meaning what it said.
+   */
+  @Test
+  void testGenericFontFamiliesAreNotQuoted() {
+    assertSanitizedCss(
+        "font-family:sans-serif , system-ui , -apple-system",
+        "font-family: sans-serif, system-ui, -apple-system");
+    assertSanitizedCss(
+        "font-family:ui-serif , ui-sans-serif , ui-monospace , ui-rounded",
+        "font-family: ui-serif, ui-sans-serif, ui-monospace, ui-rounded");
+    assertSanitizedCss(
+        "font-family:math , emoji , fangsong , cursive , fantasy",
+        "font-family: math, emoji, fangsong, cursive, fantasy");
+    // A real font name is still quoted.
+    assertSanitizedCss(
+        "font-family:'BlinkMacSystemFont' , sans-serif",
+        "font-family: BlinkMacSystemFont, sans-serif");
+  }
+
+  /**
+   * Both paths that emit a font name apply the same test, so a name cannot
+   * survive one sanitization pass and vanish on the next, and a format
+   * character cannot ride into the output on the unquoted path.
+   */
+  @Test
+  void testFontNamePathsAgree() {
+    // U+202E RIGHT-TO-LEFT OVERRIDE reorders the text around it, so it has no
+    // business in a font name.  It used to be accepted unquoted and rejected
+    // quoted, which also made sanitization non-idempotent.
+    assertSanitizedCss(null, "font-family: a\u202eb");
+    assertSanitizedCss(null, "font-family: 'a\u202eb'");
+    // U+FEFF ZERO WIDTH NO-BREAK SPACE never reaches the output either, but
+    // by a different route: quoted it is rejected here, and unquoted the
+    // lexer has already split it into two identifiers.
+    assertSanitizedCss("font-family:'a b'", "font-family: a\ufeffb");
+    assertSanitizedCss(null, "font-family: 'a\ufeffb'");
+    // Ordinary names go through either way, and agree.
+    assertSanitizedCss("font-family:'Foo_Bar'", "font-family: Foo_Bar");
+    assertSanitizedCss("font-family:'Foo_Bar'", "font-family: 'Foo_Bar'");
+  }
+
+  /**
+   * Widening what a quoted name may contain must not let a name break out of
+   * the quotes it is emitted in.  The lexer hands us quotes and backslashes
+   * already escaped, and an escape is exactly what is rejected.
+   */
+  @Test
+  void testQuotedFontNamesCannotBreakOut() {
+    assertSanitizedCss(null, "font-family: 'it\\27s'");
+    assertSanitizedCss(null, "font-family: 'a\\5c b'");
+    assertSanitizedCss(null, "font-family: 'a\\22 b'");
+    assertSanitizedCss(null, "font-family: '</style>'");
+    assertSanitizedCss(null, "font-family: 'a\\a b'");
   }
 
   @Test
   void testFont() {
     assertSanitizedCss(
-        "font:'arial' 12pt bold oblique",
+        "font:'Arial' 12pt bold oblique",
         "font: Arial 12pt bold oblique");
     assertSanitizedCss(
-        "font:'times new roman' 24px bolder",
+        "font:'Times New Roman' 24px bolder",
         "font: \"Times New Roman\" 24px bolder");
     assertSanitizedCss("font:24px", "font: 24px");
     // Non-ascii characters discarded.
@@ -151,7 +235,7 @@ class StylingPolicyTest {
         null, "font: rgb(\"expression(alert(1337))//\")");
     assertSanitizedCss("font-size:smaller", "font-size: smaller");
     assertSanitizedCss("font:smaller", "font: smaller");
-    assertSanitizedCss("font:'chalkboardse-light'", "font: 'ChalkboardSE-Light'");
+    assertSanitizedCss("font:'ChalkboardSE-Light'", "font: 'ChalkboardSE-Light'");
     assertSanitizedCss(null, "font: '---");
   }
 


### PR DESCRIPTION
Three issues, one area of `StylingPolicy`.

## #232 — sanitizing twice produced invalid CSS

The substantive one. A font name was accepted **unquoted** but rejected once **quoted**, because the quoted path required every character to be alphanumeric, a space or a hyphen. Word emits names containing an underscore, so the first pass produced a name the second pass dropped, leaving the separator behind:

```
pass 1: font-family:'wordvisi_msfontservice' , 'algerian' , sans-serif
pass 2: font-family:, 'algerian' , sans-serif
```

That leading comma is invalid CSS, so the browser discarded the whole declaration — even the `sans-serif` fallback was lost. Exactly as @jtotht diagnosed.

The quoted path now accepts what a font name legitimately contains: letters and digits in any script, spaces, and the hyphen, underscore and period. CJK family names work now too.

**It still rejects the backslash, deliberately.** The lexer normalizes a string's contents and hands us quotes and backslashes *already escaped* — `'it\27s'`, `'a\5c b'`, `'\3c/style\3e'` — so re-emitting an escape verbatim would mean reasoning about escape parity to be sure the closing quote is still the closing quote. Rejecting it outright avoids the question entirely, at the cost of the rare name that needs one.

## The other half of the asymmetry

The **unquoted** path had no character test at all. That meant it would carry a format character such as U+202E RIGHT-TO-LEFT OVERRIDE straight into the output, and it accepted names the quoted path refused — so sanitizing twice still wasn't stable even after fixing the quoted side. Both paths now apply the same test.

Verified by fuzzing: 60,000 adversarial `font-family` values built from quotes, backslashes, CSS escapes, comment delimiters, bidi overrides and CJK, each sanitized twice —

```
checked=60000  notIdempotent=0  unbalancedQuotes=0
```

## #229 — generic families were being quoted

A generic family is a keyword and must not be quoted, but the schema listed only five. `system-ui`, `ui-serif`, `ui-sans-serif`, `ui-monospace`, `ui-rounded`, `math`, `emoji` and `fangsong` fell through to the quoted-name path and stopped meaning anything. Added, along with `-apple-system`, which isn't in the spec but is keyword-like in practice and equally broken by quoting.

`BlinkMacSystemFont` is deliberately **not** in that list — it's a real font name, not a generic family, so quoting it is correct.

## #289 — names were lower-cased

A font name is a name, not a keyword, so it's now emitted as the author wrote it. The schema still matches case-insensitively; only the output changes.

```
before: font-family:'times new roman' , 'times' , serif
after:  font-family:'Times New Roman' , 'Times' , serif
```

Existing expectations that pinned the lower-casing are updated — that's the visible behaviour change in this PR.

## Verification

Full matrix locally — JDK 11, 17, 21, 25, `mvn verify`, **426 tests** (up from 422), exit 0 on all four.

Closes #232, closes #229, closes #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
