### PR TITLE
Say accurately which font names survive, and pin it with a test

### DIFF
--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
@@ -250,13 +250,22 @@ final class StylingPolicy implements JoinableAttributePolicy {
    * the closing quote.  Rejecting the backslash outright avoids that question
    * entirely, at the cost of dropping the rare font name that needs one.
    *
-   * <p>What it does allow is everything a font name legitimately contains and
-   * that carries no meaning inside a CSS string: letters and digits in any
-   * script, spaces, and the hyphen, underscore and period that appear in names
+   * <p>What it does allow is a letter or digit from the basic multilingual
+   * plane, a space, and the hyphen, underscore and period that appear in names
    * like {@code Foo_Bar} and {@code Helvetica Neue LT Std.55 Roman}.  The
    * underscore matters in practice because Word emits font names containing
    * one, and because the unquoted path already accepted it -- so a name would
    * survive sanitization once and be dropped on the way back in.
+   *
+   * <p>That covers Latin, Cyrillic, Greek, Han, Hangul, kana and the base
+   * letters of the Arabic, Hebrew, Devanagari and Thai scripts.  It does not
+   * cover a name carrying a combining mark -- a Devanagari matra, an Arabic
+   * diacritic, Hebrew niqqud, a Thai vowel sign -- nor one containing a
+   * character outside the basic multilingual plane, such as a CJK extension B
+   * ideograph.  Those never reach this method: the CSS lexer excludes them
+   * from a token before the policy sees it, and has always done so.  So this
+   * test is defence in depth for non-ASCII rather than the decisive gate, and
+   * relaxing it alone would not make such a name work.
    */
   static boolean isSafeQuotedIdentifier(
       String token, int start, int end) {
@@ -275,8 +284,12 @@ final class StylingPolicy implements JoinableAttributePolicy {
         }
       } else if (!Character.isLetterOrDigit(ch)) {
         // Non-ASCII font names are ordinary -- CJK families, for instance --
-        // but only letters and digits, so that format and control characters
-        // cannot ride along.
+        // but only letters and digits, so that a format character such as a
+        // bidi override cannot ride along.  Note this reads one char at a
+        // time, so it would also reject a supplementary code point; nothing
+        // reaches here with one today, because the lexer has already excluded
+        // it, but a lexer that stopped doing so would need this to use
+        // codePointAt.
         return false;
       }
     }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/StylingPolicyTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/StylingPolicyTest.java
@@ -202,6 +202,48 @@ class StylingPolicyTest {
   }
 
   /**
+   * Which non-ASCII font names survive, pinned so the claim in
+   * {@code isSafeQuotedIdentifier}'s javadoc stays honest.
+   *
+   * <p>The limitation on combining marks and supplementary code points is not
+   * imposed here -- the CSS lexer drops them from a token before the policy
+   * runs, and did so before the widening in #232 as well.
+   */
+  @Test
+  void testNonAsciiFontNames() {
+    // Letters and digits from the basic multilingual plane go through, quoted
+    // or not.
+    for (String name : new String[] {
+        "\u0422\u0430\u0439\u043c\u0441",              // Cyrillic
+        "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac",  // Greek, precomposed accent
+        "\u4e2d\u6587\u5b57\u4f53",                     // Han
+        "\ub9d1\uc740\uace0\ub515",                     // Hangul
+        "\u30d2\u30e9\u30ae\u30ce",                     // Katakana
+        "\u0646\u0633\u062e",                            // Arabic base letters
+        "\u05d0\u05dc\u05e3" }) {                        // Hebrew base letters
+      assertSanitizedCss("font-family:'" + name + "'", "font-family: " + name);
+      assertSanitizedCss(
+          "font-family:'" + name + "'", "font-family: '" + name + "'");
+    }
+
+    // A combining mark does not, on either path.  This is the lexer's doing,
+    // not this policy's.
+    for (String name : new String[] {
+        "\u0646\u064e\u0633",              // Arabic with fatha
+        "\u0926\u0947\u0935",              // Devanagari with matra
+        "\u05d0\u05b8\u05dc",              // Hebrew with qamats
+        "\u0e1a\u0e31\u0e0d" }) {          // Thai with vowel sign
+      assertSanitizedCss(null, "font-family: " + name);
+      assertSanitizedCss(null, "font-family: '" + name + "'");
+    }
+
+    // Nor does a supplementary code point: U+20000, a CJK extension B
+    // ideograph.
+    assertSanitizedCss(null, "font-family: \ud840\udc00");
+    assertSanitizedCss(null, "font-family: '\ud840\udc00'");
+  }
+
+  /**
    * Widening what a quoted name may contain must not let a name break out of
    * the quotes it is emitted in.  The lexer hands us quotes and backslashes
    * already escaped, and an escape is exactly what is rejected.


### PR DESCRIPTION
Follow-up to #431, correcting something I wrote there rather than changing behaviour.

#431 widened what a quoted font name may contain and described the result as **"letters and digits in any script."** That's true of the test it describes, but misleading about the library. A reader would conclude Devanagari or Arabic font names now work. They don't:

```
Cyrillic / Greek / Han / Hangul / kana        KEPT
Arabic, Hebrew, Devanagari, Thai base letters KEPT
  ... the same names with a combining mark    dropped
  (Devanagari matra, Arabic diacritic, Hebrew niqqud, Thai vowel sign)
CJK extension B (supplementary plane)         dropped
```

The limitation isn't imposed by the filter I touched — the **CSS lexer** drops those from a token before the policy runs, and did so before #431 as well. I verified that against a pre-#431 build: byte-identical results. So relaxing this test alone would not make such a name work, and someone trying would be looking in the wrong place.

The javadoc now says what actually goes through and where the remaining limitation lives. A test pins both halves, so the claim fails if it stops being true.

Also noted at the `isLetterOrDigit` call that it reads one `char` at a time and would therefore reject a supplementary code point by itself. Nothing reaches it with one today, since the lexer has already excluded them — the note is there so a future lexer change doesn't silently leave this behind.

**No behaviour change.** Full matrix locally — JDK 11, 17, 21, 25, `mvn verify`, **427 tests** (up from 426), exit 0 on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZfawfTUAFHN7cocUjcpQK
