### PR TITLE
Cover matching(Predicate) here, and configure Dependabot for new modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,27 @@
 # ${project.version} (20000101-SNAPSHOT during development), which Dependabot
 # misreads as an ancient release and then tries to "bump" (see PRs #383, #439).
 #
-# The glob covers the root POM and every module directory, including any
-# module added later; `directories` supports globbing where `directory` does
-# not. Without it, a new module is unconfigured, and Dependabot's "fix" for
-# a ${project.version} dependency is to rewrite the root POM's <version>.
+# Every directory holding a pom.xml is listed, so **a new module needs a line
+# here**; without one, Dependabot's "fix" for its ${project.version}
+# dependency is to rewrite the root POM's <version> to an old release. The
+# `directories` key accepts a glob, which would cover new modules on its own,
+# but dependabot-core#12348 reports globbing silently matching no manifests,
+# and a silent miss here is exactly what this file exists to prevent.
 #
-# open-pull-requests-limit: 0 keeps version-update PRs off; security
-# updates still run, and the ignore rules below apply to both.
+# open-pull-requests-limit: 0 keeps version-update PRs off; security updates
+# still run, and the ignore rules below apply to both. The limit is one budget
+# shared by every directory listed, not one per directory, which matters only
+# if someone raises it above 0.
 version: 2
 updates:
   - package-ecosystem: "maven"
     directories:
       - "/"
-      - "/*"
+      - "/java8-shim"
+      - "/java10-shim"
+      - "/owasp-java-html-sanitizer"
+      - "/examples"
+      - "/empiricism"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,21 +2,21 @@
 # exists only to stop Dependabot from treating the project's own reactor
 # modules as external dependencies. The modules reference each other via
 # ${project.version} (20000101-SNAPSHOT during development), which Dependabot
-# misreads as an ancient release and then tries to "bump" (see PR #383).
+# misreads as an ancient release and then tries to "bump" (see PRs #383, #439).
+#
+# The glob covers the root POM and every module directory, including any
+# module added later; `directories` supports globbing where `directory` does
+# not. Without it, a new module is unconfigured, and Dependabot's "fix" for
+# a ${project.version} dependency is to rewrite the root POM's <version>.
 #
 # open-pull-requests-limit: 0 keeps version-update PRs off; security
 # updates still run, and the ignore rules below apply to both.
 version: 2
 updates:
   - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "com.googlecode.owasp-java-html-sanitizer:*"
-  - package-ecosystem: "maven"
-    directory: "/empiricism"
+    directories:
+      - "/"
+      - "/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0

--- a/change_log.md
+++ b/change_log.md
@@ -193,12 +193,19 @@ Most recent at top.
     * Build: Coveralls coverage reporting is removed.  The plugin had not run
       since the Travis scripts were deleted in 2024, and the repo token that
       was committed with it in 2019 has been revoked.
