### PR TITLE
Report a renamed element as kept, not discarded

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,14 @@
 
 Most recent at top.
   * Next release
+    * `HtmlChangeReporter` no longer reports an element that an
+      `ElementPolicy` renamed as a discarded tag.  It decided whether a tag
+      survived by comparing the output element name with the input one, so a
+      rename never matched: the listener heard `discardedTag` for an element
+      that was kept, and, since attribute reports are suppressed for a
+      discarded tag, never heard about the attributes the policy dropped from
+      it.  It now judges survival by whether the policy opened a tag at all.
+      Reports still carry the input element name.  Closes #435.
     * `<template>` keeps its children.  The browser probe that generates the
       element tables cannot see into `template.content`, so the tables said a
       template could hold nothing, and the tag balancer hoisted every child

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -115,7 +115,7 @@ public final class HtmlChangeReporter<T> {
     }
 
     public void openTag(String elementName, List<String> attrs) {
-      output.expectedElementName = elementName;
+      output.openedElementName = null;
       output.expectedAttrNames.clear();
       for (int i = 0, n = attrs.size(); i < n; i += 2) {
         output.expectedAttrNames.add(attrs.get(i));
@@ -125,17 +125,22 @@ public final class HtmlChangeReporter<T> {
         // Gather the notification details to avoid any problems with the
         // listener re-entering the stream event receiver.  This shouldn't
         // occur, but if it does it will be a source of subtle confusing bugs.
-        String discardedElementName = output.expectedElementName;
-        output.expectedElementName = null;
+        //
+        // The tag survived if the policy opened anything in response.  Its
+        // name is not compared with the input name: an ElementPolicy may
+        // rename the element, and a renamed element was kept, not dropped.
+        boolean discarded = output.openedElementName == null;
+        output.openedElementName = null;
         int nExpected = output.expectedAttrNames.size();
         String[] discardedAttrNames =
-            nExpected != 0 && discardedElementName == null
+            nExpected != 0 && !discarded
             ? output.expectedAttrNames.toArray(new String[nExpected])
             : ZERO_STRINGS;
         output.expectedAttrNames.clear();
-        // Dispatch notifications to the listener.
-        if (discardedElementName != null) {
-          listener.discardedTag(context, discardedElementName);
+        // Dispatch notifications to the listener, under the input name,
+        // which is the one the listener can relate to what came in.
+        if (discarded) {
+          listener.discardedTag(context, elementName);
         }
         if (discardedAttrNames.length != 0) {
           listener.discardedAttributes(
@@ -157,7 +162,11 @@ public final class HtmlChangeReporter<T> {
 
   private static final class OutputChannel implements HtmlStreamEventReceiver {
     private final HtmlStreamEventReceiver renderer;
-    String expectedElementName;
+    /**
+     * The name of the tag the policy has opened in response to the tag being
+     * opened, or null while it has opened none.
+     */
+    String openedElementName;
     /**
      * Names of the attributes on the tag being opened that have not turned up
      * in the output yet.  A list rather than a set: a name repeated on one tag
@@ -181,9 +190,7 @@ public final class HtmlChangeReporter<T> {
     }
 
     public void openTag(String elementName, List<String> attrs) {
-      if (elementName.equals(expectedElementName)) {
-        expectedElementName = null;
-      }
+      openedElementName = elementName;
       for (int i = 0, n = attrs.size(); i < n; i += 2) {
         // Accounts for one copy of the name, so repeats the policy dropped
         // stay behind to be reported.

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
@@ -147,6 +147,53 @@ class HtmlChangeReporterTest {
     assertEquals("", log.toString());
   }
 
+  /**
+   * {@link ElementPolicy#apply} may return another element name, and the
+   * reporter used to decide whether a tag survived by comparing names, so a
+   * renamed element was reported as discarded and, because a discarded tag's
+   * attributes are not reported, its attribute drops went unreported too
+   * (#435).
+   */
+  @Test
+  void testRenamedElementIsNotReportedAsDiscarded() {
+    Result result = sanitize(
+        renamingSpanToDiv(), "<span id=a id=b>hi</span>");
+
+    assertEquals("<div id=\"a\">hi</div>", result.html);
+    assertEquals("<span id> ", result.log);
+  }
+
+  /** Attribute reports on a renamed element carry the input element name. */
+  @Test
+  void testRejectedAttributesOnARenamedElementAreReported() {
+    Result result = sanitize(
+        renamingSpanToDiv(), "<span id=a onclick=alert(1)>hi</span>");
+
+    assertEquals("<div id=\"a\">hi</div>", result.html);
+    assertEquals("<span onclick> ", result.log);
+  }
+
+  @Test
+  void testRenamedElementWithNothingDroppedReportsNothing() {
+    Result result = sanitize(renamingSpanToDiv(), "<span id=a>hi</span>");
+
+    assertEquals("<div id=\"a\">hi</div>", result.html);
+    assertEquals("", result.log);
+  }
+
+  /**
+   * Renames {@code span} to {@code div}.  {@code div} is allowed as well so
+   * that text inside the renamed element is kept: the policy decides whether
+   * an element may hold text by the name it is emitted under.
+   */
+  private static PolicyFactory renamingSpanToDiv() {
+    return new HtmlPolicyBuilder()
+        .allowElements((elementName, attrs) -> "div", "span")
+        .allowElements("div")
+        .allowAttributes("id").onElements("span")
+        .toFactory();
+  }
+
   /** The sanitized HTML and the log of what the listener was told about it. */
   static final class Result {
     final String html;


### PR DESCRIPTION
`HtmlChangeReporter` judged whether a tag survived the policy by comparing the emitted element name with the input name. An `ElementPolicy` that renames an element (what `allowElements(ElementPolicy, String...)` is for) never matched, so the listener was told the element was discarded, and — because attribute reports are suppressed for a discarded tag — never heard about the attributes dropped from it.

The output channel now records that the policy opened *a* tag in response to the input tag; presence is the whole question, since the policy emits at most one open tag per input tag. Reports keep the input element name.

Tests use the policy from the issue (`span` → `div`): the tag is not reported; a duplicate `id` and a rejected `onclick` on it are; a clean rename reports nothing. All three fail on the old code with `<span>` reported as discarded.

Side finding while writing the tests, filed as #445: text inside a renamed element is dropped unless the new name is itself an allowed element, because the text gate keys on the adjusted name. The tests allow `div` explicitly to sidestep that.

Closes #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8QrFovrSextDGFNWqaiML
