### PR TITLE
fix: Honor Self-Closing Tags Inside SVG and MathML

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,22 @@
 
 Most recent at top.
   * Next release
+    * Self-closing tags inside `<svg>` and `<math>` now close.  Browsers
+      honor the self-closing flag on a start tag in foreign content, so
+      `<path d="..."/>` is a complete, empty element there, and on `<svg/>`
+      and `<math/>` themselves.  The sanitizer discarded the flag, so each
+      self-closing `<path/>` nested inside the one before it and the end of
+      the SVG closed them all at once:
+      `<svg><path d="M0 0"/><path d="M1 1"/></svg>` came out as
+      `<svg><path d="M0 0"><path d="M1 1"></path></path></svg>`, and now
+      comes out as `<svg><path d="M0 0"></path><path d="M1 1"></path></svg>`.
+      A policy sees such a tag as an open tag followed at once by its close
+      tag.  Nothing changes in HTML content, where the flag means nothing on
+      a non-void element, nor for the tags that break out of foreign
+      content, such as `<div/>` or `<p/>` inside `<svg>`, which browsers
+      process as HTML.  Elements whose content the lexer reads as text, such
+      as `<style>` and `<title>`, keep that content up to their end tag as
+      before.  Issue #122.
     * `PolicyFactory.and` no longer lets a factory that allowed no URL
       protocol veto the protocols the other factory allowed.  A builder that
       never called `allowUrlProtocols` guards its URL attributes with a

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -27,9 +27,13 @@
 
 package org.owasp.html;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