-    * Build: `dependabot.yml` now covers the root POM and every module
-      directory through a glob rather than naming two of them, so a module
-      added later is configured from the start.  The `examples` module was
-      not, and Dependabot read its `${project.version}` dependency on the
-      sanitizer as an ancient release and proposed rewriting the root POM's
-      `<version>` to `20211018.1` (PR #439, and #383 before it).
+    * Docs: the `matching(ignoreCase, ...)` overloads say that the allowed
+      values must already be lower-case when `ignoreCase` is true.  The
+      attribute value is lower-cased before it is looked up but the allowed
+      values are used as given, so `matching(true, "Note")` matches nothing.
+      It fails closed, and a test pins it.
+    * Build: `dependabot.yml` now lists every directory holding a POM, where
+      it named two of them.  The `examples` module was not configured, so
+      Dependabot read its `${project.version}` dependency on the sanitizer as
+      an ancient release and proposed rewriting the root POM's `<version>` to
+      `20211018.1` (PR #439, and #383 before it).  A glob would cover modules
+      added later, but dependabot-core#12348 reports globbing silently
+      matching no manifests, so the directories are listed by hand and a new
+      module needs a line.
     * Docs: README examples compile again; Javadoc links point at `latest`.
     * Special thanks to (in lexicographic order):
       Alessandro Ruzzon, corebonts, Daham Chinthana, Domi, hwangjeyeon,

--- a/change_log.md
+++ b/change_log.md
@@ -193,6 +193,12 @@ Most recent at top.
     * Build: Coveralls coverage reporting is removed.  The plugin had not run
       since the Travis scripts were deleted in 2024, and the repo token that
       was committed with it in 2019 has been revoked.
+    * Build: `dependabot.yml` now covers the root POM and every module
+      directory through a glob rather than naming two of them, so a module
+      added later is configured from the start.  The `examples` module was
+      not, and Dependabot read its `${project.version}` dependency on the
+      sanitizer as an ancient release and proposed rewriting the root POM's
+      `<version>` to `20211018.1` (PR #439, and #383 before it).
     * Docs: README examples compile again; Javadoc links point at `latest`.
     * Special thanks to (in lexicographic order):
       Alessandro Ruzzon, corebonts, Daham Chinthana, Domi, hwangjeyeon,

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -1049,6 +1049,11 @@ public class HtmlPolicyBuilder {
      * supplied.
      * Multiple calls to {@code matching} are combined to restrict to the
      * intersection of possible matched values.
+     * <p>
+     * When {@code ignoreCase} is true the attribute value is lower-cased
+     * before it is looked up but {@code allowedValues} is used as given, so
+     * the allowed values must already be lower-case; one that is not can
+     * never match.
      */
     public AttributeBuilder matching(
         boolean ignoreCase, String... allowedValues) {
@@ -1060,6 +1065,11 @@ public class HtmlPolicyBuilder {
      * supplied.
      * Multiple calls to {@code matching} are combined to restrict to the
      * intersection of possible matched values.
+     * <p>
+     * When {@code ignoreCase} is true the attribute value is lower-cased
+     * before it is looked up but {@code allowedValues} is used as given, so
+     * the allowed values must already be lower-case; one that is not can
+     * never match.
      */
     public AttributeBuilder matching(
         final boolean ignoreCase, Set<? extends String> allowedValues) {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -30,6 +30,7 @@ package org.owasp.html;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
@@ -642,6 +643,42 @@ class HtmlPolicyBuilderTest {
         apply(b, "<img src=\"http://other.test/a.png\">"));
     assertEquals(
         "", apply(b, "<img src=\"http://other.example/a.png\">"));
+  }
+
+  /**
+   * The {@link Predicate} overload of {@code matching} keeps the values the
+   * predicate accepts and drops the rest, just as the {@link Pattern} one
+   * does.  It takes a {@code Predicate<? super String>}, so a predicate
+   * written against a supertype fits as well.
+   */
+  @Test
+  void testMatchingPredicateKeepsOnlyAcceptedValues() {
+    Predicate<String> isPng = value -> value.endsWith(".png");
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder()
+        .allowUrlProtocols("http", "https")
+        .allowElements("img")
+        .allowAttributes("src")
+            .matching(isPng)
+            .onElements("img");
+
+    assertEquals(
+        "<img src=\"http://example.test/a.png\" />",
+        apply(b, "<img src=\"http://example.test/a.png\">"));
+    assertEquals(
+        "", apply(b, "<img src=\"http://example.test/a.gif\">"),
+        "the img goes with its only attribute");
+
+    Predicate<CharSequence> isNotEmpty = value -> value.length() != 0;
+    HtmlPolicyBuilder overSupertype = new HtmlPolicyBuilder()
+        .allowElements("p")
+        .allowAttributes("title")
+            .matching(isNotEmpty)
+            .onElements("p");
+
+    assertEquals(
+        "<p title=\"t\">Hi</p>", apply(overSupertype, "<p title=\"t\">Hi</p>"));
+    assertEquals(
+        "<p>Hi</p>", apply(overSupertype, "<p title=\"\">Hi</p>"));
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -648,37 +648,95 @@ class HtmlPolicyBuilderTest {
   /**
    * The {@link Predicate} overload of {@code matching} keeps the values the
    * predicate accepts and drops the rest, just as the {@link Pattern} one
-   * does.  It takes a {@code Predicate<? super String>}, so a predicate
-   * written against a supertype fits as well.
+   * does.
    */
   @Test
   void testMatchingPredicateKeepsOnlyAcceptedValues() {
-    Predicate<String> isPng = value -> value.endsWith(".png");
+    Predicate<String> isNote = value -> value.startsWith("note-");
     HtmlPolicyBuilder b = new HtmlPolicyBuilder()
-        .allowUrlProtocols("http", "https")
-        .allowElements("img")
-        .allowAttributes("src")
-            .matching(isPng)
-            .onElements("img");
+        .allowElements("p")
+        .allowAttributes("class")
+            .matching(isNote)
+            .onElements("p");
 
     assertEquals(
-        "<img src=\"http://example.test/a.png\" />",
-        apply(b, "<img src=\"http://example.test/a.png\">"));
+        "<p class=\"note-aside\">Hi</p>",
+        apply(b, "<p class=\"note-aside\">Hi</p>"));
     assertEquals(
-        "", apply(b, "<img src=\"http://example.test/a.gif\">"),
-        "the img goes with its only attribute");
+        "<p>Hi</p>", apply(b, "<p class=\"warning\">Hi</p>"),
+        "the attribute goes, the element stays");
+  }
 
+  /**
+   * That overload takes a {@code Predicate<? super String>}, so a predicate
+   * written against a supertype fits as well.  Only the wildcard makes this
+   * compile.
+   */
+  @Test
+  void testMatchingAcceptsAPredicateOverASupertypeOfString() {
     Predicate<CharSequence> isNotEmpty = value -> value.length() != 0;
-    HtmlPolicyBuilder overSupertype = new HtmlPolicyBuilder()
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder()
         .allowElements("p")
         .allowAttributes("title")
             .matching(isNotEmpty)
             .onElements("p");
 
+    assertEquals("<p title=\"t\">Hi</p>", apply(b, "<p title=\"t\">Hi</p>"));
+    assertEquals("<p>Hi</p>", apply(b, "<p title=\"\">Hi</p>"));
+  }
+
+  /**
+   * The {@code ignoreCase} flag of the value-set overloads picks whether the
+   * value is lower-cased before it is looked up.  Every caller in the suite
+   * passed {@code true}, so the case-sensitive arm -- the one that compares
+   * the value as written -- went unexercised.
+   */
+  @Test
+  void testMatchingComparesValuesAsWrittenUnlessIgnoringCase() {
+    HtmlPolicyBuilder caseSensitive = new HtmlPolicyBuilder()
+        .allowElements("p")
+        .allowAttributes("class")
+            .matching(false, "Note")
+            .onElements("p");
+
     assertEquals(
-        "<p title=\"t\">Hi</p>", apply(overSupertype, "<p title=\"t\">Hi</p>"));
+        "<p class=\"Note\">Hi</p>",
+        apply(caseSensitive, "<p class=\"Note\">Hi</p>"));
     assertEquals(
-        "<p>Hi</p>", apply(overSupertype, "<p title=\"\">Hi</p>"));
+        "<p>Hi</p>", apply(caseSensitive, "<p class=\"note\">Hi</p>"),
+        "a value that differs in case is not one of the allowed values");
+
+    HtmlPolicyBuilder ignoringCase = new HtmlPolicyBuilder()
+        .allowElements("p")
+        .allowAttributes("class")
+            .matching(true, "note")
+            .onElements("p");
+
+    assertEquals(
+        "<p class=\"note\">Hi</p>",
+        apply(ignoringCase, "<p class=\"Note\">Hi</p>"),
+        "ignoring case keeps the lower-cased value, not the one written");
+  }
+
+  /**
+   * {@code ignoreCase} lower-cases the value it looks up but not the values it
+   * looks them up in, so an allowed value that is not already lower-case can
+   * never be matched and the policy rejects everything.  It fails closed, but
+   * silently: pinned so the asymmetry is visible to anyone changing it.
+   */
+  @Test
+  void testMatchingIgnoringCaseNeverMatchesAnUpperCaseAllowedValue() {
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder()
+        .allowElements("p")
+        .allowAttributes("class")
+            .matching(true, "Note")
+            .onElements("p");
+
+    for (String written : new String[] { "Note", "note", "NOTE" }) {
+      assertEquals(
+          "<p>Hi</p>", apply(b, "<p class=\"" + written + "\">Hi</p>"),
+          "nothing matches the allowed value `Note`");
+    }
   }
 
   /**


### PR DESCRIPTION
Two follow-ups to #438, which moved the examples into their own module. Updated after review -- see the last commit.

## The JaCoCo flag, measured

The review of #438 noted that the examples' coverage contribution vanished when they moved, since nothing merges a second `jacoco.exec`. Measuring it before fixing it:

* The example **classes** were never in the report. They lived under `owasp-java-html-sanitizer/src/test/java/org/owasp/html/examples/`, and `jacoco:report` covers `target/classes`.
* The only real loss was the exec data `ExamplesTest` and `UrlTextExampleTest` added to this module's report. Pinning the fuzz seed (`-Djunit.seed=1`) and building the pre-move commit with and without those two tests puts it at **25 instructions, 3 lines, 1 branch** out of 54,277 / 4,430 / 2,791 -- run-to-run fuzz noise alone is about 2 instructions.
* All 25 land in one place: `HtmlPolicyBuilder.AttributeBuilder.matching(Predicate<? super String>)` and its anonymous `AttributePolicy`. `EbayPolicyExample` used that overload and no test in this module did.

So the gap is a missing test, not missing build machinery. A JaCoCo agent in the `examples` module would report the three demonstration classes and leave the overload still showing as uncovered; an aggregate report would be new build surface for a report nothing consumes -- Coveralls was removed and CI neither uploads nor enforces coverage.

## What the tests cover now

`matching(Predicate)` over an accepted value and a rejected one, and over a predicate written for a supertype, since the parameter is `Predicate<? super String>`.

Covering it turned up a second uncovered arm two overloads down: every caller of `matching(ignoreCase, ...)` in the suite passed `true`, so the branch comparing the value **as written** had no test in a library whose job is allowlisting attribute values. Writing one showed why that arm matters: with `ignoreCase` true the value is lower-cased before lookup but the allowed values are used **as given**, so `matching(true, "Note")` matches nothing at all. It fails closed, but silently. Both arms and the asymmetry are pinned, and both overloads' javadoc now says allowed values must already be lower-case.

At seed 1 this module covers 52,976 instructions and 2,453 branches, against 52,974 / 2,451 for the pre-move build. `HtmlPolicyBuilderTest` goes from 69 to 73 tests.

## Dependabot had no entry for the new module

`.github/dependabot.yml` named `/` and `/empiricism`. `examples/` was unconfigured, so Dependabot read its `${project.version}` dependency on the sanitizer as an ancient release and opened #439 -- proposing to rewrite the **root** POM's `<version>` to `20211018.1`. That is the failure #383 caused and the reason the file exists.

This first used a `/*` glob to cover future modules. The review pushed back with [dependabot-core#12348](https://github.com/dependabot/dependabot-core/issues/12348), open, reporting that globbing in `directories` matches no manifests -- filed for NuGet, but the expansion is in shared config handling. A silent miss is precisely what this file exists to prevent, and it would have dropped the protection `empiricism` already had. GitHub's docs don't document a recursive form either, so the glob could not have covered a nested module regardless. All six directories holding a POM are now listed, with a comment saying a new module needs a line.

## Not done here

* The anonymous policies returned by all three `matching` shapes hold `this$1`/`this$0`, so every `PolicyFactory` retains the whole `HtmlPolicyBuilder` and its maps (verified with javap). Real, retention only, and a main-code refactor -- follow-up issue.
* A `jacoco:check` floor to catch the next silent coverage regression: coverage varies run to run with the fuzz seed, and the report is local-only, so a floor would fail builds for reasons unrelated to the change.

## Verification

`./mvnw -ntp -B verify` passes on JDK 11, 17, 21 and 25 locally. The JaCoCo numbers come from `clean verify -Djunit.seed=1` runs, with the pre-move baseline built in a throwaway worktree at 016ff91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNkJbUFF3nMtKXLGFpRPAB
