### PR TITLE
Track parser context for foreign self-closing tags

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,13 @@
 
 Most recent at top.
   * Next release
+    * Self-closing SVG and MathML handling now follows the browser's current
+      tree-construction context through HTML integration points, foreign
+      content breakout tags, and mismatched foreign end tags.  A slash after
+      an equals sign remains part of an unquoted attribute value, and a
+      self-closing foreign element named `<title>`, `<style>`, `<textarea>`,
+      or another HTML literal-content element closes without consuming the
+      markup that follows it.  Issue #457.
     * Self-closing tags inside `<svg>` and `<math>` now close.  Browsers
       honor the self-closing flag on a start tag in foreign content, so
       `<path d="..."/>` is a complete, empty element there, and on `<svg/>`
@@ -15,9 +22,7 @@ Most recent at top.
       tag.  Nothing changes in HTML content, where the flag means nothing on
       a non-void element, nor for the tags that break out of foreign
       content, such as `<div/>` or `<p/>` inside `<svg>`, which browsers
-      process as HTML.  Elements whose content the lexer reads as text, such
-      as `<style>` and `<title>`, keep that content up to their end tag as
-      before.  Issue #122.
+      process as HTML.  Issue #122.
     * `PolicyFactory.and` no longer lets a factory that allowed no URL
       protocol veto the protocols the other factory allowed.  A builder that
       never called `allowUrlProtocols` guards its URL attributes with a

--- a/change_log.md
+++ b/change_log.md
@@ -4,7 +4,8 @@ Most recent at top.
   * Next release
     * Self-closing SVG and MathML handling now follows the browser's current
       tree-construction context through HTML integration points, foreign
-      content breakout tags, and mismatched foreign end tags.  A slash after
+      content breakout tags, mismatched foreign end tags, and the end tags
+      of HTML elements enclosing the foreign content.  A slash after
       an equals sign remains part of an unquoted attribute value, and a
       self-closing foreign element named `<title>`, `<style>`, `<textarea>`,
       or another HTML literal-content element closes without consuming the

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
@@ -53,6 +53,16 @@ final class HtmlLexer extends AbstractTokenStream {
   }
 
   /**
+   * Cancels the literal-content mode tentatively selected from a start tag's
+   * name.  The tree-construction context can show that an HTML raw-text or
+   * RCDATA name actually denotes a foreign element, where those tokenizer
+   * modes do not apply.
+   */
+  void cancelPendingLiteralContent() {
+    splitter.cancelPendingLiteralContent();
+  }
+
+  /**
    * Normalize case of names that are not name-spaced.  This lower-cases HTML
    * element names, but not ones for embedded SVG or MathML.
    */
@@ -503,7 +513,6 @@ final class HtmlInputSplitter extends AbstractTokenStream {
   }
 
   private TagBodyState tagBodyState = TagBodyState.BEFORE_NAME;
-  private HtmlToken lastNonIgnorable = null;
   /**
    * Breaks the character stream into tokens.
    * This method returns a stream of tokens such that each token starts where
@@ -528,7 +537,9 @@ final class HtmlInputSplitter extends AbstractTokenStream {
         type = HtmlTokenType.TAGEND;
         inTag = false;
       } else if ('/' == ch) {
-        if (end != limit && '>' == input.charAt(end)) {
+        if (end != limit && '>' == input.charAt(end)
+            && tagBodyState != TagBodyState.BEFORE_VALUE
+            && tagBodyState != TagBodyState.IN_UNQUOTED_VALUE) {
           type = HtmlTokenType.TAGEND;
           inTag = false;
           ++end;
@@ -557,8 +568,8 @@ final class HtmlInputSplitter extends AbstractTokenStream {
         for (; end < limit; ++end) {
           ch = input.charAt(end);
           // End a text chunk before />
-          if ((lastNonIgnorable == null
-               || !lastNonIgnorable.tokenInContextMatches(input, "="))
+          if (tagBodyState != TagBodyState.BEFORE_VALUE
+              && tagBodyState != TagBodyState.IN_UNQUOTED_VALUE
               && '/' == ch && end + 1 < limit
               && '>' == input.charAt(end + 1)) {
             break;
@@ -811,10 +822,16 @@ final class HtmlInputSplitter extends AbstractTokenStream {
 
     offset = end;
     HtmlToken result = HtmlToken.instance(start, end, type);
-    if (type != HtmlTokenType.IGNORABLE) { lastNonIgnorable = result; }
     tagBodyState = inTag
         ? tagBodyStateAfter(result) : TagBodyState.BEFORE_NAME;
     return result;
+  }
+
+  /** Stops treating content after the current start tag as literal text. */
+  void cancelPendingLiteralContent() {
+    inEscapeExemptBlock = false;
+    escapeExemptTagName = null;
+    textEscapingMode = null;
   }
 
   /** The tag body state after {@code t}, a token lexed inside a tag. */

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -294,19 +294,46 @@ public final class HtmlSanitizer {
         return;
       }
 
