### PR TITLE
Gate text by its enclosing elements, and honour disallowTextIn on dropped ones

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -11,21 +11,43 @@ Most recent at top.
       `<div><object><b>x</b>y</object>z</div>` as `<div>xyz</div>`.  The
       same slip defeated `disallowTextIn`: with text disallowed in
       `<template>`, `<template><p>x</p></template>` kept `x` whenever `<p>`
-      was not allowed.  The gate is now recomputed from the open-element
-      stack, so text belongs to the nearest kept element, and a dropped
-      element in between suppresses it only when its content is never shown
-      or text in it is disallowed.  Not an XSS -- the text was escaped -- but
-      content the policy said to suppress was shown.  Closes #444.
-    * `disallowTextIn(x)` now applies when the policy drops `x` itself, not
-      only when it keeps it.  The builder discarded the disallowed names when
-      it compiled, so `disallowElements("template")` together with
-      `disallowTextIn("template")` still emitted the template's text as bare
-      text.  The names now travel through `PolicyFactory`, and `and()` keeps
-      them unless the other factory allows text in that element -- the same
-      union of grants it applies to everything else.  This also reaches an
+      was not allowed.  Text now belongs to the nearest enclosing element the
+      policy kept, and a dropped element in between suppresses it only when
+      its content is never shown or text in it is disallowed.  Two
+      consequences of that rule are worth knowing.  Text that follows a kept
+      child inside such an element stays suppressed:
+      `<noscript>a<p>b</p>c</noscript>` gives `<p>b</p>`, where `c` used to
+      leak.  And text inside a dropped child of a kept element that cannot
+      hold text itself is dropped rather than written straight into that
+      element: `<tr><td>cell</td></tr>` with `td` not allowed gives an empty
+      row, not `<tr>cell</tr>`.  Not an XSS -- the text was escaped -- but
+      content the policy said to suppress was shown.  The gate now costs
+      constant time per tag.  The close-tag path used to re-scan the open
+      elements, as did the check for text inside a kept `<style>` or
+      `<script>`, and both were quadratic on a long run of unknown tags,
+      which the balancer forwards without counting them toward its nesting
+      limit; a test pins that 200,000 of them finish in linear time.
+      Closes #444.
+    * `disallowTextIn(x)` now applies to `x` as the author wrote it, whether
+      the policy keeps it, renames it or drops it, rather than only when it
+      keeps it under its own name.  The builder discarded the disallowed
+      names when it compiled, so `disallowElements("template")` together
+      with `disallowTextIn("template")` still emitted the template's text as
+      bare text, and a policy that renamed `span` to `div` ignored
+      `disallowTextIn("span")` unless the span happened to be dropped.  The
+      names now travel through `PolicyFactory`, and `and()` keeps them
+      unless the other factory allows text in that element -- the same union
+      of grants it applies to everything else.  `disallowElements(x)` no
+      longer records `x` as a text container, since a rejected element
+      grants nothing; it used to, and under `and()` that record would have
+      cancelled the other factory's `disallowTextIn(x)`.  The tag balancer,
+      which drops a start tag past the 256-deep nesting limit before the
+      policy sees it, now asks the policy whether that element's text is
+      suppressed instead of consulting only its fixed list, so
+      `disallowTextIn` holds past the limit too.  This also reaches an
       allowed element dropped for having no attributes, such as a bare
-      `<span>` with `disallowTextIn("span")`.  Text inside an allowed element
-      nested in the dropped one is that element's, and still shows; this is
+      `<span>` with `disallowTextIn("span")`.  Text inside a nested element
+      that survives the policy is that element's, and still shows; this is
       not a way to drop an element with all of its content.  Closes #194.
     * `HtmlChangeReporter` no longer reports an element that an
       `ElementPolicy` renamed as a discarded tag.  It decided whether a tag

--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,31 @@
 
 Most recent at top.
   * Next release
+    * Text inside a dropped element is now gated by every element enclosing
+      it, not by the last tag the policy saw.  The policy kept one flag for
+      whether text may be emitted and set it from each open tag alone, so a
+      dropped tag inside `<noscript>`, `<object>` or any other element whose
+      content is never shown reset the gate and let the content through:
+      `<noscript><b>text</b></noscript>` came out as `text`, and
+      `<div><object><b>x</b>y</object>z</div>` as `<div>xyz</div>`.  The
+      same slip defeated `disallowTextIn`: with text disallowed in
+      `<template>`, `<template><p>x</p></template>` kept `x` whenever `<p>`
+      was not allowed.  The gate is now recomputed from the open-element
+      stack, so text belongs to the nearest kept element, and a dropped
+      element in between suppresses it only when its content is never shown
+      or text in it is disallowed.  Not an XSS -- the text was escaped -- but
+      content the policy said to suppress was shown.  Closes #444.
+    * `disallowTextIn(x)` now applies when the policy drops `x` itself, not
+      only when it keeps it.  The builder discarded the disallowed names when
+      it compiled, so `disallowElements("template")` together with
+      `disallowTextIn("template")` still emitted the template's text as bare
+      text.  The names now travel through `PolicyFactory`, and `and()` keeps
+      them unless the other factory allows text in that element -- the same
+      union of grants it applies to everything else.  This also reaches an
+      allowed element dropped for having no attributes, such as a bare
+      `<span>` with `disallowTextIn("span")`.  Text inside an allowed element
+      nested in the dropped one is that element's, and still shows; this is
+      not a way to drop an element with all of its content.  Closes #194.
     * `HtmlChangeReporter` no longer reports an element that an
       `ElementPolicy` renamed as a discarded tag.  It decided whether a tag
       survived by comparing the output element name with the input one, so a

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -28,6 +28,7 @@
 package org.owasp.html;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -44,12 +45,15 @@ import static org.owasp.shim.Java8Shim.j8;
 @TCB
 @NotThreadSafe
 class ElementAndAttributePolicyBasedSanitizerPolicy
