### PR TITLE
Add a JPMS module descriptor in META-INF/versions/9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,18 @@ This is a multi-module Maven build:
 - `owasp-java-html-sanitizer/` - the library. Core code:
   `owasp-java-html-sanitizer/src/main/java/org/owasp/html/`. Tests:
   `owasp-java-html-sanitizer/src/test/java/org/owasp/html/`.
+  `src/main/java9/module-info.java` is the JPMS module descriptor. A second
+  compiler execution compiles it for Java 9 into `META-INF/versions/9/` of
+  the multi-release JAR, which is how a Java 8 JAR carries one; it exports
+  `org.owasp.html` only. `src/it/jpms-consumer/` is a small module that
+  `./mvnw verify` compiles and runs against the packaged JAR to check that
+  the descriptor is read and the shim stays encapsulated. Those two are the
+  only Java 9 sources in the library module.
 - `java8-shim/`, `java10-shim/` - in-repo shims that let the Java 8 library
   use newer JDK collection APIs when running on Java 10+. Both are inlined
   into the library JAR by the shade plugin and do not appear in the published
   POM. `java10-shim` is the only module that may use Java 9 and 10 APIs
-  (`maven.compiler.release` 10). No module uses anything newer.
+  (`maven.compiler.release` 10). Nothing uses anything newer.
 - `empiricism/` - in-browser experiments that record how real browsers nest
   and balance tags. They generate `HtmlElementTablesCanned.java` in the
   library's core package. Never hand-edit that file: change the probe or
@@ -45,7 +52,9 @@ browser parser quirks.
   version that satisfies the enforcer.
 - The library targets Java 8 source and bytecode (`maven.compiler.release` 8)
   regardless of the JDK used to build, and test code is compiled at the same
-  level. Do not use newer language features or APIs in either.
+  level. Do not use newer language features or APIs in either. The module
+  descriptor and the modular consumer check are the exceptions, compiled
+  for Java 9 and nothing newer.
 - Tests use JUnit 5 (Jupiter). Do not add JUnit 4 style tests.
 - Fuzzer tests (`*FuzzerTest.java`) and the AntiSamy test suite are part of
   the normal test run. The fuzzers seed from the clock and report the seed

--- a/change_log.md
+++ b/change_log.md
@@ -214,6 +214,21 @@ Most recent at top.
       resolving the JPMS split-package error on the module path. The shim
       artifacts are no longer published separately. If you added an explicit
       dependency on `java8-shim` or `java10-shim` as a workaround, remove it.
+    * The jar is now an explicit JPMS module, `owasp.java.html.sanitizer`,
+      rather than an automatic one.  A module descriptor compiled for Java 9
+      ships at `META-INF/versions/9/module-info.class` and the manifest is
+      marked `Multi-Release: true`, so Java 9 and later read it while Java 8,
+      which never looks there, is unaffected.  The module name is the one
+      the jar already had, so `requires owasp.java.html.sanitizer` keeps
+      working; what changes is what it reaches.  The module exports
+      `org.owasp.html` and nothing else, so the bundled `org.owasp.shim`
+      package, which an automatic module exported along with everything
+      else, is now encapsulated.  The JSR 305 annotations on the API are a
+      `requires static jsr305`, so nothing new is needed on the module
+      path.  The build compiles and runs a small consumer module against
+      the packaged jar on every JDK in the CI matrix and fails if the jar
+      resolves as an automatic module, exports more than `org.owasp.html`,
+      or lets another module reach the shim.  Closes #389.
     * HTML: Follow the WHATWG tokenizer for degenerate comments. `<!>`,
       `<!-->`, `<!--->` and `<!->` are complete empty comments, and `--!>`
       closes a comment even when only dashes precede it (`<!----!>`),

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -19,6 +19,15 @@ The sanitizer JAR is self-contained: the `java8-shim` and `java10-shim` artifact
 are bundled inside it and do **not** need to be declared as separate dependencies,
 including when using the JPMS module path.
 
