### PR TITLE
fix: Let the Default URL Protocol Guard Yield in PolicyFactory.and

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,31 @@
 
 Most recent at top.
   * Next release
+    * `PolicyFactory.and` no longer lets a factory that allowed no URL
+      protocol veto the protocols the other factory allowed.  A builder that
+      never called `allowUrlProtocols` guards its URL attributes with a
+      default that rejects every absolute URL, and `and()` joined that
+      default in as though it were a policy, so `noProtocols.and(httpLinks)`
+      dropped every `http:` link that `httpLinks` allowed, in either order.
+      `Sanitizers.LINKS.and(f)` suffered the same way whenever `f` mentioned
+      `href` without allowing a protocol, which is how a factory that only
+      meant to restrict `href` to a pattern silently dropped every absolute
+      link.  The default now yields to the other factory's allowlist.  Two
+      allowlists still intersect, as `and()` documents, so
+      `httpsOnly.and(Sanitizers.LINKS)` still allows only `https:`, and the
+      default never yields to a policy attached with `matching`, so a
+      builder that allowed no protocol still rejects every absolute URL on
+      its own.  This holds for `srcset`, and for `url()` in `style` between
+      factories that both allowed URLs in styles, as well as for `href` and
+      `src`, and the same factories combined in any grouping allow the same
+      URLs.  One consequence to know about: the
+      protocol guard now runs after the policies an author attached with
+      `matching`, as the `style` guard already did, rather than before them.
+      So a `matching` policy on a URL attribute sees the value as written,
+      before the guard trims surrounding whitespace and percent-encodes
+      parentheses and control characters, and a policy that rewrites a URL
+      can no longer hand the output a protocol the builder did not allow.
+      Issue #204.
     * Text inside a dropped element is now gated by every element enclosing
       it, not by the last tag the policy saw.  The policy kept one flag for
       whether text may be emitted and set it from each open tag alone, so a

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -36,7 +36,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -552,6 +551,12 @@ public class HtmlPolicyBuilder {
    * not white-listing any protocols, effectively disallows the "href"
    * attribute globally.
    * <p>
+   * That default is not itself an allowlist, and {@link PolicyFactory#and}
+   * treats it differently from one.  A factory that allowed no protocol,
+   * combined with one that did, defers to it, so the combination allows the
+   * protocols the other factory allowed.  Two factories that each allowed
+   * some protocols together allow only those both allowed.
+   * <p>
    * Do not allow any <code>*script</code> such as <code>javascript</code>
    * protocols if you might use this policy with untrusted code.
    */
@@ -765,17 +770,12 @@ public class HtmlPolicyBuilder {
         if (intermediates.cssSchema == null) {
           return null;
         }
-        final AttributePolicy styleUrlPolicyFinal = AttributePolicy.Util.join(
-            intermediates.styleUrlPolicy, intermediates.urlAttributePolicy);
         return new StylingPolicy(
             intermediates.cssSchema,
-            new Function<String, String>() {
-              public String apply(String url) {
-                return styleUrlPolicyFinal.apply(
-                    "img", "src",
-                    url != null ? url : "about:invalid");
-              }
-            });
+            new StylingPolicy.UrlPolicyRewriter(
+                AttributePolicy.Util.join(
+                    intermediates.styleUrlPolicy,
+                    intermediates.urlAttributePolicy)));
       }
 
     });
