### PR TITLE
docs: Say Where the URL Protocol Guard Runs Relative to Author Policies

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -49,6 +49,15 @@ Most recent at top.
       parentheses and control characters, and a policy that rewrites a URL
       can no longer hand the output a protocol the builder did not allow.
       Issue #204.
+    * The javadoc for `matching`, `allowUrlProtocols` and `allowUrlsInStyles`
+      now says where the URL protocol guard runs: after the policies an
+      author attaches, which see the value as written and can be handed a
+      protocol the builder never allowed.  A policy that rewrites a URL into
+      another, such as a redirector, should vet the protocol itself, and the
+      javadoc shows how with `FilterUrlByProtocolAttributePolicy`.  The
+      `allowUrlsInStyles` javadoc had the order backwards, and said the
+      policy was never consulted without `allowUrlProtocols` when it always
+      was.  Issue #454.
     * Text inside a dropped element is now gated by every element enclosing
       it, not by the last tag the policy saw.  The policy kept one flag for
       whether text may be emitted and set it from each open tag alone, so a

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -557,6 +557,13 @@ public class HtmlPolicyBuilder {
    * protocols the other factory allowed.  Two factories that each allowed
    * some protocols together allow only those both allowed.
    * <p>
+   * The guard runs after any policies attached to the attribute with
+   * {@link AttributeBuilder#matching(AttributePolicy) matching}, and after
+   * the policy given to {@link #allowUrlsInStyles}, so it vets the value
+   * they produce.  They in turn see the value before the guard has vetted
+   * or normalized it, so a policy that rewrites URLs must vet the protocol
+   * itself; see {@code matching} for the details and an example.
+   * <p>
    * Do not allow any <code>*script</code> such as <code>javascript</code>
    * protocols if you might use this policy with untrusted code.
    */
@@ -681,23 +688,30 @@ public class HtmlPolicyBuilder {
    * URLs in CSS are typically loaded without user-interaction, the way links
    * are, so a greater degree of scrutiny is warranted.
    * <p>
-   * <b>This method only narrows what is allowed; it cannot widen it.</b>  The
-   * policy given here runs <i>after</i> the protocol filter built from
-   * {@link #allowUrlProtocols(String...)}, so a URL has to clear both.  If
-   * {@code allowUrlProtocols} was never called, that filter rejects every
-   * URL and this policy is never consulted -- calling
-   * {@code allowUrlsInStyles} on its own looks like a no-op.  Pair it with an
-   * {@code allowUrlProtocols} call:
+   * <b>This method only narrows what is allowed; it cannot widen it.</b>  A
+   * URL has to clear both the policy given here and the protocol guard built
+   * from {@link #allowUrlProtocols(String...)}, in that order.  The policy
+   * runs first, so it sees each URL before the guard has vetted or
+   * normalized it and can be handed a {@code javascript:} URL the builder
+   * never allowed.  That is harmless for a policy that only accepts or
+   * rejects, since the guard still rejects the URL afterwards, but a policy
+   * that rewrites URLs must vet the protocol itself, as
+   * {@link AttributeBuilder#matching(AttributePolicy) matching} describes.
+   * <p>
+   * If {@code allowUrlProtocols} was never called, the guard rejects every
+   * URL that names a protocol whatever this policy said about it, so
+   * {@code allowUrlsInStyles} on its own admits only relative URLs.  Pair it
+   * with an {@code allowUrlProtocols} call:
    *
    * <pre>{@code
    * new HtmlPolicyBuilder()
    *     .allowStyling()
-   *     .allowUrlProtocols("https")          // without this, the next line
-   *     .allowUrlsInStyles(myUrlPolicy)      // never sees a URL
+   *     .allowUrlProtocols("https")          // without this, the guard drops
+   *     .allowUrlsInStyles(myUrlPolicy)      // every absolute URL this keeps
    * }</pre>
    *
-   * @param newStyleUrlPolicy receives URLs from the CSS that pass the allowed
-   *     protocol policies, and may return null to veto the URL or the URL
+   * @param newStyleUrlPolicy receives each URL from the CSS before the
+   *     protocol guard does, and may return null to veto the URL or the URL
    *     to use.  URLs will be reported as content in {@code <img src=...>}.
    */
   public HtmlPolicyBuilder allowUrlsInStyles(
@@ -1018,6 +1032,38 @@ public class HtmlPolicyBuilder {
      * Multiple calls to {@code matching} are combined so that the policies
      * receive the value in order, each seeing the value after any
      * transformation by a previous policy.
+     * <p>
+     * On a URL attribute such as {@code href} or {@code src}, the protocol
+     * guard built from {@link HtmlPolicyBuilder#allowUrlProtocols} runs after
+     * the policies given here and vets what they produce.  The first policy
+     * therefore sees the value as written, after entity decoding but before
+     * the guard trims surrounding whitespace and percent-encodes parentheses
+     * and control characters, so a pattern should match the value as
+     * written; one that expects the normalized form rejects the raw one,
+     * which fails closed.  The policies also run before the guard has
+     * rejected anything, so a policy can be handed
+     * {@code javascript:alert(1)} even though the builder allowed no such
+     * protocol.  That is harmless for a policy that only accepts or rejects,
+     * since the guard still rejects the value afterwards, but a policy that
+     * rewrites one URL into another, such as a redirector or proxy that
+     * returns {@code "https://example.com/go?u=" + value}, would hand the
+     * guard an {@code https:} URL that carries the unvetted one to the
+     * redirector.  Such a policy should vet the protocol itself first, for
+     * example by putting a {@link FilterUrlByProtocolAttributePolicy} ahead
+     * of it:
+     *
+     * <pre>{@code
+     * AttributePolicy vetProtocol = new FilterUrlByProtocolAttributePolicy(
+     *     Arrays.asList("http", "https"));
+     * new HtmlPolicyBuilder()
+     *     .allowElements("a")
+     *     .allowAttributes("href")
+     *         .matching(vetProtocol)
+     *         .matching((element, attribute, url) ->
+     *             "https://example.com/go?u=" + url)
+     *         .onElements("a")
+     *     .allowUrlProtocols("https");
+     * }</pre>
      * <p>
      * Since the combination fails as soon as one policy rejects, this has no
      * effect on a builder from {@link HtmlPolicyBuilder#disallowAttributes},

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -666,6 +666,130 @@ class HtmlPolicyBuilderTest {
             "<a href='/x'>x</a>"));
   }
 
+  /**
+   * Issue #454.  A matching policy on a URL attribute runs before the
+   * protocol guard, so it sees the value as written, after entity decoding
+   * but before the guard trims whitespace and percent-encodes parentheses,
+   * and before the guard has rejected anything.  A pattern that expects the
+   * normalized form rejects the raw one, which fails closed.
+   */
+  @Test
+  void testMatchingPoliciesSeeTheUrlAsWrittenBeforeTheProtocolGuard() {
+    List<String> seen = new ArrayList<>();
+    AttributePolicy record = (elementName, attributeName, value) -> {
+      seen.add(value);
+      return value;
+    };
+    String links =
+        "<a href=\" http://example.com/a&#40;b) \">x</a>"
+        + "<a href=\"javascript:alert(1)\">y</a>";
+
+    assertEquals(
+        "<a href=\"http://example.com/a%28b%29\">x</a>y",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowAttributes("href").matching(record).onElements("a")
+            .allowUrlProtocols("http"),
+            links));
+    assertEquals(
+        Arrays.asList(" http://example.com/a(b) ", "javascript:alert(1)"),
+        seen);
+
+    Pattern normalized = Pattern.compile("http://example\\.com/a%28b%29");
+    Pattern asWritten = Pattern.compile(" http://example\\.com/a\\(b\\) ");
+    assertEquals(
+        "xy",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowAttributes("href").matching(normalized).onElements("a")
+            .allowUrlProtocols("http"),
+            links));
+    assertEquals(
+        "<a href=\"http://example.com/a%28b%29\">x</a>y",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowAttributes("href").matching(asWritten).onElements("a")
+            .allowUrlProtocols("http"),
+            links));
+  }
+
+  /**
+   * Issue #454.  A policy that rewrites one URL into another is handed the
+   * unvetted value, so a redirector that wraps it produces an allowed URL
+   * that carries a protocol the builder never allowed.  The guard passes
+   * that, as it should, so the rewriter has to vet the protocol itself,
+   * which putting a FilterUrlByProtocolAttributePolicy ahead of it does.
+   */
+  @Test
+  void testARewritingPolicyMustVetTheProtocolItself() {
+    AttributePolicy redirector = (elementName, attributeName, url) ->
+        "https://example.com/go?u=" + url;
+    String links =
+        "<a href=\"javascript:alert(1)\">x</a>"
+        + "<a href=\"https://other.example/p\">y</a>";
+
+    assertEquals(
+        "<a href=\"https://example.com/go?u&#61;javascript:alert%281%29\">x</a>"
+        + "<a href=\"https://example.com/go?u&#61;https://other.example/p\">"
+        + "y</a>",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowAttributes("href").matching(redirector).onElements("a")
+            .allowUrlProtocols("https"),
+            links));
+
+    assertEquals(
+        "x"
+        + "<a href=\"https://example.com/go?u&#61;https://other.example/p\">"
+        + "y</a>",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowAttributes("href")
+                .matching(new FilterUrlByProtocolAttributePolicy(
+                    Arrays.asList("https")))
+                .matching(redirector)
+                .onElements("a")
+            .allowUrlProtocols("https"),
+            links));
+  }
+
+  /**
+   * Issue #454.  The policy given to allowUrlsInStyles runs before the
+   * protocol guard too, so it is consulted even when no protocol was
+   * allowed, sees a javascript: URL the guard goes on to drop, and on its
+   * own admits only relative URLs.
+   */
+  @Test
+  void testStyleUrlPolicyRunsBeforeTheProtocolGuard() {
+    List<String> seen = new ArrayList<>();
+    AttributePolicy record = (elementName, attributeName, value) -> {
+      seen.add(value);
+      return value;
+    };
+    CssSchema images =
+        CssSchema.withProperties(Arrays.asList("background-image"));
+
+    assertEquals(
+        "<div>x</div>"
+        + "<div style=\"background-image:url(&#39;/i.png&#39;)\">y</div>",
+        apply(
+            new HtmlPolicyBuilder()
+            .allowElements("div")
+            .allowAttributes("style").onElements("div")
+            .allowStyling(images)
+            .allowUrlsInStyles(record),
+            "<div style=\"background-image: url(javascript:alert%281%29)\">"
+            + "x</div>"
+            + "<div style=\"background-image: url(/i.png)\">y</div>"));
+    assertEquals(
+        Arrays.asList("javascript:alert%281%29", "/i.png"), seen);
+  }
+
   /** Rejecting only some values means allowing the rest. */
   @Test
   void testAnInvertedAllowRejectsOnlyTheMatchingValues() {


### PR DESCRIPTION
Since #452 the URL protocol guard built from `allowUrlProtocols` runs after the policies an author attaches with `matching`, on every URL attribute, as the `style` guard already did. The change log says so but the javadoc did not. Closes #454.

Javadoc changes in `HtmlPolicyBuilder`:

- `matching(AttributePolicy)` now says the guard runs after its policies and vets what they produce. The first policy sees the value as written, after entity decoding but before the guard trims surrounding whitespace and percent-encodes parentheses and control characters, so a pattern that expects the normalized form rejects the raw one, which fails closed. The policies also run before the guard has rejected anything, so a policy can be handed `javascript:alert(1)`. That is harmless for an accept-or-reject policy, but a redirector that returns `"https://example.com/go?u=" + value` hands the guard an `https:` URL carrying the unvetted one. The javadoc shows how to vet the protocol first by putting a `FilterUrlByProtocolAttributePolicy` ahead of the rewriter.
- `allowUrlProtocols` says where its guard sits and points at `matching` for the rewriter guidance.
- `allowUrlsInStyles` had the order backwards. It said the policy runs after the protocol filter and is never consulted when `allowUrlProtocols` was not called. The builder has always joined that policy ahead of the guard, so it runs first, sees `javascript:` URLs the guard goes on to drop, and on its own admits only relative URLs. The text and example now say that.

Tests, all in `HtmlPolicyBuilderTest`, pin what the javadoc now promises rather than change behavior:

- `testMatchingPoliciesSeeTheUrlAsWrittenBeforeTheProtocolGuard`: a recording policy sees ` http://example.com/a(b) ` and `javascript:alert(1)`, the output carries `http://example.com/a%28b%29`, a pattern for the normalized form drops the link, and one for the raw form keeps it.
- `testARewritingPolicyMustVetTheProtocolItself`: an unvetted redirector wraps the `javascript:` URL into an allowed `https:` one, and the same redirector behind `FilterUrlByProtocolAttributePolicy` drops it while still wrapping an `https:` link.
- `testStyleUrlPolicyRunsBeforeTheProtocolGuard`: with no protocol allowed, the style URL policy is consulted for both `javascript:alert%281%29` and `/i.png`, and only the relative URL survives.

The `change_log.md` bullet under Next release records the clarification. No behavior, API, or dependency changes.

`./mvnw clean verify` is green locally on JDK 11, 17, 21, and 25. Javadoc with doclint on `org.owasp.html` reports nothing in the edited hunks; the one warning in `HtmlPolicyBuilder.java`, an empty `<p>` at line 499, predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYF1WjZmwbGNrph7RDw2BS