+
+import static org.owasp.shim.Java8Shim.j8;
 
 /**
  * Consumes an HTML stream, and dispatches events to a policy object which
@@ -64,7 +68,10 @@ public final class HtmlSanitizer {
     void openTag(String elementName, List<String> attrs);
 
     /**
-     * Called when an HTML tag like {@code </foo>} is seen in the input.
+     * Called when an HTML tag like {@code </foo>} is seen in the input, and
+     * right after {@link #openTag} for a self-closing tag like
+     * {@code <path/>} where browsers honor the self-closing flag: on
+     * {@code <svg/>} and {@code <math/>}, and on most tags inside them.
      *
      * @param elementName a normalized (lower-case for non-namespaced names)
      *     element name.
@@ -136,6 +143,12 @@ public final class HtmlSanitizer {
     // Use a linked list so that policies can use Iterator.remove() in an O(1)
     // way.
     LinkedList<String> attrs = new LinkedList<>();
+    // The number of <svg> and <math> start tags seen without a matching end
+    // tag.  Browsers parse the content of those elements as foreign content,
+    // where a start tag's self-closing flag is honored: <path/> is a whole,
+    // empty element.  In HTML content the flag means nothing, and <path/>
+    // opens an element that only an end tag closes.  Issue #122.
+    int foreignContentDepth = 0;
     while (lexer.hasNext()) {
       HtmlToken token = lexer.next();
       switch (token.type) {
@@ -149,16 +162,22 @@ public final class HtmlSanitizer {
           break;
         case TAGBEGIN:
           if (htmlContent.charAt(token.start + 1) == '/') {  // A close tag.
-            receiver.closeTag(HtmlLexer.canonicalElementName(
-                htmlContent.substring(token.start + 2, token.end)));
+            String elementName = HtmlLexer.canonicalElementName(
+                htmlContent.substring(token.start + 2, token.end));
+            receiver.closeTag(elementName);
             while (lexer.hasNext()
                    && lexer.next().type != HtmlTokenType.TAGEND) {
               // skip tokens until we see a ">"
+            }
+            if (foreignContentDepth != 0
+                && isForeignContentRoot(elementName)) {
+              --foreignContentDepth;
             }
           } else {
             attrs.clear();
 
             boolean attrsReadyForName = true;
+            boolean selfClosing = false;
             tagBody:
             while (lexer.hasNext()) {
               HtmlToken tagBodyToken = lexer.next();
@@ -180,6 +199,10 @@ public final class HtmlSanitizer {
                   attrsReadyForName = true;
                   break;
                 case TAGEND:
+                  // The lexer ends a start tag with a "/>" token only when
+                  // the solidus immediately precedes the ">", which is when
+                  // the WHATWG tokenizer sets the self-closing flag.
+                  selfClosing = htmlContent.charAt(tagBodyToken.start) == '/';
                   break tagBody;
                 default:
                   // Just drop anything not recognized
@@ -188,10 +211,21 @@ public final class HtmlSanitizer {
             if (!attrsReadyForName) {
               attrs.add(attrs.getLast());
             }
-            receiver.openTag(
-                HtmlLexer.canonicalElementName(
-                    htmlContent.substring(token.start + 1, token.end)),
-                attrs);
+            String elementName = HtmlLexer.canonicalElementName(
+                htmlContent.substring(token.start + 1, token.end));
+            boolean foreignContentRoot = isForeignContentRoot(elementName);
+            // Decided before the policy sees the attributes, since it may
+            // edit them.
+            boolean closesItself = selfClosing
+                && (foreignContentRoot
+                    || (foreignContentDepth != 0
+                        && closesItselfInForeignContent(elementName, attrs)));
+            receiver.openTag(elementName, attrs);
+            if (closesItself) {
+              receiver.closeTag(elementName);
+            } else if (foreignContentRoot) {
+              ++foreignContentDepth;
+            }
           }
           break;
         default:
@@ -203,6 +237,69 @@ public final class HtmlSanitizer {
 
     receiver.closeDocument();
   }
+
+  /**
+   * True for the elements whose content browsers parse as foreign content
+   * rather than as HTML.
+   */
+  private static boolean isForeignContentRoot(String canonElementName) {
+    return "svg".equals(canonElementName) || "math".equals(canonElementName);
+  }
+
+  /**
+   * True if a self-closing start tag for the named element, seen inside
+   * {@code <svg>} or {@code <math>}, opens an element that closes at once.
+   *
+   * <p>That is what browsers do with a start tag processed under the rules
+   * for foreign content.  The exceptions are the tags that break out of
+   * foreign content, which browsers process as HTML, where the flag on a
+   * non-void element is ignored, and the elements whose content the lexer
+   * has already committed to treating as text.
+   *
+   * @param attrs alternating attribute names and values as the author wrote
+   *     them, before any policy has edited them.
+   */
+  private static boolean closesItselfInForeignContent(
+      String canonElementName, List<String> attrs) {
+    if (HtmlTextEscapingMode.getModeForTag(canonElementName)
+        != HtmlTextEscapingMode.PCDATA) {
+      // A void element is empty already.  The lexer treats the content of
+      // <style>, <title> and the other elements with literal content as text
+      // up to the matching end tag, so the element stays open to hold it.
+      return false;
+    }
+    if (FOREIGN_CONTENT_BREAKOUT_ELEMENT_NAMES.contains(canonElementName)) {
+      return false;
+    }
+    if ("font".equals(canonElementName)) {
+      for (Iterator<String> it = attrs.iterator(); it.hasNext();) {
+        String name = it.next();
+        if (it.hasNext()) { it.next(); }  // The value.
+        if ("color".equals(name) || "face".equals(name)
+            || "size".equals(name)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * The start tags that end foreign content: inside {@code <svg>} or
+   * {@code <math>}, a browser pops back out to HTML content and processes one
+   * of these as HTML.  A {@code <font>} tag with a color, face or size
+   * attribute does the same.
+   *
+   * @see <a href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign"
+   *     >The rules for parsing tokens in foreign content</a>
+   */
+  private static final Set<String> FOREIGN_CONTENT_BREAKOUT_ELEMENT_NAMES
+      = j8().setOf(
+          "b", "big", "blockquote", "body", "br", "center", "code", "dd",
+          "div", "dl", "dt", "em", "embed", "h1", "h2", "h3", "h4", "h5",
+          "h6", "head", "hr", "i", "img", "li", "listing", "menu", "meta",
+          "nobr", "ol", "p", "pre", "ruby", "s", "small", "span", "strong",
+          "strike", "sub", "sup", "table", "tt", "u", "ul", "var");
 
   private static String stripQuotes(String encodedAttributeValue) {
     int n = encodedAttributeValue.length();

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -787,6 +787,208 @@ class HtmlSanitizerTest {
         sanitize("<p>foo</p> <p class=\"test\" \"=\">bar</p> <p>baz</p>"));
   }
 
+  /**
+   * Issue #122.  Browsers honor the self-closing flag on {@code <svg/>} and
+   * {@code <math/>}, and on most start tags inside them, where
+   * {@code <path/>} is a complete, empty element.  The sanitizer discarded
+   * the flag, so each self-closing path nested inside the one before it and
+   * the end of the SVG closed them all at once.
+   */
+  @Test
+  void testSelfClosingTagsInForeignContent() {
+    PolicyFactory p = foreignContentPolicy();
+    // The markup from the issue.
+    assertEquals(
+        "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\">\n"
+        + "    <path id=\"bounds\" opacity=\"0\" d=\"M0 0h24v24H0z\"></path>\n"
+        + "    <path d=\"M2 2\"></path>\n"
+        + "    <path d=\"M3 3\"></path>\n"
+        + "</svg>",
+        p.sanitize(
+            "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\">\n"
+            + "    <path id=\"bounds\" opacity=\"0\" d=\"M0 0h24v24H0z\"/>\n"
+            + "    <path d=\"M2 2\"/>\n"
+            + "    <path d=\"M3 3\"/>\n"
+            + "</svg>"));
+    // What follows a self-closing tag is a sibling, not content.
+    assertEquals(
+        "<svg><path d=\"M0 0\"></path>text<path d=\"M1 1\"></path></svg>",
+        p.sanitize("<svg><path d=\"M0 0\"/>text<path d=\"M1 1\"/></svg>"));
+    assertEquals(
+        "<svg><g><path d=\"M0 0\"></path><rect></rect></g>"
+        + "<path d=\"M1 1\"></path></svg>",
+        p.sanitize(
+            "<svg><g><path d=\"M0 0\"/><rect/></g><path d=\"M1 1\"/></svg>"));
+    // Names that keep their case are foreign content too, and SVG's
+    // textArea is not HTML's textarea.
+    assertEquals(
+        "<svg><clipPath></clipPath><g></g>x</svg>",
+        p.sanitize("<svg><clipPath/><g/>x</svg>"));
+    assertEquals(
+        "<svg><textArea></textArea>x</svg>",
+        p.sanitize("<svg><textArea/>x</svg>"));
+    assertEquals(
+        "<math><mi></mi>x<mrow></mrow>y</math>",
+        p.sanitize("<math><mi/>x<mrow/>y</math>"));
+    // The flag is honored on <svg/> and <math/> themselves, anywhere.
+    assertEquals("<svg></svg>x", p.sanitize("<svg/>x"));
+    assertEquals("<svg></svg>x", p.sanitize("<SVG/>x"));
+    assertEquals("<math></math>x", p.sanitize("<math/>x"));
+    assertEquals(
+        "<svg><svg></svg><path d=\"M0 0\"></path></svg>",
+        p.sanitize("<svg><svg/><path d=\"M0 0\"/></svg>"));
+    // Only a solidus right before the '>' sets the flag.
+    assertEquals(
+        "<svg><path d=\"M0\"></path>x</svg>",
+        p.sanitize("<svg><path d=M0 />x</svg>"));
+    assertEquals(
+        "<svg><path d=\"M0/&gt;\"></path>x</svg>",
+        p.sanitize("<svg><path d=\"M0/>\"/>x</svg>"));
+    // In an unquoted value the solidus is part of the value.
+    assertEquals(
+        "<svg><path d=\"M0/\">x</path></svg>",
+        p.sanitize("<svg><path d=M0/>x</svg>"));
+    assertEquals(
+        "<svg><path>x</path></svg>", p.sanitize("<svg><path / >x</svg>"));
+  }
+
+  /**
+   * Issue #122.  In HTML content the self-closing flag means nothing on a
+   * non-void element, so outside {@code <svg>} and {@code <math>} nothing
+   * changes: {@code <path/>} still opens an element that only an end tag
+   * closes.
+   */
+  @Test
+  void testSelfClosingTagsOutsideForeignContent() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<path d=\"M0 0\">x</path>", p.sanitize("<path d=\"M0 0\"/>x"));
+    assertEquals("<p>x</p>", p.sanitize("<p/>x"));
+    // Foreign content ends with the element that started it.
+    assertEquals(
+        "<svg></svg><path d=\"M0 0\">x</path>",
+        p.sanitize("<svg></svg><path d=\"M0 0\"/>x"));
+    assertEquals(
+        "<svg><path></path></svg><path d=\"M0 0\">x</path>",
+        p.sanitize("<svg><path/></svg><path d=\"M0 0\"/>x"));
+  }
+
+  /**
+   * Issue #122.  Browsers process the start tags that break out of foreign
+   * content as HTML, where the flag is ignored again; a void element is
+   * empty with or without it; and the elements whose content the lexer
+   * reads as text keep that content up to their end tag.
+   */
+  @Test
+  void testSelfClosingTagsThatBreakOutOfForeignContent() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals("<svg><div>x</div></svg>", p.sanitize("<svg><div/>x</svg>"));
+    assertEquals("<svg><p>x</p></svg>", p.sanitize("<svg><p/>x</svg>"));
+    // <font> breaks out only with a color, face or size attribute.
+    assertEquals(
+        "<svg><font color=\"red\">x</font></svg>",
+        p.sanitize("<svg><font color=\"red\"/>x</svg>"));
+    assertEquals(
+        "<svg><font></font>x</svg>", p.sanitize("<svg><font/>x</svg>"));
+    assertEquals("<svg><br />x</svg>", p.sanitize("<svg><br/>x</svg>"));
+    assertEquals(
+        "<svg><textarea>x</textarea></svg>",
+        p.sanitize("<svg><textarea/>x</textarea></svg>"));
+  }
+
+  /**
+   * Issue #122.  A self-closing tag is still subject to the policy, and what
+   * follows one is still text or markup that the policy sees, so the flag
+   * cannot smuggle anything past either.
+   */
+  @Test
+  void testSelfClosingTagsInForeignContentAreStillSanitized() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<svg><path></path>x</svg>",
+        p.sanitize("<svg><path onload=\"alert(1)\"/>x</svg>"));
+    // The solidus does not end this tag, so what follows it is an attribute.
+    assertEquals(
+        "<svg><path>x</path></svg>",
+        p.sanitize("<svg><path/onload=alert(1)>x</svg>"));
+    assertEquals(
+        "<svg>x</svg>",
+        p.sanitize("<svg><a href=\"javascript:alert(1)\"/>x</svg>"));
+    assertEquals(
+        "<svg><a href=\"http://example.com/\"></a>x</svg>",
+        p.sanitize("<svg><a href=\"http://example.com/\"/>x</svg>"));
+    assertEquals(
+        "<svg><g></g></svg>",
+        p.sanitize("<svg><g/><img src=x onerror=alert(1)></svg>"));
+    assertEquals(
+        "<svg><foreignObject></foreignObject><div>x</div></svg>",
+        p.sanitize("<svg><foreignObject/><div>x</div></svg>"));
+    // Raw text content is read up to the end tag and escaped, as before.
+    assertEquals(
+        "<svg><title>&lt;img src&#61;x onerror&#61;alert(1)&gt;</title></svg>",
+        p.sanitize("<svg><title/><img src=x onerror=alert(1)></title></svg>"));
+    assertEquals(
+        "<svg><style></style></svg>",
+        p.sanitize("<svg><style/><script>alert(1)</script></style></svg>"));
+    // Text after a dropped element that closed itself is shown, as in a
+    // browser, where that element is empty.
+    assertEquals("<svg>x</svg>", p.sanitize("<svg><noscript/>x</svg>"));
+    // Self-closing elements are siblings, so they never reach the nesting
+    // limit.
+    StringBuilder sb = new StringBuilder("<svg>");
+    for (int i = 0; i < 300; ++i) { sb.append("<g/>"); }
+    sb.append("x</svg>");
+    String out = p.sanitize(sb.toString());
+    assertEquals(300, out.split("<g></g>", -1).length - 1);
+    assertTrue(out.endsWith("x</svg>"));
+  }
+
+  /** Issue #122.  The events a policy sees for a self-closing tag. */
+  @Test
+  void testSelfClosingTagEvents() {
+    final List<String> events = new ArrayList<>();
+    HtmlSanitizer.Policy recorder = new HtmlSanitizer.Policy() {
+      public void openDocument() { events.add("openDocument"); }
+      public void closeDocument() { events.add("closeDocument"); }
+      public void openTag(String elementName, List<String> attrs) {
+        events.add("openTag " + elementName + " " + attrs);
+      }
+      public void closeTag(String elementName) {
+        events.add("closeTag " + elementName);
+      }
+      public void text(String text) { events.add("text " + text); }
+    };
+    HtmlSanitizer.sanitize(
+        "<svg><path d=\"M0 0\"/>x</svg><path/>y", recorder);
+    assertEquals(
+        Arrays.asList(
+            "openDocument",
+            "openTag svg []",
+            "openTag path [d, M0 0]",
+            "closeTag path",
+            "text x",
+            "closeTag svg",
+            "openTag path []",
+            "text y",
+            "closeDocument"),
+        events);
+  }
+
+  private static PolicyFactory foreignContentPolicy() {
+    return new HtmlPolicyBuilder()
+        .allowElements(
+            "svg", "math", "path", "g", "rect", "clipPath", "foreignObject",
+            "textArea", "textarea", "mi", "mrow", "a", "div", "p", "font",
+            "br", "style", "title")
+        .allowAttributes("width", "height", "viewBox").onElements("svg")
+        .allowAttributes("id", "opacity", "d").onElements("path")
+        .allowAttributes("href").onElements("a")
+        .allowAttributes("color").onElements("font")
+        .allowWithoutAttributes("font")
+        .allowStandardUrlProtocols()
+        .toFactory();
+  }
+
   private static String sanitize(@Nullable String html) {
     StringBuilder sb = new StringBuilder();
     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(


### PR DESCRIPTION
Browsers honor the self-closing flag on a start tag in foreign content, so `<path d="..."/>` inside `<svg>` is a complete, empty element, and on `<svg/>` and `<math/>` themselves. The sanitizer discarded the flag, so each self-closing `<path/>` nested inside the one before it and the end of the SVG closed them all at once: `<svg><path d="M0 0"/><path d="M1 1"/></svg>` came out as `<svg><path d="M0 0"><path d="M1 1"></path></path></svg>`. This is bug 1 of #122, which several people have hit since, and the fix has the shape suggested in that thread in 2022.

The `/>` is visible only in `HtmlSanitizer.sanitize`, whose token loop dropped it. The loop now counts the `<svg>` and `<math>` start tags seen without an end tag and, inside them, follows a self-closing start tag with its close tag at once, so a policy sees such a tag as an open tag followed by its close tag, exactly as it sees `<path></path>`. Everything downstream already handles that pair, so the policy, balancer and renderer are untouched. The decision is made before the policy sees the attributes, since it may edit them.

Left alone, as browsers do: the tags that break out of foreign content (`div`, `p`, `span` and the rest of the list in the WHATWG rules for parsing tokens in foreign content, plus `font` with a `color`, `face` or `size` attribute), which browsers process as HTML, where the flag means nothing on a non-void element; void elements, which are empty either way; and the elements whose content the lexer has already committed to reading as text up to the end tag, such as `style`, `title` and `textarea`, which stay open to hold that text. Nothing changes in HTML content: `<path/>` outside `<svg>` still opens an element that only an end tag closes.

Scope notes:
- The model is a depth count of unclosed `<svg>` and `<math>`, the same one `HtmlStreamRenderer` keeps for the output. MathML text integration points and HTML integration points (`foreignObject`, `desc`, `title`, `annotation-xml`), inside which browsers return to HTML rules, are not modeled, so a self-closing tag directly inside `<foreignObject>` closes at once here while a browser would leave it open. A breakout tag does not reset the count either. In every such case the output is explicit and re-parses the same way; the difference is only in how the input is read.
- `<path d=/>` is read as an empty `d` and self-closing, where a browser reads `d="/"` and no flag. The empty value is how the lexer already read it; the flag is new. Harmless, and not worth a special case.
- Bug 2 of #122, `{{` rendered as `{<!-- -->{`, is deliberate: it keeps sanitized text out of client-side template engines. Not changed.
- No public API changes. The `Policy.closeTag` javadoc now says when a self-closing tag produces the call.

Four of the five new tests in `HtmlSanitizerTest` fail on `main`; the fifth pins that HTML content is unchanged. The hostile inputs, `onload` on a self-closed `path`, `<path/onload=alert(1)>`, a `javascript:` href on a self-closed `a`, and `<title/>` or `<style/>` followed by script markup, come out as they should. `./mvnw clean verify` is green locally on JDK 11, 17, 21 and 25.

Closes #122.