-    implements HtmlSanitizer.Policy {
+    implements HtmlSanitizer.Policy,
+               TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy {
   final Map<String, ElementAndAttributePolicies> elAndAttrPolicies;
   final Set<String> allowedTextContainers;
   /**
-   * Elements whose text is suppressed even when the element itself is dropped,
-   * from {@link HtmlPolicyBuilder#disallowTextIn}.
+   * Elements in which text is disallowed, from
+   * {@link HtmlPolicyBuilder#disallowTextIn}, by the name the author wrote:
+   * the rule holds whether the policy keeps, renames or drops the element.
+   * Disjoint from {@link #allowedTextContainers}.
    */
   final Set<String> disallowedTextContainers;
   private final HtmlStreamEventReceiver out;
@@ -57,15 +61,42 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    * True to skip textual content.  Used to ignore the content of embedded CDATA
    * content that is not meant to be human-readable.
    * <p>
-   * Always a function of {@link #openElementStack}; see
-   * {@link #recomputeSkipText}.
+   * While a document is open, this is the gate {@link #openElementStack}
+   * implies.  Text belongs to the nearest enclosing element the policy kept,
+   * and is emitted only if that element is an allowed text container whose
+   * input name is not one text was disallowed in.  A dropped element between
+   * the text and that container is not a container in the output, so it does
+   * not decide -- unless its content is never meant to be read as text
+   * ({@link #SKIPPABLE_ELEMENT_CONTENT}) or text in it was disallowed, either
+   * of which suppresses the text.  Outside a document it is true, so stray
+   * text is dropped.
+   * <p>
+   * The gate costs constant time per tag: each push derives the new value from
+   * the old one, and {@link #skipTextBeforeOpen} remembers the old one so a
+   * pop can restore it.  Re-deriving it by walking the stack would be
+   * quadratic on a long run of unknown tags, which the balancer forwards
+   * without counting them toward its nesting limit.
    */
   transient boolean skipText = true;
+  /**
+   * True while a kept {@code <style>} or {@code <script>} that is an allowed
+   * text container is open, so {@link #text} knows to vet its content for the
+   * tags the lexer hands over as text.  Maintained like {@link #skipText}.
+   */
+  private boolean inKeptCdataElement;
   /**
    * Alternating input names and adjusted names of elements opened by the
    * caller.
    */
   private final List<String> openElementStack = new ArrayList<>();
+  /**
+   * Bit {@code k} is the value {@link #skipText} had before the {@code k}-th
+   * element on {@link #openElementStack} was pushed, so that popping back to
+   * {@code k} elements restores it.
+   */
+  private final BitSet skipTextBeforeOpen = new BitSet();
+  /** The same for {@link #inKeptCdataElement}. */
+  private final BitSet inKeptCdataBeforeOpen = new BitSet();
 
   ElementAndAttributePolicyBasedSanitizerPolicy(
       HtmlStreamEventReceiver out,
@@ -79,9 +110,11 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   }
 
   /**
-   * Elements whose content is not meant to be read as text -- script source,
-   * stylesheets, fallback content -- so that when the policy drops one of
-   * them, it suppresses the content too rather than emitting it as text.
+   * Elements whose own text the policy does not surface when it drops them:
+   * script and style source, and fallback or metadata content that a browser
+   * would hide in place.  Children the policy keeps still render.  The tag
+   * balancer consults this list too, for start tags it drops at the nesting
+   * limit before the policy sees them.
    */
   static final Set<String> SKIPPABLE_ELEMENT_CONTENT
       = j8().setOf(
@@ -90,7 +123,10 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
   public void openDocument() {
     skipText = false;
+    inKeptCdataElement = false;
     openElementStack.clear();
+    skipTextBeforeOpen.clear();
+    inKeptCdataBeforeOpen.clear();
     out.openDocument();
   }
 
@@ -102,30 +138,21 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       }
     }
     openElementStack.clear();
+    skipTextBeforeOpen.clear();
+    inKeptCdataBeforeOpen.clear();
     skipText = true;
+    inKeptCdataElement = false;
     out.closeDocument();
   }
 
   public void text(String textChunk) {
     if (!skipText) {
-      // Check if we're inside a CDATA element (style/script) with allowTextIn
-      // where tags are reclassified as UNESCAPED text and need to be validated
       // Note: Only style and script are CDATA elements; noscript/noembed/noframes are PCDATA
-      boolean insideCdataElement = false;
-      for (int i = openElementStack.size() - 1; i >= 0; i -= 2) {
-        String adjustedName = openElementStack.get(i);
-        if (adjustedName != null 
-            && allowedTextContainers.contains(adjustedName)
-            && ("style".equals(adjustedName) || "script".equals(adjustedName))) {
-          insideCdataElement = true;
-          break;
-        }
-      }
-      
       // If inside a CDATA element (style/script) with allowTextIn, we need to filter out 
       // HTML tags that aren't allowed because tags inside these blocks are reclassified 
       // as UNESCAPED text by the lexer
-      if (insideCdataElement && textChunk != null && textChunk.indexOf('<') >= 0) {
+      if (inKeptCdataElement
+          && textChunk != null && textChunk.indexOf('<') >= 0) {
         // Strip out HTML tags that aren't in the allowed elements list
         String filtered = stripDisallowedTags(textChunk);
         out.text(filtered);
@@ -342,60 +369,60 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
           }
         }
         openElementStack.subList(i, n).clear();
+        skipText = skipTextBeforeOpen.get(i / 2);
+        inKeptCdataElement = inKeptCdataBeforeOpen.get(i / 2);
         break;
       }
     }
-    recomputeSkipText();
   }
 
   void writeOpenTag(
       ElementAndAttributePolicies policies, String adjustedElementName,
       List<String> attrs) {
     if (!HtmlTextEscapingMode.isVoidElement(adjustedElementName)) {
-      openElementStack.add(policies.elementName);
-      openElementStack.add(adjustedElementName);
-      recomputeSkipText();
+      push(policies.elementName, adjustedElementName);
+      // A kept element is the container for the text inside it.  It is judged
+      // by the name it was kept under, and by the name the author wrote when
+      // text was disallowed in that.
+      skipText = !allowedTextContainers.contains(adjustedElementName)
+          || disallowedTextContainers.contains(policies.elementName);
+      inKeptCdataElement = inKeptCdataElement
+          || (("style".equals(adjustedElementName)
+               || "script".equals(adjustedElementName))
+              && allowedTextContainers.contains(adjustedElementName));
     }
     out.openTag(adjustedElementName, attrs);
   }
 
   void deferOpenTag(String elementName) {
     if (!HtmlTextEscapingMode.isVoidElement(elementName)) {
-      openElementStack.add(elementName);
-      openElementStack.add(null);
-      recomputeSkipText();
+      push(elementName, null);
+      // A dropped element is not a container in the output, so the gate stays
+      // as it was -- unless the element's content must not surface as text.
+      skipText = skipText || suppressesTextWhenDropped(elementName);
     }
   }
 
   /**
-   * Recomputes {@link #skipText} from {@link #openElementStack}.
-   * <p>
-   * Text belongs to the nearest enclosing element that the policy kept, and
-   * is emitted only if that element is an allowed text container.  A dropped
-   * element between the text and that container is not a container in the
-   * output, so it does not decide -- unless its content is never meant to be
-   * read as text ({@link #SKIPPABLE_ELEMENT_CONTENT}) or the policy
-   * disallowed text in it, either of which suppresses the text.
-   * <p>
-   * Deriving the gate from the whole stack rather than from the last tag seen
-   * is what keeps a dropped {@code <b>} inside a dropped {@code <noscript>}
-   * from letting the noscript's content through.
+   * Pushes an element onto {@link #openElementStack}, remembering the gates in
+   * effect before it so that {@link #closeTag} can restore them.
    */
-  private void recomputeSkipText() {
-    for (int i = openElementStack.size() - 1; i >= 0; i -= 2) {
-      String adjustedName = openElementStack.get(i);
-      if (adjustedName != null) {
-        skipText = !allowedTextContainers.contains(adjustedName);
-        return;
-      }
-      String inputName = openElementStack.get(i - 1);
-      if (SKIPPABLE_ELEMENT_CONTENT.contains(inputName)
-          || disallowedTextContainers.contains(inputName)) {
-        skipText = true;
-        return;
-      }
-    }
-    skipText = false;
+  private void push(String elementName, @Nullable String adjustedElementName) {
+    int depth = openElementStack.size() / 2;
+    skipTextBeforeOpen.set(depth, skipText);
+    inKeptCdataBeforeOpen.set(depth, inKeptCdataElement);
+    openElementStack.add(elementName);
+    openElementStack.add(adjustedElementName);
+  }
+
+  /**
+   * True if text directly inside a dropped {@code elementName} is suppressed
+   * rather than emitted where the element was: its content is never meant to
+   * be read as text, or the policy disallowed text in it.
+   */
+  public boolean suppressesTextWhenDropped(String elementName) {
+    return SKIPPABLE_ELEMENT_CONTENT.contains(elementName)
+        || disallowedTextContainers.contains(elementName);
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -47,10 +47,18 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     implements HtmlSanitizer.Policy {
   final Map<String, ElementAndAttributePolicies> elAndAttrPolicies;
   final Set<String> allowedTextContainers;
+  /**
+   * Elements whose text is suppressed even when the element itself is dropped,
+   * from {@link HtmlPolicyBuilder#disallowTextIn}.
+   */
+  final Set<String> disallowedTextContainers;
   private final HtmlStreamEventReceiver out;
   /**
    * True to skip textual content.  Used to ignore the content of embedded CDATA
    * content that is not meant to be human-readable.
+   * <p>
+   * Always a function of {@link #openElementStack}; see
+   * {@link #recomputeSkipText}.
    */
   transient boolean skipText = true;
   /**
@@ -62,12 +70,19 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   ElementAndAttributePolicyBasedSanitizerPolicy(
       HtmlStreamEventReceiver out,
       Map<String, ElementAndAttributePolicies> elAndAttrPolicies,
-      Set<String> allowedTextContainers) {
+      Set<String> allowedTextContainers,
+      Set<String> disallowedTextContainers) {
     this.out = out;
     this.elAndAttrPolicies = j8().mapCopyOf(elAndAttrPolicies);
     this.allowedTextContainers = j8().setCopyOf(allowedTextContainers);
+    this.disallowedTextContainers = j8().setCopyOf(disallowedTextContainers);
   }
 
+  /**
+   * Elements whose content is not meant to be read as text -- script source,
+   * stylesheets, fallback content -- so that when the policy drops one of
+   * them, it suppresses the content too rather than emitting it as text.
+   */
   static final Set<String> SKIPPABLE_ELEMENT_CONTENT
       = j8().setOf(
           "script", "style", "noscript", "nostyle", "noembed", "noframes",
@@ -330,14 +345,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
         break;
       }
     }
-    skipText = false;
-    for (int i = openElementStack.size() - 1; i >= 0; i -= 2) {
-      String adjustedName = openElementStack.get(i);
-      if (adjustedName != null) {
-        skipText = !(allowedTextContainers.contains(adjustedName));
-        break;
-      }
-    }
+    recomputeSkipText();
   }
 
   void writeOpenTag(
@@ -346,7 +354,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     if (!HtmlTextEscapingMode.isVoidElement(adjustedElementName)) {
       openElementStack.add(policies.elementName);
       openElementStack.add(adjustedElementName);
-      skipText = !allowedTextContainers.contains(adjustedElementName);
+      recomputeSkipText();
     }
     out.openTag(adjustedElementName, attrs);
   }
@@ -355,8 +363,39 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     if (!HtmlTextEscapingMode.isVoidElement(elementName)) {
       openElementStack.add(elementName);
       openElementStack.add(null);
+      recomputeSkipText();
     }
-    skipText = SKIPPABLE_ELEMENT_CONTENT.contains(elementName);
+  }
+
+  /**
+   * Recomputes {@link #skipText} from {@link #openElementStack}.
+   * <p>
+   * Text belongs to the nearest enclosing element that the policy kept, and
+   * is emitted only if that element is an allowed text container.  A dropped
+   * element between the text and that container is not a container in the
+   * output, so it does not decide -- unless its content is never meant to be
+   * read as text ({@link #SKIPPABLE_ELEMENT_CONTENT}) or the policy
+   * disallowed text in it, either of which suppresses the text.
+   * <p>
+   * Deriving the gate from the whole stack rather than from the last tag seen
+   * is what keeps a dropped {@code <b>} inside a dropped {@code <noscript>}
+   * from letting the noscript's content through.
+   */
+  private void recomputeSkipText() {
+    for (int i = openElementStack.size() - 1; i >= 0; i -= 2) {
+      String adjustedName = openElementStack.get(i);
+      if (adjustedName != null) {
+        skipText = !allowedTextContainers.contains(adjustedName);
+        return;
+      }
+      String inputName = openElementStack.get(i - 1);
+      if (SKIPPABLE_ELEMENT_CONTENT.contains(inputName)
+          || disallowedTextContainers.contains(inputName)) {
+        skipText = true;
+        return;
+      }
+    }
+    skipText = false;
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -32,6 +32,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import org.owasp.html.TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy;
+
 /**
  * Sits between the HTML parser, the policy, and the renderer so that it
  * can report dropped elements and attributes to an {@link HtmlChangeListener}.
@@ -83,7 +85,8 @@ public final class HtmlChangeReporter<T> {
 
   private static final class InputChannel<T>
       implements HtmlSanitizer.Policy,
-                 TagBalancingHtmlStreamEventReceiver.NestingLimitListener {
+                 TagBalancingHtmlStreamEventReceiver.NestingLimitListener,
+                 TextSuppressionPolicy {
     HtmlStreamEventReceiver policy;
     final OutputChannel output;
     final T context;
@@ -104,6 +107,17 @@ public final class HtmlChangeReporter<T> {
      */
     public void nestingLimitReached(String elementName) {
       listener.discardedTag(context, elementName);
+    }
+
+    /**
+     * For the same reason: before dropping a start tag at the limit, the
+     * balancer asks whether the element's text is suppressed, and the policy
+     * that knows sits behind this channel.
+     */
+    public boolean suppressesTextWhenDropped(String canonElementName) {
+      return policy instanceof TextSuppressionPolicy
+          && ((TextSuppressionPolicy) policy)
+              .suppressesTextWhenDropped(canonElementName);
     }
 
     public void openDocument() {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -270,7 +270,12 @@ public class HtmlPolicyBuilder {
       // that to infect later allowElement calls for this particular element
       // name.  rejects should have higher priority than allows.
       elPolicies.put(elementName, newPolicy);
-      if (!textContainers.containsKey(elementName)) {
+      // An allowed element that can hold text is a text container unless
+      // told otherwise.  A rejected element grants nothing, so it is not
+      // recorded as one: under PolicyFactory.and, that record would cancel a
+      // disallowTextIn for the same element in the other factory.
+      if (!ElementPolicy.REJECT_ALL_ELEMENT_POLICY.equals(newPolicy)
+          && !textContainers.containsKey(elementName)) {
         if (METADATA.canContainPlainText(METADATA.indexForName(elementName))) {
           textContainers.put(elementName, true);
         }
@@ -338,7 +343,8 @@ public class HtmlPolicyBuilder {
    * are eventually for human consumption, but which are created in a separate
    * document fragment.
    * <p>
-   * This applies whether or not the element itself is allowed.  With both
+   * This applies to the element as the author wrote it, whether the policy
+   * keeps it, renames it or drops it.  With both
    * {@code disallowElements("template")} and
    * {@code disallowTextIn("template")} in effect,
    * {@code <template>hidden</template>} contributes nothing to the output,
@@ -346,10 +352,10 @@ public class HtmlPolicyBuilder {
    * bare text.
    * <p>
    * Text belongs to the nearest enclosing element that survives the policy,
-   * so this does not reach text inside an <i>allowed</i> element nested in
-   * the named one: {@code <template><p>shown</p></template>} keeps
-   * {@code shown} if {@code <p>} is allowed.  It is not a way to drop an
-   * element together with everything inside it.
+   * so this does not reach text inside a nested element that survives:
+   * {@code <template><p>shown</p></template>} keeps {@code shown} if
+   * {@code <p>} is allowed and kept.  It is not a way to drop an element
+   * together with everything inside it.
    */
   public HtmlPolicyBuilder disallowTextIn(String... elementNames) {
     invalidateCompiledState();

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -337,6 +337,19 @@ public class HtmlPolicyBuilder {
    * default stylesheets, or, like {@code <template>} contain text nodes that
    * are eventually for human consumption, but which are created in a separate
    * document fragment.
+   * <p>
+   * This applies whether or not the element itself is allowed.  With both
+   * {@code disallowElements("template")} and
+   * {@code disallowTextIn("template")} in effect,
+   * {@code <template>hidden</template>} contributes nothing to the output,
+   * where dropping the element alone would leave {@code hidden} behind as
+   * bare text.
+   * <p>
+   * Text belongs to the nearest enclosing element that survives the policy,
+   * so this does not reach text inside an <i>allowed</i> element nested in
+   * the named one: {@code <template><p>shown</p></template>} keeps
+   * {@code shown} if {@code <p>} is allowed.  It is not a way to drop an
+   * element together with everything inside it.
    */
   public HtmlPolicyBuilder disallowTextIn(String... elementNames) {
     invalidateCompiledState();
@@ -808,16 +821,21 @@ public class HtmlPolicyBuilder {
    */
   public PolicyFactory toFactory() {
     Set<String> textContainerSetBuilder = new HashSet<>();
+    Set<String> disallowedTextContainerSetBuilder = new HashSet<>();
     for (Map.Entry<String, Boolean> textContainer
          : this.textContainers.entrySet()) {
       if (Boolean.TRUE.equals(textContainer.getValue())) {
         textContainerSetBuilder.add(textContainer.getKey());
+      } else {
+        disallowedTextContainerSetBuilder.add(textContainer.getKey());
       }
     }
     CompiledState compiled = compilePolicies();
 
     return new PolicyFactory(
-        compiled.compiledPolicies, Collections.unmodifiableSet(textContainerSetBuilder),
+        compiled.compiledPolicies,
+        Collections.unmodifiableSet(textContainerSetBuilder),
+        Collections.unmodifiableSet(disallowedTextContainerSetBuilder),
         j8().mapCopyOf(compiled.globalAttrPolicies),
         preprocessor, postprocessor);
   }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
@@ -56,17 +56,25 @@ public final class PolicyFactory
   private final Map<String, ElementAndAttributePolicies> policies;
   private final Map<String, AttributePolicy> globalAttrPolicies;
   private final Set<String> textContainers;
+  /**
+   * Elements whose text is suppressed even when the element itself is dropped,
+   * from {@link HtmlPolicyBuilder#disallowTextIn}.  Disjoint from
+   * {@link #textContainers}.
+   */
+  private final Set<String> disallowedTextContainers;
   private final HtmlStreamEventProcessor preprocessor;
   private final HtmlStreamEventProcessor postprocessor;
 
   PolicyFactory(
       Map<String, ElementAndAttributePolicies> policies,
       Set<String> textContainers,
+      Set<String> disallowedTextContainers,
       Map<String, AttributePolicy> globalAttrPolicies,
       HtmlStreamEventProcessor preprocessor,
       HtmlStreamEventProcessor postprocessor) {
     this.policies = policies;
     this.textContainers = textContainers;
+    this.disallowedTextContainers = disallowedTextContainers;
     this.globalAttrPolicies = globalAttrPolicies;
     this.preprocessor = preprocessor;
     this.postprocessor = postprocessor;
@@ -80,7 +88,8 @@ public final class PolicyFactory
   /** Produces a sanitizer that emits tokens to {@code out}. */
   public HtmlSanitizer.Policy apply(@Nonnull HtmlStreamEventReceiver out) {
     return new ElementAndAttributePolicyBasedSanitizerPolicy(
-        postprocessor.wrap(out), policies, textContainers);
+        postprocessor.wrap(out), policies, textContainers,
+        disallowedTextContainers);
   }
 
   /**
@@ -182,6 +191,20 @@ public final class PolicyFactory
       f.textContainers.forEach(containerBuilder::add);
       allTextContainers = Collections.unmodifiableSet(containerBuilder);
     }
+    // A disallowTextIn from either factory carries over, unless the other
+    // allows text in that element: grants union here as they do above.
+    Set<String> allDisallowedTextContainers;
+    if (this.disallowedTextContainers.isEmpty()
+        && f.disallowedTextContainers.isEmpty()) {
+      allDisallowedTextContainers = this.disallowedTextContainers;
+    } else {
+      Set<String> disallowedBuilder = new HashSet<>();
+      disallowedBuilder.addAll(this.disallowedTextContainers);
+      disallowedBuilder.addAll(f.disallowedTextContainers);
+      disallowedBuilder.removeAll(allTextContainers);
+      allDisallowedTextContainers
+          = Collections.unmodifiableSet(disallowedBuilder);
+    }
     Map<String, AttributePolicy> allGlobalAttrPolicies;
     if (f.globalAttrPolicies.isEmpty()) {
       allGlobalAttrPolicies = this.globalAttrPolicies;
@@ -213,7 +236,8 @@ public final class PolicyFactory
         = HtmlStreamEventProcessor.Processors.compose(
             this.postprocessor, f.postprocessor);
     return new PolicyFactory(
-        Collections.unmodifiableMap(builder), allTextContainers, allGlobalAttrPolicies,
+        Collections.unmodifiableMap(builder), allTextContainers,
+        allDisallowedTextContainers, allGlobalAttrPolicies,
         compositionOfPreprocessors, compositionOfPostprocessors);
   }
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
@@ -57,9 +57,9 @@ public final class PolicyFactory
   private final Map<String, AttributePolicy> globalAttrPolicies;
   private final Set<String> textContainers;
   /**
-   * Elements whose text is suppressed even when the element itself is dropped,
-   * from {@link HtmlPolicyBuilder#disallowTextIn}.  Disjoint from
-   * {@link #textContainers}.
+   * Elements in which text is disallowed, from
+   * {@link HtmlPolicyBuilder#disallowTextIn}, whether the element is kept,
+   * renamed or dropped.  Disjoint from {@link #textContainers}.
    */
   private final Set<String> disallowedTextContainers;
   private final HtmlStreamEventProcessor preprocessor;
@@ -192,19 +192,14 @@ public final class PolicyFactory
       allTextContainers = Collections.unmodifiableSet(containerBuilder);
     }
     // A disallowTextIn from either factory carries over, unless the other
-    // allows text in that element: grants union here as they do above.
-    Set<String> allDisallowedTextContainers;
-    if (this.disallowedTextContainers.isEmpty()
-        && f.disallowedTextContainers.isEmpty()) {
-      allDisallowedTextContainers = this.disallowedTextContainers;
-    } else {
-      Set<String> disallowedBuilder = new HashSet<>();
-      disallowedBuilder.addAll(this.disallowedTextContainers);
-      disallowedBuilder.addAll(f.disallowedTextContainers);
-      disallowedBuilder.removeAll(allTextContainers);
-      allDisallowedTextContainers
-          = Collections.unmodifiableSet(disallowedBuilder);
-    }
+    // allows text in that element: grants union here as they do above, and
+    // the two sets stay disjoint as they are in a single builder.
+    Set<String> disallowedBuilder
+        = new HashSet<>(this.disallowedTextContainers);
+    disallowedBuilder.addAll(f.disallowedTextContainers);
+    disallowedBuilder.removeAll(allTextContainers);
+    Set<String> allDisallowedTextContainers
+        = Collections.unmodifiableSet(disallowedBuilder);
     Map<String, AttributePolicy> allGlobalAttrPolicies;
     if (f.globalAttrPolicies.isEmpty()) {
       allGlobalAttrPolicies = this.globalAttrPolicies;

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -72,9 +72,30 @@ public class TagBalancingHtmlStreamEventReceiver
   }
 
   /**
+   * Implemented by a policy that suppresses the text inside dropped elements
+   * beyond the fixed {@link
+   * ElementAndAttributePolicyBasedSanitizerPolicy#SKIPPABLE_ELEMENT_CONTENT}
+   * list, such as one built with {@code disallowTextIn}.
+   *
+   * <p>This receiver drops a start tag that would exceed the nesting limit
+   * before the policy sees it, and keeps the content of such an element
+   * suppressed on the policy's behalf (see {@link #droppedSkippableDepth}).
+   * It knows the fixed list itself; for anything else it has to ask.
+   */
+  interface TextSuppressionPolicy {
+    /**
+     * @param canonElementName a canonical element name.
+     * @return true if text directly inside a dropped {@code canonElementName}
+     *     is suppressed rather than emitted where the element was.
+     */
+    boolean suppressesTextWhenDropped(String canonElementName);
+  }
+
+  /**
    * How many elements whose content the policy would suppress -- {@code
-   * <script>}, {@code <style>}, {@code <iframe>} and friends -- have been
-   * dropped for exceeding the nesting limit and not yet closed.
+   * <script>}, {@code <style>}, {@code <iframe>} and friends, plus any the
+   * policy names through {@link TextSuppressionPolicy} -- have been dropped
+   * for exceeding the nesting limit and not yet closed.
    *
    * <p>The policy decides to skip such an element's text when it sees the
    * element's start tag.  A tag this receiver drops never reaches the policy,
@@ -83,9 +104,14 @@ public class TagBalancingHtmlStreamEventReceiver
    */
   private int droppedSkippableDepth;
 
-  private static boolean contentIsSkippable(String canonElementName) {
-    return ElementAndAttributePolicyBasedSanitizerPolicy
-        .SKIPPABLE_ELEMENT_CONTENT.contains(canonElementName);
+  private boolean contentIsSkippable(String canonElementName) {
+    if (ElementAndAttributePolicyBasedSanitizerPolicy
+        .SKIPPABLE_ELEMENT_CONTENT.contains(canonElementName)) {
+      return true;
+    }
+    return underlying instanceof TextSuppressionPolicy
+        && ((TextSuppressionPolicy) underlying)
+            .suppressesTextWhenDropped(canonElementName);
   }
 
   private void reportDroppedByNestingLimit(String elementName) {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -1675,6 +1675,110 @@ class HtmlPolicyBuilderTest {
   }
 
   /**
+   * The text gate was set from the last tag alone, so a dropped tag inside an
+   * element whose content is never shown reset it and let the content
+   * through.  Text now belongs to the nearest enclosing element the policy
+   * kept, and a dropped element in between suppresses it only if its content
+   * is never shown.  Regression test for #444.
+   */
+  @Test
+  void testDroppedTagInsideSuppressedContentDoesNotResetTheTextGate() {
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder().allowElements("h1", "div");
+    assertEquals("", apply(b, "<noscript>text</noscript>"));
+    assertEquals("", apply(b, "<noscript><b>text</b></noscript>"));
+    assertEquals("", apply(b, "<noscript><b>a</b>b</noscript>"));
+    // A dropped void element never goes on the stack, so it must not reset
+    // the gate either.
+    assertEquals("", apply(b, "<noscript><img>text</noscript>"));
+    assertEquals(
+        "<div>z</div>",
+        apply(b, "<div><object><b>x</b>y</object>z</div>"));
+    // A kept element inside is a text container in its own right.
+    assertEquals(
+        "<div>shown</div>",
+        apply(b, "<noscript><div>shown</div></noscript>"));
+  }
+
+  /**
+   * The same slip seen through {@code disallowTextIn}: a dropped {@code <p>}
+   * between the text and the kept template reset the gate.  Part of #444.
+   */
+  @Test
+  void testDisallowTextInReachesPastADroppedChild() {
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder()
+        .allowElements("template", "h1")
+        .disallowTextIn("template");
+    assertEquals(
+        "<template></template>",
+        apply(b, "<template><p>excluded-text</p></template>"));
+    assertEquals(
+        "<template><h1>shown</h1></template>",
+        apply(b, "<template><h1>shown</h1></template>"));
+  }
+
+  /**
+   * {@code disallowTextIn(x)} applies when the policy drops {@code x} too.
+   * The builder used to discard the disallowed names when it compiled, so a
+   * policy that disallowed both the template element and text in it still
+   * emitted the template's text as bare text.  The policy and input are the
+   * ones reported in #194.
+   */
+  @Test
+  void testDisallowTextInAppliesToADroppedElement() {
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder()
+        .disallowElements("template")
+        .disallowTextIn("template")
+        .allowElements("h1");
+    assertEquals(
+        "<h1>allowed text</h1>",
+        apply(
+            b,
+            "<html><h1>allowed text</h1><template><p>excluded-text</p>"
+            + "</template><script>script-text</script><html>"));
+    // Text after the dropped element resumes.
+    assertEquals("after", apply(b, "<template>hidden</template>after"));
+    // Text inside an allowed element nested in the dropped one belongs to
+    // that element, and is not affected.
+    assertEquals(
+        "<h1>shown</h1>",
+        apply(b, "<template><h1>shown</h1></template>"));
+
+    // An allowed element that is dropped for having no attributes is dropped
+    // all the same, so the text in it goes too.
+    HtmlPolicyBuilder noBareSpans = new HtmlPolicyBuilder()
+        .allowElements("span")
+        .allowAttributes("title").onElements("span")
+        .disallowTextIn("span");
+    assertEquals(
+        "<span title=\"t\"></span>",
+        apply(noBareSpans, "<span title=t>x</span>"));
+    assertEquals("", apply(noBareSpans, "<span>x</span>"));
+  }
+
+  /**
+   * {@code and} carries a {@code disallowTextIn} over from either factory,
+   * unless the other allows text in that element: grants union under
+   * {@code and}, as they do for elements and attributes.
+   */
+  @Test
+  void testAndCombinesDisallowedTextContainers() {
+    PolicyFactory headings = new HtmlPolicyBuilder()
+        .allowElements("h1").toFactory();
+    PolicyFactory noTemplateText = new HtmlPolicyBuilder()
+        .disallowTextIn("template").toFactory();
+    String html = "<h1>a</h1><template>hidden</template>";
+    assertEquals("<h1>a</h1>hidden", headings.sanitize(html));
+    assertEquals("<h1>a</h1>", headings.and(noTemplateText).sanitize(html));
+    assertEquals("<h1>a</h1>", noTemplateText.and(headings).sanitize(html));
+
+    PolicyFactory templates = new HtmlPolicyBuilder()
+        .allowElements("template").toFactory();
+    assertEquals(
+        "<h1>a</h1><template>hidden</template>",
+        headings.and(noTemplateText).and(templates).sanitize(html));
+  }
+
+  /**
    * A factory is typically parked in a static final for the life of the JVM,
    * so nothing it holds may point back at the throwaway builder.  The value
    * policies behind {@code matching(...)} used to be anonymous classes, and

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -1776,6 +1776,72 @@ class HtmlPolicyBuilderTest {
     assertEquals(
         "<h1>a</h1><template>hidden</template>",
         headings.and(noTemplateText).and(templates).sanitize(html));
+
+    // Disallowing the element in one factory grants nothing, so it does not
+    // cancel the other factory's disallowTextIn.
+    PolicyFactory noDivs = new HtmlPolicyBuilder()
+        .disallowElements("div").toFactory();
+    PolicyFactory noDivText = new HtmlPolicyBuilder()
+        .disallowTextIn("div").toFactory();
+    assertEquals("", noDivText.and(noDivs).sanitize("<div>hidden</div>"));
+    assertEquals("", noDivs.and(noDivText).sanitize("<div>hidden</div>"));
+  }
+
+  /**
+   * A kept element is judged by the name it was kept under, so a policy that
+   * renames {@code span} to {@code div} would otherwise honour
+   * {@code disallowTextIn("span")} only when the span happened to be dropped.
+   * The rule follows the name the author wrote.
+   */
+  @Test
+  void testDisallowTextInFollowsARenamedElement() {
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder()
+        .allowElements((name, attrs) -> "div", "span")
+        .allowElements("div")
+        .allowAttributes("title").onElements("span")
+        .disallowTextIn("span");
+    assertEquals(
+        "<div title=\"t\"></div>", apply(b, "<span title=t>hi</span>"));
+    assertEquals("", apply(b, "<span>hi</span>"));
+    assertEquals("<div>hi</div>", apply(b, "<div>hi</div>"));
+  }
+
+  /**
+   * Once a kept child closes, the text that follows it is still inside the
+   * dropped element, and stays suppressed.  The old gate reset to the nearest
+   * kept ancestor at every close tag, so that text leaked.
+   */
+  @Test
+  void testSuppressionResumesAfterAKeptChildCloses() {
+    HtmlPolicyBuilder b = new HtmlPolicyBuilder().allowElements("p");
+    assertEquals("<p>b</p>", apply(b, "<noscript>a<p>b</p>c</noscript>"));
+    // Text after the dropped element itself is unaffected.
+    assertEquals("<p>b</p>d", apply(b, "<noscript>a<p>b</p>c</noscript>d"));
+    assertEquals(
+        "<p>b</p>",
+        apply(
+            b.disallowTextIn("template"), "<template>a<p>b</p>c</template>"));
+  }
+
+  /**
+   * The other side of the gate following the nearest kept element: text inside
+   * a dropped child of a kept element that cannot hold text itself is dropped
+   * too, where it used to be written straight into that element.  A browser
+   * would not keep text directly inside a {@code <tr>} either.  Policies that
+   * allow the cells are unaffected.
+   */
+  @Test
+  void testTextInADroppedCellOfAKeptRowIsDropped() {
+    String table = "<table><tr><td>cell</td></tr></table>";
+    assertEquals(
+        "<table><tbody><tr></tr></tbody></table>",
+        apply(new HtmlPolicyBuilder().allowElements("table", "tbody", "tr"),
+              table));
+    assertEquals(
+        "<table><tbody><tr><td>cell</td></tr></tbody></table>",
+        apply(
+            new HtmlPolicyBuilder().allowElements("table", "tbody", "tr", "td"),
+            table));
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -27,6 +27,7 @@
 
 package org.owasp.html;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -110,6 +112,55 @@ class HtmlSanitizerTest {
     // But ordinary text outside the suppressed element still comes through.
     assertTrue(
         p.sanitize(nest("<script>S</script>VISIBLE", 300)).contains("VISIBLE"));
+
+    // The same holds for an element the policy, rather than the fixed list,
+    // says to suppress text in: the balancer has to ask the policy.
+    PolicyFactory q = new HtmlPolicyBuilder()
+        .allowElements("div").disallowTextIn("template").toFactory();
+    String deep = nest("<template>SECRET</template>", 300);
+    assertFalse(q.sanitize(deep).contains("SECRET"));
+    // Also with an HtmlChangeReporter between the balancer and the policy.
+    HtmlChangeListener<Object> listener = new HtmlChangeListener<Object>() {
+      public void discardedTag(@Nullable Object context, String elementName) {
+        // Not under test.
+      }
+      public void discardedAttributes(
+          @Nullable Object context, String tagName, String... attributeNames) {
+        // Not under test.
+      }
+    };
+    assertFalse(q.sanitize(deep, listener, null).contains("SECRET"));
+    // And the template's text still shows where nothing disallows it.
+    assertTrue(p.sanitize(deep).contains("SECRET"));
+  }
+
+  /**
+   * The balancer forwards tags it does not recognize without counting them
+   * toward the nesting limit, so a run of them is the one way to grow the
+   * policy's open-element stack without bound.  Nothing on the per-tag or
+   * per-text path may walk that stack, or a few hundred kilobytes of unknown
+   * tags cost seconds of CPU.  Quadratic behaviour takes minutes here; linear
+   * takes a fraction of a second.
+   */
+  @Test
+  void testLongRunOfUnknownTagsIsLinear() {
+    PolicyFactory p = new HtmlPolicyBuilder().allowElements("div").toFactory();
+    int n = 200_000;
+    StringBuilder html = new StringBuilder("<div>");
+    StringBuilder expected = new StringBuilder("<div>");
+    for (int i = 0; i < n; ++i) {
+      html.append("<zz>a");
+      expected.append('a');
+    }
+    for (int i = 0; i < n; ++i) {
+      html.append("</zz>");
+    }
+    html.append("</div>");
+    expected.append("</div>");
+    String input = html.toString();
+    String out = assertTimeoutPreemptively(
+        Duration.ofSeconds(20), () -> p.sanitize(input));
+    assertEquals(expected.toString(), out);
   }
 
   /**


### PR DESCRIPTION
`ElementAndAttributePolicyBasedSanitizerPolicy` kept one flag for whether text may be emitted and set it from each open tag alone. A dropped tag inside an element whose content is never shown reset the gate and let the content through: `<noscript><b>text</b></noscript>` came out as `text`, and `<div><object><b>x</b>y</object>z</div>` as `<div>xyz</div>`. A dropped void element such as `<img>` did the same. The same slip defeated `disallowTextIn` whenever a dropped element sat between the text and its container.

Text now belongs to the nearest enclosing element the policy kept, and a dropped element in between suppresses it only when its content is never shown or text in it is disallowed. The gate costs constant time per tag: each push derives the new value from the old one, and a bit per open element remembers the previous value so a pop restores it.

`disallowTextIn(x)` now applies to `x` as the author wrote it, whether the policy keeps, renames or drops it. That resolves #194: the builder used to discard the disallowed names when it compiled, so `disallowElements("template")` with `disallowTextIn("template")` still emitted the template's text. The names travel through `PolicyFactory`; `and()` keeps them unless the other factory allows text in that element; `disallowElements(x)` no longer records `x` as a text container, since a rejected element grants nothing; and the tag balancer asks the policy, through a new package-private `TextSuppressionPolicy` hook that `HtmlChangeReporter` forwards, whether a start tag it drops at the nesting limit opens suppressed content.

The second commit takes the review of the first. Every finding is fixed: the stack walk was quadratic on a run of unknown tags, which the balancer forwards without counting toward its limit (320 KB took 10 s; the close-tag path and the kept-`<style>` check were already quadratic on `main` with a smaller constant); `and()` cancelled a `disallowTextIn` when the other factory merely disallowed the element; the nesting limit bypassed `disallowTextIn`; a renamed element ignored it; and two consequences of the new rule were untested and undocumented.

Scope notes:
- Text inside a nested element that survives the policy belongs to that element and still shows. This is not a drop-the-subtree operation; the javadoc says so.
- Text that follows a kept child inside a dropped `<noscript>` stays suppressed, and text in a dropped `<td>` inside a kept `<tr>` is dropped rather than written into the row. Both are pinned and in the change log.
- An allowed element dropped for having no attributes (a bare `<span>`) is dropped all the same, so `disallowTextIn("span")` removes its text too.
- A void element renamed to a non-void one leaves a phantom stack entry. Pre-existing; filed as #450.

Each new test fails on the old code. `./mvnw verify` is green locally on JDK 21; CI covers 11 through 25.

Closes #444. Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