+      // The foreign-content end-tag algorithm walks down from the current
+      // node.  A foreign node with the tag name closes, along with every
+      // node above it.  At the first HTML node the browser reprocesses the
+      // token under the HTML rules instead, where an HTML node with the tag
+      // name closes the same way, but a node in the special category, which
+      // among foreign elements means an integration point, ends the search
+      // and the token is ignored.
+      boolean htmlRules = false;
+      boolean sawIntegrationPoint = false;
       for (int i = openElements.size(); --i >= 0;) {
         OpenElement open = openElements.get(i);
-        if (open.namespace == Namespace.HTML) {
-          // The browser reprocesses the token under the HTML insertion mode.
-          // A foreign element above this HTML node blocks a generic HTML end
-          // tag from reaching farther down the stack.
+        boolean isHtml = open.namespace == Namespace.HTML;
+        boolean isIntegrationPoint
+            = open.mathTextIntegrationPoint || open.htmlIntegrationPoint;
+        if (isHtml) {
+          htmlRules = true;
+        } else if (htmlRules && isIntegrationPoint) {
           return;
         }
-        if (asciiEqualsIgnoreCase(open.elementName, elementName)) {
+        if (isHtml == htmlRules
+            && asciiEqualsIgnoreCase(open.elementName, elementName)) {
           openElements.subList(i, openElements.size()).clear();
           return;
         }
+        sawIntegrationPoint |= isIntegrationPoint;
       }
+      // Nothing tracked matched, so the token now applies to the HTML
+      // elements below the first foreign root, which are not tracked.  No
+      // HTML element is named svg or math, and an integration point in
+      // between is special and stops the search, so the browser ignores the
+      // token in those cases.  Otherwise the named element may well be
+      // open below, in which case the browser closes it and every foreign
+      // element above it.  Assume that it is: the cost of guessing wrong is
+      // only that self-closing flags stop being honored in the rest of an
+      // svg or math element whose author wrote a stray end tag, which is
+      // how those tags were always processed before the flag was honored.
+      if (isForeignContentRoot(elementName) || sawIntegrationPoint) {
+        return;
+      }
+      openElements.clear();
     }
 
     private boolean processHtmlStartTag(

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -27,6 +27,7 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -143,12 +144,7 @@ public final class HtmlSanitizer {
     // Use a linked list so that policies can use Iterator.remove() in an O(1)
     // way.
     LinkedList<String> attrs = new LinkedList<>();
-    // The number of <svg> and <math> start tags seen without a matching end
-    // tag.  Browsers parse the content of those elements as foreign content,
-    // where a start tag's self-closing flag is honored: <path/> is a whole,
-    // empty element.  In HTML content the flag means nothing, and <path/>
-    // opens an element that only an end tag closes.  Issue #122.
-    int foreignContentDepth = 0;
+    ForeignContentContext foreignContent = new ForeignContentContext();
     while (lexer.hasNext()) {
       HtmlToken token = lexer.next();
       switch (token.type) {
@@ -169,10 +165,7 @@ public final class HtmlSanitizer {
                    && lexer.next().type != HtmlTokenType.TAGEND) {
               // skip tokens until we see a ">"
             }
-            if (foreignContentDepth != 0
-                && isForeignContentRoot(elementName)) {
-              --foreignContentDepth;
-            }
+            foreignContent.processEndTag(elementName);
           } else {
             attrs.clear();
 
@@ -199,9 +192,9 @@ public final class HtmlSanitizer {
                   attrsReadyForName = true;
                   break;
                 case TAGEND:
-                  // The lexer ends a start tag with a "/>" token only when
-                  // the solidus immediately precedes the ">", which is when
-                  // the WHATWG tokenizer sets the self-closing flag.
+                  // HtmlInputSplitter only combines the solidus with the
+                  // greater-than sign when the tokenizer is in a state where
+                  // the solidus sets the self-closing flag.
                   selfClosing = htmlContent.charAt(tagBodyToken.start) == '/';
                   break tagBody;
                 default:
@@ -213,18 +206,21 @@ public final class HtmlSanitizer {
             }
             String elementName = HtmlLexer.canonicalElementName(
                 htmlContent.substring(token.start + 1, token.end));
-            boolean foreignContentRoot = isForeignContentRoot(elementName);
             // Decided before the policy sees the attributes, since it may
             // edit them.
-            boolean closesItself = selfClosing
-                && (foreignContentRoot
-                    || (foreignContentDepth != 0
-                        && closesItselfInForeignContent(elementName, attrs)));
+            boolean closesItself = foreignContent.processStartTag(
+                elementName, attrs, selfClosing);
+            if (closesItself
+                && HtmlTextEscapingMode.isTagFollowedByLiteralContent(
+                    elementName)) {
+              // The splitter tentatively chose an HTML raw-text or RCDATA
+              // mode from the name alone.  Foreign elements stay in the data
+              // state, and this one has already closed.
+              lexer.cancelPendingLiteralContent();
+            }
             receiver.openTag(elementName, attrs);
             if (closesItself) {
               receiver.closeTag(elementName);
-            } else if (foreignContentRoot) {
-              ++foreignContentDepth;
             }
           }
           break;
@@ -238,51 +234,233 @@ public final class HtmlSanitizer {
     receiver.closeDocument();
   }
 
-  /**
-   * True for the elements whose content browsers parse as foreign content
-   * rather than as HTML.
-   */
+  /** Tracks the tree-construction context needed for self-closing flags. */
+  private static final class ForeignContentContext {
+    /** Match the sanitizer's output nesting limit without growing unchecked. */
+    private static final int MAX_DEPTH = 256;
+
+    /** Elements from the first open foreign root through the current node. */
+    private final List<OpenElement> openElements = new ArrayList<>();
+
+    /**
+     * True once the bounded stack is exhausted.  The legacy HTML behavior is
+     * the conservative fallback for ordinary tags from that point onward.
+     */
+    private boolean unknown;
+
+    /**
+     * Updates the context for a start tag and returns whether its self-closing
+     * flag is honored by tree construction.
+     */
+    boolean processStartTag(
+        String elementName, List<String> attrs, boolean selfClosing) {
+      if (unknown) {
+        return selfClosing && isForeignContentRoot(elementName);
+      }
+
+      OpenElement current = currentElement();
+      boolean usesHtmlRules = usesHtmlRulesForStartTag(current, elementName);
+      if (!usesHtmlRules
+          && breaksOutOfForeignContent(elementName, attrs)) {
+        popToHtmlOrIntegrationPoint();
+        usesHtmlRules = true;
+      }
+
+      if (usesHtmlRules) {
+        return processHtmlStartTag(elementName, attrs, selfClosing);
+      }
+
+      // Any other start tag in foreign content inherits the current
+      // namespace, even one named "svg" or "math".
+      if (!selfClosing) {
+        push(new OpenElement(elementName, current.namespace, attrs));
+      }
+      return selfClosing;
+    }
+
+    /** Updates the context using the foreign-content or HTML end-tag rules. */
+    void processEndTag(String elementName) {
+      if (unknown || openElements.isEmpty()) { return; }
+
+      OpenElement current = currentElement();
+      if (current.namespace == Namespace.HTML) {
+        processHtmlEndTag(elementName);
+        return;
+      }
+
+      if ("br".equals(elementName) || "p".equals(elementName)) {
+        popToHtmlOrIntegrationPoint();
+        processHtmlEndTag(elementName);
+        return;
+      }
+
+      for (int i = openElements.size(); --i >= 0;) {
+        OpenElement open = openElements.get(i);
+        if (open.namespace == Namespace.HTML) {
+          // The browser reprocesses the token under the HTML insertion mode.
+          // A foreign element above this HTML node blocks a generic HTML end
+          // tag from reaching farther down the stack.
+          return;
+        }
+        if (asciiEqualsIgnoreCase(open.elementName, elementName)) {
+          openElements.subList(i, openElements.size()).clear();
+          return;
+        }
+      }
+    }
+
+    private boolean processHtmlStartTag(
+        String elementName, List<String> attrs, boolean selfClosing) {
+      Namespace namespace;
+      if ("svg".equals(elementName)) {
+        namespace = Namespace.SVG;
+      } else if ("math".equals(elementName)) {
+        namespace = Namespace.MATHML;
+      } else {
+        if (!openElements.isEmpty()
+            && !HtmlTextEscapingMode.isVoidElement(elementName)) {
+          push(new OpenElement(elementName, Namespace.HTML, attrs));
+        }
+        // HTML ignores the self-closing flag on ordinary non-void elements.
+        // Void elements are already empty and need no synthetic close event.
+        return false;
+      }
+
+      if (!selfClosing) {
+        push(new OpenElement(elementName, namespace, attrs));
+      }
+      return selfClosing;
+    }
+
+    private void processHtmlEndTag(String elementName) {
+      for (int i = openElements.size(); --i >= 0;) {
+        OpenElement open = openElements.get(i);
+        if (open.namespace != Namespace.HTML) { return; }
+        if (asciiEqualsIgnoreCase(open.elementName, elementName)) {
+          openElements.subList(i, openElements.size()).clear();
+          return;
+        }
+      }
+    }
+
+    private void popToHtmlOrIntegrationPoint() {
+      while (!openElements.isEmpty()) {
+        OpenElement current = currentElement();
+        if (current.namespace == Namespace.HTML
+            || current.mathTextIntegrationPoint
+            || current.htmlIntegrationPoint) {
+          return;
+        }
+        openElements.remove(openElements.size() - 1);
+      }
+    }
+
+    private void push(OpenElement element) {
+      if (openElements.size() == MAX_DEPTH) {
+        openElements.clear();
+        unknown = true;
+      } else {
+        openElements.add(element);
+      }
+    }
+
+    private OpenElement currentElement() {
+      int size = openElements.size();
+      return size != 0 ? openElements.get(size - 1) : null;
+    }
+
+    private static boolean usesHtmlRulesForStartTag(
+        @Nullable OpenElement current, String elementName) {
+      if (current == null || current.namespace == Namespace.HTML) {
+        return true;
+      }
+      if (current.mathTextIntegrationPoint
+          && !"mglyph".equals(elementName)
+          && !"malignmark".equals(elementName)) {
+        return true;
+      }
+      return current.htmlIntegrationPoint
+          || (current.namespace == Namespace.MATHML
+              && "annotation-xml".equals(current.elementName)
+              && "svg".equals(elementName));
+    }
+  }
+
+  private enum Namespace {
+    HTML,
+    SVG,
+    MATHML,
+  }
+
+  /** One element relevant to the foreign-content tree-construction state. */
+  private static final class OpenElement {
+    final String elementName;
+    final Namespace namespace;
+    final boolean mathTextIntegrationPoint;
+    final boolean htmlIntegrationPoint;
+
+    OpenElement(
+        String elementName, Namespace namespace, List<String> attrs) {
+      this.elementName = elementName;
+      this.namespace = namespace;
+      this.mathTextIntegrationPoint = namespace == Namespace.MATHML
+          && MATHML_TEXT_INTEGRATION_POINT_NAMES.contains(elementName);
+      this.htmlIntegrationPoint = isHtmlIntegrationPoint(
+          elementName, namespace, attrs);
+    }
+  }
+
   private static boolean isForeignContentRoot(String canonElementName) {
     return "svg".equals(canonElementName) || "math".equals(canonElementName);
   }
 
-  /**
-   * True if a self-closing start tag for the named element, seen inside
-   * {@code <svg>} or {@code <math>}, opens an element that closes at once.
-   *
-   * <p>That is what browsers do with a start tag processed under the rules
-   * for foreign content.  The exceptions are the tags that break out of
-   * foreign content, which browsers process as HTML, where the flag on a
-   * non-void element is ignored, and the elements whose content the lexer
-   * has already committed to treating as text.
-   *
-   * @param attrs alternating attribute names and values as the author wrote
-   *     them, before any policy has edited them.
-   */
-  private static boolean closesItselfInForeignContent(
-      String canonElementName, List<String> attrs) {
-    if (HtmlTextEscapingMode.getModeForTag(canonElementName)
-        != HtmlTextEscapingMode.PCDATA) {
-      // A void element is empty already.  The lexer treats the content of
-      // <style>, <title> and the other elements with literal content as text
-      // up to the matching end tag, so the element stays open to hold it.
+  private static boolean isHtmlIntegrationPoint(
+      String elementName, Namespace namespace, List<String> attrs) {
+    if (namespace == Namespace.SVG) {
+      return "desc".equals(elementName) || "title".equals(elementName)
+          || asciiEqualsIgnoreCase("foreignObject", elementName);
+    }
+    if (namespace != Namespace.MATHML
+        || !"annotation-xml".equals(elementName)) {
       return false;
     }
+    for (Iterator<String> it = attrs.iterator(); it.hasNext();) {
+      String name = it.next();
+      String value = it.hasNext() ? it.next() : "";
+      if ("encoding".equals(name)) {
+        return asciiEqualsIgnoreCase("text/html", value)
+            || asciiEqualsIgnoreCase("application/xhtml+xml", value);
+      }
+    }
+    return false;
+  }
+
+  private static boolean asciiEqualsIgnoreCase(String a, String b) {
+    int length = a.length();
+    return b.length() == length
+        && Strings.regionMatchesIgnoreCase(a, 0, b, 0, length);
+  }
+
+  private static boolean breaksOutOfForeignContent(
+      String canonElementName, List<String> attrs) {
     if (FOREIGN_CONTENT_BREAKOUT_ELEMENT_NAMES.contains(canonElementName)) {
-      return false;
+      return true;
     }
     if ("font".equals(canonElementName)) {
       for (Iterator<String> it = attrs.iterator(); it.hasNext();) {
         String name = it.next();
-        if (it.hasNext()) { it.next(); }  // The value.
+        if (it.hasNext()) { it.next(); }
         if ("color".equals(name) || "face".equals(name)
             || "size".equals(name)) {
-          return false;
+          return true;
         }
       }
     }
-    return true;
+    return false;
   }
+
+  private static final Set<String> MATHML_TEXT_INTEGRATION_POINT_NAMES
+      = j8().setOf("mi", "mo", "mn", "ms", "mtext");
 
   /**
    * The start tags that end foreign content: inside {@code <svg>} or

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
@@ -96,6 +96,28 @@ class HtmlLexerTest {
   }
 
   @Test
+  void testSlashStartsAnUnquotedValueAfterEquals() {
+    assertTokens(
+        "<path d=/>x</path>",
+        "TAGBEGIN: <path",
+        "ATTRNAME: d",
+        "ATTRVALUE: /",
+        "TAGEND: >",
+        "TEXT: x",
+        "TAGBEGIN: </path",
+        "TAGEND: >");
+    assertTokens(
+        "<path d = />x</path>",
+        "TAGBEGIN: <path",
+        "ATTRNAME: d",
+        "ATTRVALUE: /",
+        "TAGEND: >",
+        "TEXT: x",
+        "TAGBEGIN: </path",
+        "TAGEND: >");
+  }
+
+  @Test
   void testShortTags() {
     // See comments in html-sanitizer-test.js as to why we don't bother with
     // short tags.  In short, they are not in HTML5 and not implemented properly

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -962,12 +962,64 @@ class HtmlSanitizerTest {
     assertEquals(
         "<svg><math></math></svg>",
         p.sanitize("<svg><math></svg><object/>hidden"));
-    // An end tag cannot match through an intervening HTML element while the
-    // current node is foreign.
+    // The end tag of an HTML element that is open below a foreign element
+    // closes both, and puts the parser back under the HTML rules.
     assertEquals(
-        "<math><mi><div><svg></svg></div><path></path>x</mi></math>",
+        "<math><mi><div><svg></svg></div><path>x</path></mi></math>",
         p.sanitize(
             "<math><mi><div><svg></div><path/>x</svg></div></mi></math>"));
+  }
+
+  /**
+   * Issue #457.  An end tag that names none of the open foreign elements
+   * may close an HTML ancestor of the foreign root, which is not tracked,
+   * so the parser is assumed to be back in HTML content unless the browser
+   * would ignore the tag.
+   */
+  @Test
+  void testEndTagsOfHtmlAncestorsEndForeignContent() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<div><svg></svg></div>",
+        p.sanitize("<div><svg></div><object/>hidden"));
+    assertEquals(
+        "<div><svg><path></path></svg></div>",
+        p.sanitize("<div><svg><path></div><object/>hidden"));
+    assertEquals(
+        "<p><svg></svg></p>",
+        p.sanitize("<p><svg></p><object/>hidden"));
+    assertEquals(
+        "<div><svg><path></path></svg></div><path>x</path>",
+        p.sanitize("<div><svg><path></div><path/>x"));
+    // An integration point is in the special category and stops the search
+    // for the named element, so the tag is ignored and the content of the
+    // integration point stays under the HTML rules.
+    assertEquals(
+        "<div><svg><foreignObject></foreignObject></svg></div>",
+        p.sanitize("<div><svg><foreignObject></div><object/>hidden"));
+    assertEquals(
+        "<div><math><mi></mi></math></div>",
+        p.sanitize("<div><math><mi></div><object/>hidden"));
+    // The path is still empty and closes at once.  Where the tag balancer
+    // then puts it is its own concern.
+    assertEquals(
+        "<div><svg><foreignObject><div><svg></svg></div></foreignObject>"
+        + "<path></path>x</svg></div>",
+        p.sanitize(
+            "<div><svg><foreignObject><div><svg></foreignObject>"
+            + "<path/>x"));
+    // No HTML element is named svg or math, so a stray foreign end tag is
+    // ignored rather than taken as closing an ancestor.
+    assertEquals(
+        "<div><math><mi></mi>x</math></div>",
+        p.sanitize("<div><math></svg><mi/>x</math></div>"));
+    // A stray end tag that names nothing open is ignored by browsers, and
+    // the self-closing flag is still honored after it.  The sanitizer does
+    // not know that nothing below the svg matched, so it errs toward the
+    // HTML rules, where the flag is ignored and the path holds the text.
+    assertEquals(
+        "<svg><path>x</path></svg>",
+        p.sanitize("<svg></foo><path/>x</svg>"));
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -849,6 +849,9 @@ class HtmlSanitizerTest {
         "<svg><path d=\"M0/\">x</path></svg>",
         p.sanitize("<svg><path d=M0/>x</svg>"));
     assertEquals(
+        "<svg><path d=\"/\">x</path></svg>",
+        p.sanitize("<svg><path d=/>x</svg>"));
+    assertEquals(
         "<svg><path>x</path></svg>", p.sanitize("<svg><path / >x</svg>"));
   }
 
@@ -876,8 +879,7 @@ class HtmlSanitizerTest {
   /**
    * Issue #122.  Browsers process the start tags that break out of foreign
    * content as HTML, where the flag is ignored again; a void element is
-   * empty with or without it; and the elements whose content the lexer
-   * reads as text keep that content up to their end tag.
+   * empty with or without it.
    */
   @Test
   void testSelfClosingTagsThatBreakOutOfForeignContent() {
@@ -891,9 +893,115 @@ class HtmlSanitizerTest {
     assertEquals(
         "<svg><font></font>x</svg>", p.sanitize("<svg><font/>x</svg>"));
     assertEquals("<svg><br />x</svg>", p.sanitize("<svg><br/>x</svg>"));
+  }
+
+  /** Issue #457.  Start tags at integration points use the HTML rules. */
+  @Test
+  void testSelfClosingTagsAtHtmlIntegrationPoints() {
+    PolicyFactory p = foreignContentPolicy();
     assertEquals(
-        "<svg><textarea>x</textarea></svg>",
+        "<svg><foreignObject><path>x</path></foreignObject></svg>",
+        p.sanitize("<svg><foreignObject><path/>x</foreignObject></svg>"));
+    assertEquals(
+        "<svg><desc><path>x</path></desc></svg>",
+        p.sanitize("<svg><desc><path/>x</desc></svg>"));
+    assertEquals(
+        "<math><mi><path>x</path></mi></math>",
+        p.sanitize("<math><mi><path/>x</mi></math>"));
+    assertEquals(
+        "<math><annotation-xml encoding=\"text/html\"><path>x</path>"
+        + "</annotation-xml></math>",
+        p.sanitize(
+            "<math><annotation-xml encoding=text/html><path/>x"
+            + "</annotation-xml></math>"));
+    assertEquals(
+        "<math><mi><mglyph></mglyph>x</mi></math>",
+        p.sanitize("<math><mi><mglyph/>x</mi></math>"));
+    // A dropped object remains open under HTML rules, so its fallback text
+    // stays suppressed.
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><object/>hidden</foreignObject></svg>"));
+  }
+
+  /** Issue #457.  A breakout token ends the surrounding foreign context. */
+  @Test
+  void testForeignContentBreakoutUpdatesFollowingContext() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<svg><p><path>x</path></p></svg>",
+        p.sanitize("<svg><p/><path/>x</svg>"));
+    assertEquals(
+        "<svg><p>x</p></svg>",
+        p.sanitize("<svg><p/>x<object/>hidden</svg>"));
+    assertEquals(
+        "<svg><font color=\"red\"><path>x</path></font></svg>",
+        p.sanitize("<svg><font color=red /><path/>x</svg>"));
+    assertEquals(
+        "<svg><path>x</path></svg>",
+        p.sanitize("<svg></p><path/>x</svg>"));
+  }
+
+  /** Issue #457.  Foreign end tags match against the open-element stack. */
+  @Test
+  void testForeignContentEndTagsUpdateTheMatchingContext() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<math><mi></mi>x</math>",
+        p.sanitize("<math></svg><mi/>x</math>"));
+    assertEquals(
+        "<svg><math></math></svg><path>x</path>",
+        p.sanitize("<svg><math></svg><path/>x"));
+    assertEquals(
+        "<math><svg></svg></math><path>x</path>",
+        p.sanitize("<math><svg></math><path/>x"));
+    assertEquals(
+        "<svg><math></math><path></path>x</svg>",
+        p.sanitize("<svg><math></math><path/>x</svg>"));
+    assertEquals(
+        "<svg><math></math></svg>",
+        p.sanitize("<svg><math></svg><object/>hidden"));
+    // An end tag cannot match through an intervening HTML element while the
+    // current node is foreign.
+    assertEquals(
+        "<math><mi><div><svg></svg></div><path></path>x</mi></math>",
+        p.sanitize(
+            "<math><mi><div><svg></div><path/>x</svg></div></mi></math>"));
+  }
+
+  /**
+   * Issue #457.  HTML raw-text and RCDATA modes do not apply to self-closing
+   * foreign elements that happen to have the same names.
+   */
+  @Test
+  void testSelfClosingForeignLiteralContentNames() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<svg><title></title>x</svg><p>after</p>",
+        p.sanitize("<svg><title/>x</svg><p>after</p>"));
+    assertEquals(
+        "<svg><style></style>x</svg><p>after</p>",
+        p.sanitize("<svg><style/>x</svg><p>after</p>"));
+    assertEquals(
+        "<svg><textarea></textarea>x</svg>",
         p.sanitize("<svg><textarea/>x</textarea></svg>"));
+    assertEquals(
+        "<math><textarea></textarea>x</math><p>after</p>",
+        p.sanitize("<math><textarea/>x</math><p>after</p>"));
+    // The dropped script closes before ordinary text, so that text survives.
+    assertEquals(
+        "<svg>visible</svg><p>after</p>",
+        p.sanitize("<svg><script/>visible</svg><p>after</p>"));
+    assertEquals(
+        "<svg>visible</svg><p>after</p>",
+        p.sanitize("<svg><plaintext/>visible</svg><p>after</p>"));
+    // At an HTML integration point, the same name really is RCDATA and a
+    // solidus does not close it.
+    assertEquals(
+        "<svg><foreignObject><title>x</title></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><title/>x</title></foreignObject></svg>"));
   }
 
   /**
@@ -923,9 +1031,9 @@ class HtmlSanitizerTest {
     assertEquals(
         "<svg><foreignObject></foreignObject><div>x</div></svg>",
         p.sanitize("<svg><foreignObject/><div>x</div></svg>"));
-    // Raw text content is read up to the end tag and escaped, as before.
+    // A self-closing foreign RCDATA element closes before the next tag.
     assertEquals(
-        "<svg><title>&lt;img src&#61;x onerror&#61;alert(1)&gt;</title></svg>",
+        "<svg><title></title></svg>",
         p.sanitize("<svg><title/><img src=x onerror=alert(1)></title></svg>"));
     assertEquals(
         "<svg><style></style></svg>",
@@ -974,16 +1082,28 @@ class HtmlSanitizerTest {
         events);
   }
 
+  /** The bounded context tracker falls back to suppressing dropped content. */
+  @Test
+  void testDeepForeignContentContextFailsClosed() {
+    PolicyFactory p = foreignContentPolicy();
+    StringBuilder html = new StringBuilder("<svg>");
+    for (int i = 0; i < 300; ++i) { html.append("<g>"); }
+    html.append("<object/>hidden");
+    String out = p.sanitize(html.toString());
+    assertFalse(out.contains("hidden"), out);
+  }
+
   private static PolicyFactory foreignContentPolicy() {
     return new HtmlPolicyBuilder()
         .allowElements(
             "svg", "math", "path", "g", "rect", "clipPath", "foreignObject",
-            "textArea", "textarea", "mi", "mrow", "a", "div", "p", "font",
-            "br", "style", "title")
+            "desc", "annotation-xml", "textArea", "textarea", "mi", "mrow",
+            "mglyph", "a", "div", "p", "font", "br", "style", "title")
         .allowAttributes("width", "height", "viewBox").onElements("svg")
         .allowAttributes("id", "opacity", "d").onElements("path")
         .allowAttributes("href").onElements("a")
         .allowAttributes("color").onElements("font")