@@ -903,16 +903,8 @@ public class HtmlPolicyBuilder {
 
     // Add guards on top of any custom policies.
     {
-      final AttributePolicy urlAttributePolicy;
-      if (allowedProtocols.size() == 3
-          && allowedProtocols.contains("mailto")
-          && allowedProtocols.contains("http")
-          && allowedProtocols.contains("https")) {
-        urlAttributePolicy = StandardUrlAttributePolicy.INSTANCE;
-      } else {
-        urlAttributePolicy = new FilterUrlByProtocolAttributePolicy(
-            allowedProtocols);
-      }
+      final AttributePolicy urlAttributePolicy =
+          UrlProtocolGuard.forProtocols(allowedProtocols);
 
       Set<String> toGuard = new HashSet<>(ATTRIBUTE_GUARDS.keySet());
       AttributeGuardIntermediates intermediates = new AttributeGuardIntermediates(

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
@@ -151,6 +151,11 @@ public final class PolicyFactory
    * Produces a factory that allows the union of the grants, and intersects
    * policies where they overlap on a particular granted attribute or element
    * name.
+   * <p>
+   * The guard a builder puts on URL attributes when it allowed no protocol
+   * is a default rather than a policy, so it yields here to the other
+   * factory's protocol allowlist; two allowlists intersect like any other
+   * overlapping policies.  See {@link HtmlPolicyBuilder#allowUrlProtocols}.
    */
   public PolicyFactory and(PolicyFactory f) {
     Map<String, ElementAndAttributePolicies> builder

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/SrcsetAttributePolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/SrcsetAttributePolicy.java
@@ -27,6 +27,11 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.owasp.html.AttributePolicy.JoinableAttributePolicy;
+
 /**
  * Applies a URL policy to all URLs in a srcset attribute value.
  * <p>
@@ -47,7 +52,7 @@ package org.owasp.html;
  * This policy applies the given attribute policy to URLs and emits metadata
  * as given, but normalizing spaces.
  */
-final class SrcsetAttributePolicy implements AttributePolicy {
+final class SrcsetAttributePolicy implements JoinableAttributePolicy {
 
   private final AttributePolicy srcPolicy;
 
@@ -128,6 +133,43 @@ final class SrcsetAttributePolicy implements AttributePolicy {
       return null;
     }
     return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof SrcsetAttributePolicy
+        && srcPolicy.equals(((SrcsetAttributePolicy) o).srcPolicy);
+  }
+
+  @Override
+  public int hashCode() {
+    return srcPolicy.hashCode();
+  }
+
+  public Joinable.JoinStrategy<JoinableAttributePolicy> getJoinStrategy() {
+    return SrcsetJoinStrategy.INSTANCE;
+  }
+
+  /**
+   * Joins srcset policies by joining the policies they apply to each URL, so
+   * that the URL protocol guards inside them meet and join as they do on
+   * {@code src}: a builder that allowed no protocol yields to one that did,
+   * and two allowlists intersect.
+   */
+  static final class SrcsetJoinStrategy
+  implements Joinable.JoinStrategy<JoinableAttributePolicy> {
+    static final SrcsetJoinStrategy INSTANCE = new SrcsetJoinStrategy();
+
+    public JoinableAttributePolicy join(
+        Iterable<? extends JoinableAttributePolicy> toJoin) {
+      List<AttributePolicy> srcPolicies = new ArrayList<>();
+      for (JoinableAttributePolicy p : toJoin) {
+        srcPolicies.add(((SrcsetAttributePolicy) p).srcPolicy);
+      }
+      return new SrcsetAttributePolicy(
+          AttributePolicy.Util.join(
+              srcPolicies.toArray(new AttributePolicy[0])));
+    }
   }
 
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/StylingPolicy.java
@@ -336,9 +336,8 @@ final class StylingPolicy implements JoinableAttributePolicy {
 
     public JoinableAttributePolicy join(
         Iterable<? extends JoinableAttributePolicy> toJoin) {
-      Function<String, String> identity = Function.<String>identity();
       CssSchema cssSchema = null;
-      Function<String, String> urlRewriter = identity;
+      List<AttributePolicy> urlPolicies = new ArrayList<>();
       for (JoinableAttributePolicy p : toJoin) {
         StylingPolicy sp = (StylingPolicy) p;
         // Joining narrows: a value has to satisfy every policy being joined,
@@ -347,31 +346,88 @@ final class StylingPolicy implements JoinableAttributePolicy {
         // properties that neither a nor b allowed on its own.
         cssSchema = cssSchema == null
             ? sp.cssSchema : CssSchema.intersection(cssSchema, sp.cssSchema);
-        urlRewriter = urlRewriter.equals(identity)
-            || urlRewriter.equals(sp.urlRewriter)
-            ? sp.urlRewriter
-            : andThen(urlRewriter, sp.urlRewriter);
+        urlPolicies.add(UrlPolicyRewriter.toAttributePolicy(sp.urlRewriter));
       }
-      return new StylingPolicy(cssSchema, urlRewriter);
+      // The rewriters are joined as attribute policies rather than composed
+      // as functions so that the URL protocol guards the builder put in them
+      // meet and join as they do on href: a builder that allowed no protocol
+      // yields to one that did, and two allowlists intersect.  A URL still
+      // has to satisfy every rewriter, in the order they were joined.
+      return new StylingPolicy(
+          cssSchema,
+          new UrlPolicyRewriter(
+              AttributePolicy.Util.join(
+                  urlPolicies.toArray(new AttributePolicy[0]))));
+    }
+  }
+
+  /**
+   * A url rewriter that applies an attribute policy, which is how the builder
+   * vets the URLs in a style attribute: the policy is the join of the one
+   * given to {@link HtmlPolicyBuilder#allowUrlsInStyles} and the protocol
+   * guard.  Keeping the policy reachable, rather than closing over it, lets
+   * the join strategy above join rewriters as attribute policies.
+   */
+  static final class UrlPolicyRewriter implements Function<String, String> {
+    final AttributePolicy policy;
+
+    UrlPolicyRewriter(AttributePolicy policy) {
+      this.policy = policy;
     }
 
-    /**
-     * A rewriter that runs both in turn, so a URL has to satisfy both to
-     * survive.  A rewriter signals "dropped" by returning null or the empty
-     * string, which is not a URL, so it short-circuits instead of being
-     * passed on to the next rewriter.
-     */
-    private static Function<String, String> andThen(
-        final Function<String, String> first,
-        final Function<String, String> second) {
-      return new Function<String, String>() {
-        public @Nullable String apply(String url) {
-          String rewritten = first.apply(url);
-          return rewritten == null || rewritten.isEmpty()
-              ? null
-              : second.apply(rewritten);
-        }
-      };
+    public @Nullable String apply(String url) {
+      return policy.apply("img", "src", url != null ? url : "about:invalid");
+    }
+
+    /** The attribute policy that vets a URL the way the rewriter does. */
+    static AttributePolicy toAttributePolicy(
+        Function<String, String> rewriter) {
+      return rewriter instanceof UrlPolicyRewriter
+          ? ((UrlPolicyRewriter) rewriter).policy
+          : new RewriterAttributePolicy(rewriter);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof UrlPolicyRewriter
+          && policy.equals(((UrlPolicyRewriter) o).policy);
+    }
+
+    @Override
+    public int hashCode() {
+      return policy.hashCode();
+    }
+  }
+
+  /**
+   * A caller's rewriter as an attribute policy.  A rewriter signals "dropped"
+   * by returning null or the empty string, which is not a URL, so the empty
+   * string becomes the null that stops a joined policy rather than being
+   * passed on to the next one.
+   */
+  private static final class RewriterAttributePolicy
+  implements AttributePolicy {
+    final Function<String, String> rewriter;
+
+    RewriterAttributePolicy(Function<String, String> rewriter) {
+      this.rewriter = rewriter;
+    }
+
+    public @Nullable String apply(
+        String elementName, String attributeName, String value) {
+      String rewritten = rewriter.apply(value);
+      return rewritten == null || rewritten.isEmpty() ? null : rewritten;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof RewriterAttributePolicy
+          && rewriter.equals(((RewriterAttributePolicy) o).rewriter);
+    }
+
+    @Override
+    public int hashCode() {
+      return rewriter.hashCode();
     }
   }
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/UrlProtocolGuard.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/UrlProtocolGuard.java
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause
+
+package org.owasp.html;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.owasp.html.AttributePolicy.JoinableAttributePolicy;
+
+import static org.owasp.shim.Java8Shim.j8;
+
+/**
+ * The guard {@link HtmlPolicyBuilder} puts on every URL attribute it allows,
+ * which lets a value through only if it names no protocol or names one the
+ * builder allowed via {@link HtmlPolicyBuilder#allowUrlProtocols}.
+ *
+ * <p>A builder that allowed no protocol installs {@link #NONE}, which rejects
+ * every URL that names a protocol.  That is a default, not an allowlist, and
+ * the difference shows when two factories are combined by
+ * {@link PolicyFactory#and}: the default yields to the other factory's
+ * allowlist, whereas two allowlists intersect, as policies on the same
+ * attribute always do.  So a factory that never mentioned protocols leaves
+ * the links of one that did alone, while two factories that each allowed
+ * some protocols together allow only those both allowed.  The default yields
+ * only to another guard.  It never yields to a policy an author attached with
+ * {@code matching}, so a builder that allowed no protocol rejects every
+ * absolute URL on its own, however its author-supplied policies are written.
+ *
+ * <p>Two allowlists with nothing in common join to an empty allowlist.  On
+ * its own that behaves like the default, but it is not one and does not
+ * yield, so the same factories combined in any grouping allow the same URLs.
+ */
+@TCB
+@Immutable
+final class UrlProtocolGuard implements JoinableAttributePolicy {
+
+  private static final Set<String> STANDARD_PROTOCOLS
+      = j8().setOf("http", "https", "mailto");
+
+  /** The guard for a builder that allowed no protocol. */
+  static final UrlProtocolGuard NONE = new UrlProtocolGuard(null);
+
+  /** The protocols allowed, or null for the default guard. */
+  private final @Nullable Set<String> allowlist;
+  private final AttributePolicy delegate;
+
+  /**
+   * The guard that enforces the given allowlist, or {@link #NONE} if it is
+   * empty.
+   */
+  static UrlProtocolGuard forProtocols(Set<? extends String> protocols) {
+    return protocols.isEmpty() ? NONE : new UrlProtocolGuard(protocols);
+  }
+
+  private UrlProtocolGuard(@Nullable Set<? extends String> allowlist) {
+    if (allowlist == null) {
+      this.allowlist = null;
+      this.delegate = new FilterUrlByProtocolAttributePolicy(j8().setOf());
+    } else {
+      this.allowlist = j8().setCopyOf(allowlist);
+      // The standard set has a checker that allocates nothing per URL.
+      this.delegate = STANDARD_PROTOCOLS.equals(this.allowlist)
+          ? StandardUrlAttributePolicy.INSTANCE
+          : new FilterUrlByProtocolAttributePolicy(this.allowlist);
+    }
+  }
+
+  public @Nullable String apply(
+      String elementName, String attributeName, String value) {
+    return delegate.apply(elementName, attributeName, value);
+  }
+
+  public Joinable.JoinStrategy<JoinableAttributePolicy> getJoinStrategy() {
+    return UrlProtocolGuardJoinStrategy.INSTANCE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof UrlProtocolGuard
+        && Objects.equals(allowlist, ((UrlProtocolGuard) o).allowlist);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(allowlist);
+  }
+
+  /** Intersects the allowlists being joined; the default guard yields. */
+  static final class UrlProtocolGuardJoinStrategy
+  implements Joinable.JoinStrategy<JoinableAttributePolicy> {
+    static final UrlProtocolGuardJoinStrategy INSTANCE =
+        new UrlProtocolGuardJoinStrategy();
+
+    public JoinableAttributePolicy join(
+        Iterable<? extends JoinableAttributePolicy> toJoin) {
+      Set<String> allowed = null;
+      for (JoinableAttributePolicy p : toJoin) {
+        Set<String> allowlist = ((UrlProtocolGuard) p).allowlist;
+        if (allowlist == null) { continue; }
+        if (allowed == null) {
+          allowed = new HashSet<>(allowlist);
+        } else {
+          allowed.retainAll(allowlist);
+        }
+      }
+      return allowed == null ? NONE : new UrlProtocolGuard(allowed);
+    }
+  }
+}

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -634,6 +634,38 @@ class HtmlPolicyBuilderTest {
     assertEquals("", withMatching, "the non-matching src is dropped too");
   }
 
+  /**
+   * The URL protocol guard runs after the policies an author attaches with
+   * matching, so it vets what they produce: a rewrite cannot hand the output
+   * a protocol the builder did not allow, while a rewrite to an allowed one
+   * survives.
+   */
+  @Test
+  void testUrlProtocolGuardVetsWhatAMatchingPolicyProduces() {
+    assertEquals(
+        "x",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowAttributes("href")
+                .matching((elementName, attributeName, value) ->
+                    "javascript:" + value)
+                .onElements("a")
+            .allowUrlProtocols("http"),
+            "<a href='/x'>x</a>"));
+    assertEquals(
+        "<a href=\"http://example.com/x\">x</a>",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowAttributes("href")
+                .matching((elementName, attributeName, value) ->
+                    "http://example.com" + value)
+                .onElements("a")
+            .allowUrlProtocols("http"),
+            "<a href='/x'>x</a>"));
+  }
+
   /** Rejecting only some values means allowing the rest. */
   @Test
   void testAnInvertedAllowRejectsOnlyTheMatchingValues() {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -95,6 +96,350 @@ final class PolicyFactoryTest {
     assertEquals(
         "<div style=\"color:red;width:10px\">x</div>",
         p.sanitize("<div style=\"color: red; width: 10px\">x</div>"));
+  }
+
+  /**
+   * Issue #204.  A builder that never allowed a URL protocol guards its URL
+   * attributes with a default that rejects every absolute URL.  Joined with
+   * a factory that did allow some, that default used to be intersected as
+   * though it were a policy, so the combination rejected the protocols the
+   * other factory allowed, in either order.  The default now yields to an
+   * allowlist.
+   */
+  @Test
+  void testAndDefaultUrlProtocolGuardYieldsToAnAllowlist() {
+    String links = String.join(
+        "\n",
+        "<a href='http://example.com/'>http</a>",
+        "<a href='HTTP://example.com/'>HTTP</a>",
+        "<a href='https://example.com/'>https</a>",
+        "<a href='//example.com/'>scheme-relative</a>",
+        "<a href='/local'>relative</a>",
+        "<a href='javascript:alert(1)'>js</a>",
+        "<a href='jAvAsCrIpT:alert(1)'>JS</a>",
+        "<a href='\tjavascript:alert(1)'>tab js</a>",
+        "<a href='java&#9;script:alert(1)'>split js</a>",
+        "<a href='data:text/html,x'>data</a>",
+        "<a href='vbscript:x'>vbs</a>");
+    String relativeOnly = String.join(
+        "\n",
+        "http",
+        "HTTP",
+        "https",
+        "scheme-relative",
+        "<a href=\"/local\">relative</a>",
+        "js",
+        "JS",
+        "tab js",
+        "split js",
+        "data",
+        "vbs");
+    String httpOnly = String.join(
+        "\n",
+        "<a href=\"http://example.com/\">http</a>",
+        "<a href=\"HTTP://example.com/\">HTTP</a>",
+        "https",
+        "scheme-relative",
+        "<a href=\"/local\">relative</a>",
+        "js",
+        "JS",
+        "tab js",
+        "split js",
+        "data",
+        "vbs");
+
+    PolicyFactory noProtocols = links();
+    PolicyFactory http = links("http");
+
+    assertEquals(relativeOnly, noProtocols.sanitize(links));
+    assertEquals(httpOnly, http.sanitize(links));
+    assertEquals(httpOnly, noProtocols.and(http).sanitize(links));
+    assertEquals(httpOnly, http.and(noProtocols).sanitize(links));
+  }
+
+  /** Two factories that allowed no protocol still allow none together. */
+  @Test
+  void testAndOfTwoDefaultUrlProtocolGuardsAllowsNoProtocol() {
+    PolicyFactory noProtocols = links();
+    PolicyFactory noProtocolsWithTitle = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href", "title").onElements("a")
+        .toFactory();
+    String links = String.join(
+        "\n",
+        "<a href='http://example.com/' title='t'>http</a>",
+        "<a href='/local' title='t'>relative</a>");
+    String expected = String.join(
+        "\n",
+        "<a title=\"t\">http</a>",
+        "<a href=\"/local\" title=\"t\">relative</a>");
+
+    assertEquals(
+        expected, noProtocols.and(noProtocolsWithTitle).sanitize(links));
+    assertEquals(
+        expected, noProtocolsWithTitle.and(noProtocols).sanitize(links));
+  }
+
+  /**
+   * Two allowlists intersect, as and() documents.  An empty intersection is
+   * an allowlist too, not the default, so it does not yield to a third
+   * factory: the same factories allow the same URLs however they are
+   * grouped.
+   */
+  @Test
+  void testAndIntersectsUrlProtocolAllowlists() {
+    PolicyFactory http = links("http");
+    PolicyFactory https = links("https");
+    PolicyFactory both = links("http", "https");
+
+    String links = String.join(
+        "\n",
+        "<a href='http://example.com/'>http</a>",
+        "<a href='https://example.com/'>https</a>",
+        "<a href='//example.com/'>scheme-relative</a>",
+        "<a href='/local'>relative</a>",
+        "<a href='javascript:alert(1)'>js</a>");
+    String bothKept = String.join(
+        "\n",
+        "<a href=\"http://example.com/\">http</a>",
+        "<a href=\"https://example.com/\">https</a>",
+        "<a href=\"//example.com/\">scheme-relative</a>",
+        "<a href=\"/local\">relative</a>",
+        "js");
+    String httpKept = String.join(
+        "\n",
+        "<a href=\"http://example.com/\">http</a>",
+        "https",
+        "scheme-relative",
+        "<a href=\"/local\">relative</a>",
+        "js");
+    String noneKept = String.join(
+        "\n",
+        "http",
+        "https",
+        "scheme-relative",
+        "<a href=\"/local\">relative</a>",
+        "js");
+
+    assertEquals(bothKept, both.sanitize(links));
+    assertEquals(httpKept, both.and(http).sanitize(links));
+    assertEquals(httpKept, http.and(both).sanitize(links));
+    assertEquals(noneKept, http.and(https).sanitize(links));
+    assertEquals(noneKept, https.and(http).sanitize(links));
+
+    assertEquals(noneKept, http.and(https).and(both).sanitize(links));
+    assertEquals(noneKept, both.and(http.and(https)).sanitize(links));
+    assertEquals(noneKept, http.and(both.and(https)).sanitize(links));
+    assertEquals(noneKept, http.and(https).and(links()).sanitize(links));
+  }
+
+  /**
+   * The case that bites in practice: Sanitizers.LINKS combined with a
+   * factory that only meant to restrict href to a pattern, and so never
+   * mentioned protocols, used to lose every absolute link.
+   */
+  @Test
+  void testAndLinksWithAFactoryThatRestrictsHrefButAllowedNoProtocol() {
+    PolicyFactory exampleOnly = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href")
+            .matching(Pattern.compile("(?:https?://example\\.com)?/.*"))
+            .onElements("a")
+        .toFactory();
+    String links = String.join(
+        "\n",
+        "<a href='http://example.com/a'>example</a>",
+        "<a href='https://example.com/b'>secure example</a>",
+        "<a href='http://evil.example/c'>elsewhere</a>",
+        "<a href='/d'>local</a>",
+        "<a href='javascript:alert(1)'>js</a>",
+        "<a href='mailto:x@example.com'>mail</a>");
+    String expected = String.join(
+        "\n",
+        "<a href=\"http://example.com/a\" rel=\"nofollow\">example</a>",
+        "<a href=\"https://example.com/b\" rel=\"nofollow\">secure example</a>",
+        "elsewhere",
+        "<a href=\"/d\" rel=\"nofollow\">local</a>",
+        "js",
+        "mail");
+
+    assertEquals(
+        String.join(
+            "\n",
+            "example",
+            "secure example",
+            "elsewhere",
+            "<a href=\"/d\">local</a>",
+            "js",
+            "mail"),
+        exampleOnly.sanitize(links));
+    assertEquals(expected, Sanitizers.LINKS.and(exampleOnly).sanitize(links));
+    assertEquals(expected, exampleOnly.and(Sanitizers.LINKS).sanitize(links));
+  }
+
+  /** A global href grant that allowed no protocol does not veto either. */
+  @Test
+  void testAndLinksWithAGlobalHrefGrantThatAllowedNoProtocol() {
+    PolicyFactory hrefAnywhere = new HtmlPolicyBuilder()
+        .allowAttributes("href").globally()
+        .toFactory();
+    String links = String.join(
+        "\n",
+        "<a href='http://example.com/'>http</a>",
+        "<a href='javascript:alert(1)'>js</a>");
+    String expected = String.join(
+        "\n",
+        "<a href=\"http://example.com/\" rel=\"nofollow\">http</a>",
+        "js");
+
+    assertEquals(expected, Sanitizers.LINKS.and(hrefAnywhere).sanitize(links));
+    assertEquals(expected, hrefAnywhere.and(Sanitizers.LINKS).sanitize(links));
+  }
+
+  /**
+   * The default yields only to another builder's allowlist, never to a
+   * policy the author attached with matching, so a builder that allowed no
+   * protocol still rejects every absolute URL on its own, as the javadoc of
+   * allowUrlProtocols promises, even when that policy is the library's own
+   * protocol filter.  And an allowlist from another factory intersects with
+   * such a policy, as with any other.
+   */
+  @Test
+  void testDefaultUrlProtocolGuardDoesNotYieldToAMatchingPolicy() {
+    PolicyFactory httpsByMatching = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href")
+            .matching(new FilterUrlByProtocolAttributePolicy(
+                Arrays.asList("https")))
+            .onElements("a")
+        .toFactory();
+    String links = String.join(
+        "\n",
+        "<a href='https://example.com/'>https</a>",
+        "<a href='/local'>relative</a>");
+    String relativeOnly = String.join(
+        "\n",
+        "https",
+        "<a href=\"/local\">relative</a>");
+
+    assertEquals(relativeOnly, httpsByMatching.sanitize(links));
+    assertEquals(relativeOnly, httpsByMatching.and(links()).sanitize(links));
+    assertEquals(relativeOnly, links().and(httpsByMatching).sanitize(links));
+    assertEquals(
+        relativeOnly, httpsByMatching.and(links("http")).sanitize(links));
+    assertEquals(
+        String.join(
+            "\n",
+            "<a href=\"https://example.com/\">https</a>",
+            "<a href=\"/local\">relative</a>"),
+        httpsByMatching.and(links("https")).sanitize(links));
+  }
+
+  /** The same for srcset, whose guard wraps the protocol guard. */
+  @Test
+  void testAndDefaultUrlProtocolGuardYieldsInSrcset() {
+    PolicyFactory noProtocols = images();
+    PolicyFactory http = images("http");
+    String img = "<img src='http://example.com/a.png'"
+        + " srcset='http://example.com/a.png 1x, javascript:alert(1) 2x,"
+        + " /b.png 3x'>";
+    String httpKept = "<img src=\"http://example.com/a.png\""
+        + " srcset=\"http://example.com/a.png 1x , /b.png 3x\" />";
+
+    assertEquals("<img srcset=\"/b.png 3x\" />", noProtocols.sanitize(img));
+    assertEquals(httpKept, http.sanitize(img));
+    assertEquals(httpKept, noProtocols.and(http).sanitize(img));
+    assertEquals(httpKept, http.and(noProtocols).sanitize(img));
+  }
+
+  /**
+   * And for url() in style, whose rewriter wraps the protocol guard, between
+   * factories that both allowed URLs in styles.  A rewriter from
+   * CssSchema.toAttributePolicy is a policy of the author's, and takes part
+   * however the factories are grouped, as does the policy given to
+   * allowUrlsInStyles, which the default does not yield to.
+   */
+  @Test
+  void testAndDefaultUrlProtocolGuardYieldsInStyles() {
+    CssSchema images =
+        CssSchema.withProperties(Arrays.asList("background-image"));
+    PolicyFactory noProtocols = styled(images);
+    PolicyFactory https = styled(images, "https");
+    String divs =
+        "<div style=\"background-image: url(https://example.com/i.png)\">"
+        + "x</div>"
+        + "<div style=\"background-image: url(javascript:alert%281%29)\">"
+        + "y</div>";
+    String httpsKept =
+        "<div style=\"background-image:url("
+        + "&#39;https://example.com/i.png&#39;)\">"
+        + "x</div><div>y</div>";
+
+    assertEquals("<div>x</div><div>y</div>", noProtocols.sanitize(divs));
+    assertEquals(httpsKept, https.sanitize(divs));
+    assertEquals(httpsKept, noProtocols.and(https).sanitize(divs));
+    assertEquals(httpsKept, https.and(noProtocols).sanitize(divs));
+
+    PolicyFactory vetted = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style")
+            .matching(images.toAttributePolicy(url -> url + "?vetted"))
+            .onElements("div")
+        .toFactory();
+    String vettedKept =
+        "<div style=\"background-image:url("
+        + "&#39;https://example.com/i.png?vetted&#39;)\">"
+        + "x</div><div>y</div>";
+    assertEquals(
+        "<div>x</div><div>y</div>", noProtocols.and(vetted).sanitize(divs));
+    assertEquals(vettedKept, noProtocols.and(vetted).and(https).sanitize(divs));
+    assertEquals(vettedKept, noProtocols.and(vetted.and(https)).sanitize(divs));
+    assertEquals(vettedKept, vetted.and(https).and(noProtocols).sanitize(divs));
+    assertEquals(vettedKept, https.and(noProtocols.and(vetted)).sanitize(divs));
+
+    PolicyFactory httpsInStylesOnly = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(images)
+        .allowUrlsInStyles(new FilterUrlByProtocolAttributePolicy(
+            Arrays.asList("https")))
+        .toFactory();
+    assertEquals("<div>x</div><div>y</div>", httpsInStylesOnly.sanitize(divs));
+    assertEquals(
+        "<div>x</div><div>y</div>",
+        httpsInStylesOnly.and(noProtocols).sanitize(divs));
+    assertEquals(httpsKept, httpsInStylesOnly.and(https).sanitize(divs));
+  }
+
+  /** Links, with the given protocols allowed. */
+  private static PolicyFactory links(String... protocols) {
+    return new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href").onElements("a")
+        .allowUrlProtocols(protocols)
+        .toFactory();
+  }
+
+  /** Images with src and srcset, with the given protocols allowed. */
+  private static PolicyFactory images(String... protocols) {
+    return new HtmlPolicyBuilder()
+        .allowElements("img")
+        .allowAttributes("src", "srcset").onElements("img")
+        .allowUrlProtocols(protocols)
+        .toFactory();
+  }
+
+  /**
+   * Styled divs that allow URLs in styles, with the given protocols allowed.
+   */
+  private static PolicyFactory styled(CssSchema schema, String... protocols) {
+    return new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(schema)
+        .allowUrlsInStyles(AttributePolicy.IDENTITY_ATTRIBUTE_POLICY)
+        .allowUrlProtocols(protocols)
+        .toFactory();
   }
 
   @Test


### PR DESCRIPTION
A builder that never called `allowUrlProtocols` guards its URL attributes with a protocol filter over an empty set, which rejects every absolute URL. `PolicyFactory.and` joined that guard in like any other attribute policy, so it vetoed the protocols the other factory allowed: `noProtocols.and(httpLinks)` dropped every `http:` link in either order, and `Sanitizers.LINKS.and(f)` dropped every absolute link whenever `f` mentioned `href` without allowing a protocol, which is how a factory that only meant to restrict `href` to a pattern lost all its links. This is the URL protocol part of #204.

The default is not an allowlist, and now says so. A new package-private `UrlProtocolGuard` is what the builder installs. It uses the existing `Joinable` scaffolding, and its join strategy intersects the allowlists it is given while a guard with none, the default, yields. Two allowlists still intersect, as `and()` documents and `SanitizersTest.testAndIntersects` pins, so `httpsOnly.and(Sanitizers.LINKS)` still allows only `https:`. The default yields only to another guard, never to a policy attached with `matching`, so a builder that allowed no protocol still rejects every absolute URL on its own. An empty intersection stays distinct from the default so that it does not yield either, which keeps `and()` associative.

The same guard sits inside `SrcsetAttributePolicy` and inside the style guard's URL rewriter, so both learn to join: srcset by joining the policies it applies to each URL, and `StylingPolicy` by joining its rewriters as attribute policies rather than composing them as functions. A caller's rewriter from `CssSchema.toAttributePolicy` is adapted with the same empty-means-dropped rule the old composition had.

Scope notes:
- The guard now runs after the policies an author attached with `matching`, as the style guard already did, rather than before them. A `matching` policy on a URL attribute therefore sees the value as written, before the guard trims whitespace and percent-encodes parentheses and control characters, and a rewriting policy can no longer hand the output a protocol the builder did not allow. A test pins the latter; the change log describes both.
- `allowUrlsInStyles` has a reject-everything default of its own that `and()` still treats as a policy: a factory that never called it vetoes the CSS URLs of one that did. That is the same shape of problem one level up, but it is a grant of URLs rather than of protocols, and is not touched here.
- Part 2 of #204, where `allowElements("p").and(disallowElements("p"))` keeps `p`, is the documented union of grants and is not changed.
- No public API changes. `FilterUrlByProtocolAttributePolicy` and `StandardUrlAttributePolicy` are untouched; the guard delegates to them.

Each new test fails on `main` except the two that pin what did not change: two defaults still allow nothing, and allowlists still intersect. `./mvnw clean verify` is green locally on JDK 17; CI covers 11 through 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZemHzAgi8HdNgDFPzBqfs