+On the module path the JAR is an explicit module named
+`owasp.java.html.sanitizer` that exports the `org.owasp.html` package:
+
+```Java
+module com.example.app {
+    requires owasp.java.html.sanitizer;
+}
+```
+
 Be sure to change the
 [version](https://cwiki.apache.org/confluence/display/MAVENOLD/Dependency+Mediation+and+Conflict+Resolution#DependencyMediationandConflictResolution-DependencyVersionRanges)
 to a range suitable to your project.  There are no unstable releases

--- a/owasp-java-html-sanitizer/pom.xml
+++ b/owasp-java-html-sanitizer/pom.xml
@@ -22,6 +22,45 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <!-- The library is compiled for Java 8 by the default execution,
+               so the module descriptor cannot sit beside the sources.  This
+               second execution compiles src/main/java9/module-info.java
+               for Java 9 into target/classes/META-INF/versions/9, where a
+               multi-release jar keeps the classes for that release.  The
+               plugin patches the Java 8 classes already in target/classes
+               into the module for this compile, so javac checks that every
+               exported package exists.  See issue #389.
+
+               The plugin prints a boxed warning that jsr305 is a
+               filename-based automatic module and the project should not
+               be published.  That is expected and safe here: the JSR 305
+               jar has no Automatic-Module-Name and, with no release since
+               3.0.2 in 2017, never will, so the derived name is stable;
+               the descriptor requires it static, so nothing is asked of a
+               consumer at run time; and module resolution does not follow
+               a static dependence, so consumers compile against this
+               module without jsr305 on their module path.  The consumer
+               check below runs without it. -->
+          <execution>
+            <id>compile-module-info</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+              </compileSourceRoots>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- http://www.javaworld.com/article/2074515/core-java/
            unit-test-code-coverage-with-maven-and-jacoco.html -->
       <plugin>
@@ -76,9 +115,22 @@
                  package unless we name it, and naming it advertises a
                  dependency the bundle does not have. -->
             <Import-Package>!org.owasp.shim,javax.annotation;resolution:=optional,*</Import-Package>
-            <!-- Explicit JPMS automatic module name so consumers using the
-                 module path can require this module by a stable name that
-                 is independent of the JAR filename. -->
+            <!-- bnd 3.5 predates multi-release jars and warns that
+                 META-INF/versions/9/module-info.class is a class in the
+                 wrong directory.  It is exactly where the JDK expects it,
+                 so drop that one warning and no other. -->
+            <_fixupmessages>Classes found in the wrong directory*module-info*;is:=ignore</_fixupmessages>
+            <!-- The jar is a multi-release jar for one reason: to carry the
+                 JPMS module descriptor compiled from src/main/java9 at
+                 META-INF/versions/9/module-info.class, which Java 9 and
+                 later read only when this header is present and Java 8
+                 never looks at.  There are no versioned copies of any
+                 class.  See issue #389. -->
+            <Multi-Release>true</Multi-Release>
+            <!-- Java 9 and later take the module name from the descriptor
+                 and ignore this header.  It is kept so that tools which
+                 read only the manifest, and any that predate multi-release
+                 descriptors, see the same stable name. -->
             <Automatic-Module-Name>owasp.java.html.sanitizer</Automatic-Module-Name>
           </instructions>
         </configuration>
@@ -133,6 +185,66 @@
               <!-- Generate a reduced POM that omits the now-inlined shim
                    dependencies, keeping the published POM accurate -->
               <createDependencyReducedPom>true</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Compile and run src/it/jpms-consumer, a named module that
+           declares `requires owasp.java.html.sanitizer`, against the
+           packaged jar with plain javac and java from the JDK running the
+           build.  That is the check issue #389 asked for: the jar must be
+           read as an explicit module by every JDK in the CI matrix, and
+           JpmsConsumerCheck then verifies what it exports, what it
+           requires, and that the bundled shim stays encapsulated.  It runs
+           at integration-test, after the shaded jar exists, so `mvn test`
+           is unaffected; nothing here is a surefire test because the
+           test sources are compiled for Java 8, which has no modules. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>compile-jpms-consumer</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${java.home}/bin/javac</executable>
+              <!-- By default the plugin rewrites a module path option into
+                   an @argfile and, for java, loses the path.  Pass the
+                   arguments as written. -->
+              <longModulepath>false</longModulepath>
+              <arguments>
+                <!-- Java 9 is the release the descriptor targets, and
+                     pinning it keeps the check from drifting onto APIs
+                     newer than the JDKs it has to run on. -->
+                <argument>--release</argument>
+                <argument>9</argument>
+                <argument>-d</argument>
+                <argument>${project.build.directory}/jpms-consumer</argument>
+                <argument>--module-path</argument>
+                <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
+                <argument>${project.basedir}/src/it/jpms-consumer/module-info.java</argument>
+                <argument>${project.basedir}/src/it/jpms-consumer/org/owasp/html/jpmscheck/JpmsConsumerCheck.java</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>run-jpms-consumer</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${java.home}/bin/java</executable>
+              <longModulepath>false</longModulepath>
+              <arguments>
+                <argument>--module-path</argument>
+                <argument>${project.build.directory}/${project.build.finalName}.jar${path.separator}${project.build.directory}/jpms-consumer</argument>
+                <argument>--module</argument>
+                <argument>org.owasp.html.jpmscheck/org.owasp.html.jpmscheck.JpmsConsumerCheck</argument>
+              </arguments>
             </configuration>
           </execution>
         </executions>

--- a/owasp-java-html-sanitizer/src/it/jpms-consumer/module-info.java
+++ b/owasp-java-html-sanitizer/src/it/jpms-consumer/module-info.java
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause
+
+/**
+ * A consumer of the sanitizer on the module path.  The build compiles this
+ * module against the packaged jar and runs it, so a jar that Java 9 and
+ * later would not read as the explicit module {@code owasp.java.html.sanitizer}
+ * fails right here with "module not found".  See issue #389.
+ */
+module org.owasp.html.jpmscheck {
+  requires owasp.java.html.sanitizer;
+}

--- a/owasp-java-html-sanitizer/src/it/jpms-consumer/org/owasp/html/jpmscheck/JpmsConsumerCheck.java
+++ b/owasp-java-html-sanitizer/src/it/jpms-consumer/org/owasp/html/jpmscheck/JpmsConsumerCheck.java
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause
+
+package org.owasp.html.jpmscheck;
+
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleDescriptor.Exports;
+import java.lang.module.ModuleDescriptor.Requires;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
+
+/**
+ * Checks, from inside a named module that requires the sanitizer, that the
+ * packaged jar is the explicit JPMS module issue #389 asked for.
+ *
+ * <p>The build runs this at the integration-test phase with the packaged
+ * jar and this module on the module path and nothing else, which is how a
+ * consumer that declares {@code requires owasp.java.html.sanitizer} sees
+ * the library.  Any failure exits non-zero and fails the build.  This is not
+ * a unit test: the sanitizer's tests are compiled for Java 8 and cannot
+ * name {@link java.lang.Module}, and they run before the jar exists.  It is
+ * compiled for Java 9, the release the descriptor targets, so keep to Java 9
+ * APIs here.
+ */
+public final class JpmsConsumerCheck {
+
+  private JpmsConsumerCheck() {}
+
+  public static void main(String[] args) {
+    Module module = PolicyFactory.class.getModule();
+    check(module.isNamed(), "the sanitizer is in the unnamed module");
+    check("owasp.java.html.sanitizer".equals(module.getName()),
+        "unexpected module name " + module.getName());
+
+    ModuleDescriptor descriptor = module.getDescriptor();
+    check(!descriptor.isAutomatic(),
+        "the sanitizer was resolved as an automatic module, so the jar's"
+        + " module-info.class was not read");
+    check(!descriptor.isOpen(), "the module is open");
+
+    // The API package, and nothing else, is exported.
+    Set<String> exported = new TreeSet<>();
+    for (Exports e : descriptor.exports()) {
+      check(!e.isQualified(), "qualified export of " + e.source());
+      exported.add(e.source());
+    }
+    check(Set.of("org.owasp.html").equals(exported),
+        "exports " + exported + " rather than only org.owasp.html");
+    check(descriptor.opens().isEmpty(), "opens " + descriptor.opens());
+    check(descriptor.uses().isEmpty(), "uses " + descriptor.uses());
+    check(descriptor.provides().isEmpty(), "provides " + descriptor.provides());
+
+    // The bundled shim is inside the module -- so the sanitizer can load it
+    // -- but is not exported, so no one else can depend on it.
+    check(descriptor.packages().contains("org.owasp.shim"),
+        "org.owasp.shim is not a package of the module: "
+        + descriptor.packages());
+    check(!module.isExported("org.owasp.shim"), "org.owasp.shim is exported");
+    check(!module.isOpen("org.owasp.shim"), "org.owasp.shim is open");
+
+    // The only dependences are java.base and, at compile time only, the JSR
+    // 305 annotations.  jsr305 is not on the module path here, which a
+    // static dependence has to tolerate and a plain one would not.
+    Map<String, Set<Requires.Modifier>> requires = new HashMap<>();
+    for (Requires r : descriptor.requires()) {
+      requires.put(r.name(), r.modifiers());
+    }
+    check(Set.of("java.base", "jsr305").equals(requires.keySet()),
+        "requires " + requires);
+    check(requires.get("jsr305").contains(Requires.Modifier.STATIC),
+        "jsr305 is not a static dependence: " + requires);
+    check(!requires.get("jsr305").contains(Requires.Modifier.TRANSITIVE),
+        "jsr305 is a transitive dependence: " + requires);
+    check(!ModuleLayer.boot().findModule("jsr305").isPresent(),
+        "jsr305 is on the module path, so this run proves nothing about"
+        + " the static dependence");
+
+    // Encapsulation holds at run time: the public shim entry point that
+    // org.owasp.html calls freely is inaccessible from another module,
+    // while the same reflective call into the exported package works.
+    try {
+      Sanitizers.class.getField("FORMATTING").get(null);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("cannot reach the exported API reflectively", e);
+    }
+    try {
+      Class.forName("org.owasp.shim.Java8Shim").getMethod("j8").invoke(null);
+      check(false, "org.owasp.shim.Java8Shim.j8() is accessible from another"
+          + " module");
+    } catch (IllegalAccessException expected) {
+      // Not exported to us: exactly what a real module descriptor buys.
+    } catch (ClassNotFoundException | NoSuchMethodException
+        | InvocationTargetException e) {
+      throw new AssertionError("the shim did not fail in the expected way", e);
+    }
+
+    // And the sanitizer works from the module path, which drives the shim
+    // loader inside the module.
+    String sanitized = Sanitizers.FORMATTING.sanitize(
+        "<b onclick=\"steal()\">safe</b><script>alert(1)</script>");
+    check("<b>safe</b>".equals(sanitized), "sanitized to " + sanitized);
+
+    System.out.println("owasp.java.html.sanitizer is an explicit module"
+        + " exporting only org.owasp.html; " + descriptor);
+  }
+
+  private static void check(boolean condition, String failure) {
+    if (!condition) {
+      throw new AssertionError(failure);
+    }
+  }
+}

--- a/owasp-java-html-sanitizer/src/main/java9/module-info.java
+++ b/owasp-java-html-sanitizer/src/main/java9/module-info.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause
+
+/**
+ * The OWASP Java HTML Sanitizer: takes third-party HTML and produces HTML
+ * that is safe to embed in your web application.
+ *
+ * <p>This descriptor is compiled for Java 9 and packaged under
+ * {@code META-INF/versions/9/} in a multi-release jar, so the jar stays
+ * usable on Java 8, which never looks there, while Java 9 and later read
+ * it as an explicit module.  Only {@code org.owasp.html} is exported.
+ * {@code org.owasp.shim}, the Java 8 shim bundled into this jar, is an
+ * implementation detail and stays encapsulated.
+ */
+module owasp.java.html.sanitizer {
+  exports org.owasp.html;
+
+  // The JSR 305 nullability and concurrency annotations on the API
+  // (javax.annotation and javax.annotation.concurrent) document it and have
+  // no runtime behaviour, so the dependency is compile-time only and a
+  // consumer need not have jsr305 on its module path.  The jsr305 jar has no
+  // Automatic-Module-Name, so its module name derives from the file name.
+  requires static jsr305;
+}

--- a/owasp-java-html-sanitizer/src/test/resources/packaging-verification.xml
+++ b/owasp-java-html-sanitizer/src/test/resources/packaging-verification.xml
@@ -6,6 +6,21 @@
       <location>target/classes/META-INF/MANIFEST.MF</location>
       <contains>Export-Package: org.owasp.html</contains>
     </file>
+    <!-- The JPMS module descriptor is compiled for Java 9 into the
+         versioned directory of the multi-release jar, and Java 9 and later
+         look there only when the manifest says Multi-Release.  Without
+         either half, `requires owasp.java.html.sanitizer` silently gets
+         the automatic module derived from the manifest, which exports
+         every package.  This checks the compiler's output and the
+         manifest bnd wrote; the modular consumer under src/it/jpms-consumer
+         checks the packaged jar itself.  See #389. -->
+    <file>
+      <location>target/classes/META-INF/MANIFEST.MF</location>
+      <contains>Multi-Release: true</contains>
+    </file>
+    <file>
+      <location>target/classes/META-INF/versions/9/module-info.class</location>
+    </file>
     <!-- The examples are demonstration code, not API, and live in their own
          unpublished module.  This catches the way they would realistically
          come back: someone re-adding a class under src/main/java here.  It


### PR DESCRIPTION
## Summary

Follow-up to #379. The jar is now an explicit JPMS module rather than an automatic one: `src/main/java9/module-info.java` is compiled for Java 9 by a second compiler execution into `META-INF/versions/9/module-info.class`, and the manifest is marked `Multi-Release: true`, which is what makes Java 9 and later read it. Java 8 never looks there, so the jar is unchanged for it.

```java
module owasp.java.html.sanitizer {
  exports org.owasp.html;
  requires static jsr305;
}
```

- Only `org.owasp.html` is exported. The bundled `org.owasp.shim` package, which an automatic module exported along with everything else, is now encapsulated.
- The JSR 305 annotations on the API are a static dependence, so consumers need nothing new on their module path. Resolution does not follow static dependences, so a consumer compiles and runs against the module without `jsr305` present; the new check runs that way.
- The module name is the one the jar already had, so existing `requires owasp.java.html.sanitizer` directives keep working. The `Automatic-Module-Name` header stays for tools that read only the manifest.

## Verification built into the build

The issue asked for verification with a small consumer project on Java 11, 17 and 21. That is now part of `mvn verify`, so CI does it on every JDK in the matrix (11, 17, 21, 25):

- `src/it/jpms-consumer` is a named module with `requires owasp.java.html.sanitizer`. At `integration-test`, after the shaded jar exists, the build compiles it with plain `javac` against the packaged jar and runs it with `java` on the module path, with nothing else on it.
- `JpmsConsumerCheck` fails the build if the jar resolves as an automatic module, exports anything but `org.owasp.html`, requires anything but `java.base` and a static `jsr305`, or lets a reflective call from another module reach `org.owasp.shim`. It also sanitizes a payload so the shim loader runs inside the module.
- Negative check, done by hand: with `META-INF/versions/9/module-info.class` deleted from the jar, or with `Multi-Release: true` removed from the manifest, the consumer still compiles (against the automatic module) but the check fails with "resolved as an automatic module". So both halves are load-bearing and both are covered.
- The packaging verifier additionally requires `Multi-Release: true` in the manifest bnd wrote and the compiled descriptor under `target/classes`.
- `mvn test` is unaffected: the check runs after packaging, and the reactor still resolves the library to `target/classes` for the `examples` tests as before.

Local results, all green: `./mvnw clean verify` on JDK 11, 17, 21 and 25 (462 library tests plus the examples), `./mvnw -Ppublication -DskipTests verify` on JDK 11 for the javadoc and sources jars, and `./mvnw -DskipTests test` for the test lifecycle. `java --describe-module` on each JDK reports:

```
owasp.java.html.sanitizer@20000101-SNAPSHOT
exports org.owasp.html
requires java.base mandated
requires jsr305 static
contains org.owasp.shim
```

## Notes for review

- The compiler plugin prints a boxed warning that `jsr305` is a filename-based automatic module and the project should not be published. The POM comment explains why that is expected and safe: the JSR 305 jar has no `Automatic-Module-Name` and, with no release since 3.0.2 in 2017, never will; the dependence is static; and consumers resolve the module without it.
- bnd 3.5 predates multi-release jars and warned about a class in the wrong directory. That one message is fixed up with a pattern that matches only the module descriptor.
- The exec plugin's `longModulepath` option defaults to true and silently drops a `--module-path` argument passed to `java`; both executions turn it off.
- The descriptor does not appear in the `-sources.jar`, since `src/main/java9` is not a compile source root. Making it one would put a `module-info.java` in front of the Java 8 compile and of javadoc.
- No Java 8 JDK is installed here, so the Java 8 side rests on the specification: a Java 8 `JarFile` has no notion of `META-INF/versions`, and the base classes are unchanged.

Closes #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZemHzAgi8HdNgDFPzBqfs
