### PR TITLE
Say that matching() after disallowAttributes() does nothing

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,12 @@
 
 Most recent at top.
   * Next release
+    * Docs: `disallowAttributes(...)` now says that a `matching(...)` call on
+      the builder it returns has no effect -- it already rejects every value,
+      and joining a narrower policy onto one that rejects everything cannot
+      widen it -- and shows the inverted `allowAttributes` that rejects only
+      some values, which also composes through `PolicyFactory.and`.  Two tests
+      pin both behaviours.  Reported in #292 by subbudvk.
     * Attributes: an attribute whose name matched an **earlier attribute's
       value** on the same tag was silently dropped as a duplicate.  The
       duplicate scan walks a flat list of alternating names and values but

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -398,6 +398,25 @@ public class HtmlPolicyBuilder {
    * <p>
    * Attributes are disallowed by default, so there is no need to call this
    * with a laundry list of attribute/element pairs.
+   * <p>
+   * This rejects the attribute whatever its value, and a
+   * {@link AttributeBuilder#matching matching} call on the returned builder
+   * has <b>no effect</b>: rejecting everything and then narrowing to the
+   * values that match still rejects everything.  To keep an attribute except
+   * where its value matches, allow it with a pattern that excludes those
+   * values instead:
+   * <pre class="prettyprint lang-java">
+   * // Not this: the pattern is ignored and every src is dropped.
+   * .disallowAttributes("src").matching(BAD_URL).onElements("img")
+   *
+   * // This: keep the values that are not bad.
+   * .allowAttributes("src")
+   *     .matching(v -&gt; BAD_URL.matcher(v).find() ? null : v)
+   *     .onElements("img")
+   * </pre>
+   * A factory built the second way can also narrow a more permissive one
+   * through {@link PolicyFactory#and}, since {@code and} intersects the two
+   * attribute policies.
    */
   public AttributeBuilder disallowAttributes(String... attributeNames) {
     return this.allowAttributes(attributeNames)
@@ -983,6 +1002,11 @@ public class HtmlPolicyBuilder {
      * Multiple calls to {@code matching} are combined so that the policies
      * receive the value in order, each seeing the value after any
      * transformation by a previous policy.
+     * <p>
+     * Since the combination fails as soon as one policy rejects, this has no
+     * effect on a builder from {@link HtmlPolicyBuilder#disallowAttributes},
+     * which already rejects every value.  See that method for how to reject
+     * only some.
      */
     public AttributeBuilder matching(AttributePolicy attrPolicy) {
       this.policy = AttributePolicy.Util.join(this.policy, attrPolicy);

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -607,6 +607,44 @@ class HtmlPolicyBuilderTest {
   }
 
   /**
+   * disallowAttributes rejects every value, and joining a policy onto one that
+   * already rejects everything cannot widen it, so a matching call after
+   * disallowAttributes does nothing.  Pinned because it reads as though it
+   * should reject only the matching values.
+   */
+  @Test
+  void testMatchingAfterDisallowAttributesHasNoEffect() {
+    String withMatching = apply(
+        new HtmlPolicyBuilder()
+        .allowUrlProtocols("http", "https")
+        .allowElements("img")
+        .allowAttributes("src").onElements("img")
+        .disallowAttributes("src")
+            .matching(Pattern.compile(".*example.*")).onElements("img"),
+        "<img src=\"http://other.example/a.png\">");
+
+    assertEquals("", withMatching, "the non-matching src is dropped too");
+  }
+
+  /** Rejecting only some values means allowing the rest. */
+  @Test
+  void testAnInvertedAllowRejectsOnlyTheMatchingValues() {
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder()
+        .allowUrlProtocols("http", "https")
+        .allowElements("img")
+        .allowAttributes("src")
+            .matching((elementName, attributeName, value) ->
+                value.contains("example") ? null : value)
+            .onElements("img");
+
+    assertEquals(
+        "<img src=\"http://other.test/a.png\" />",
+        apply(b, "<img src=\"http://other.test/a.png\">"));
+    assertEquals(
+        "", apply(b, "<img src=\"http://other.example/a.png\">"));
+  }
+
+  /**
    * The duplicate-attribute scan walks a flat list of alternating names and
    * values, so it has to compare names against names.  It used to compare
    * against values too, which dropped an attribute whose name matched an


### PR DESCRIPTION
`disallowAttributes(n)` is `allowAttributes(n).matching(REJECT_ALL_ATTRIBUTE_POLICY)`, and `AttributePolicy.Util.join` takes `REJECT_ALL_ATTRIBUTE_POLICY` as its zero element. So a `matching(...)` call on the builder it returns is absorbed and does nothing at all.

That matters because the call reads like it should work. From #292:

```java
.disallowAttributes("src").matching(Pattern.compile(".*google.*")).onElements("img")
```

reads as "drop src when it points at google", but drops **every** `src`. Verified — the pattern makes no difference whatsoever:

```
<img src='http://yahoo.com/a.png'>
  with .matching():    (empty)
  without .matching(): (empty)
```

It fails closed, so nothing unsafe gets through; the policy is just quietly stricter than it reads, which is a bad property for something people audit by eye.

## What this changes

Documentation and tests only — no behaviour change.

- `disallowAttributes` now states that `matching` on the returned builder has no effect, and shows the inverted `allowAttributes` that expresses the intent.
- `AttributeBuilder.matching` notes the same thing from the other end, since that is where someone lands when they go looking for why their pattern was ignored.
- Two tests pin both halves: the pattern really is ignored, and the inverted form really does keep the non-matching values.

The doc also points out that a factory built the inverted way composes through `PolicyFactory.and`, which is the actual use case in #292 — shipping a minimal base policy that consumers narrow further. Verified:

```
base.and(restriction):
  <img src='http://yahoo.com/a.png'>   ->  <img src="http://yahoo.com/a.png" />
  <img src='http://google.com/a.png'>  ->  (empty)
```

## Testing

`mvnw verify` green on JDK 11, 17, 21 and 25 — 436 tests each. `javadoc:javadoc` reports 104 diagnostics both before and after this change, so the new prose adds none (that goal already fails on `main` for unrelated pre-existing reasons: an out-of-sequence `<h3>` and missing `@param`s).

Addresses #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgBerh4Q8S2e1Eb6pVeQMM