+        .allowAttributes("encoding").onElements("annotation-xml")
         .allowWithoutAttributes("font")
         .allowStandardUrlProtocols()
         .toFactory();

--- a/owasp-java-html-sanitizer/src/test/resources/org/owasp/html/htmllexergolden1.txt
+++ b/owasp-java-html-sanitizer/src/test/resources/org/owasp/html/htmllexergolden1.txt
@@ -226,8 +226,8 @@ ATTRVALUE  []  :  1940-1940
 TAGEND     [>]  :  1940-1941
 TAGBEGIN   [<a]  :  1941-1943
 ATTRNAME   [href]  :  1944-1948
-ATTRVALUE  []  :  1949-1949
-TAGEND     [/>]  :  1949-1951
+ATTRVALUE  [/]  :  1949-1950
+TAGEND     [>]  :  1950-1951
 TEXT       [\n\n]  :  1951-1953
 TAGBEGIN   [<span]  :  1953-1958
 ATTRNAME   [title]  :  1959-1964


### PR DESCRIPTION
PR #456 began honoring self-closing flags in SVG and MathML, but its lexical depth counter could not tell when browser tree construction had switched back to HTML. For example, a tag immediately inside `<svg><foreignObject>` follows HTML rules and keeps the slash ignored, while the same tag under an ordinary SVG element closes immediately.

This change replaces that counter with a bounded open-element context that tracks HTML, SVG, and MathML namespaces; HTML and MathML integration points; foreign-content breakout tags; and matching foreign end tags. It also makes `name=/>` retain `/` as its unquoted attribute value and cancels the lexer's tentative raw-text or RCDATA mode after a self-closing foreign element such as `<title/>` or `<style/>`.

The regression coverage includes positive and hostile cases for SVG and MathML integration points, breakout start and end tags, mismatched and nested foreign end tags, HTML boundaries during foreign end-tag scans, literal-content names, unquoted slash values, dropped-content suppression, and the context tracker's bounded fallback. The expected structures follow the [HTML foreign-content tree-construction rules](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign).

Closes #457.

Validation:

- `./mvnw clean verify` on Java 11
- `./mvnw clean verify` on Java 21
- `./mvnw clean verify` on Java 25
