### PR TITLE
Add an explicit relative-only URL policy

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -16,6 +16,13 @@ Most recent at top.
       should call `allowOnlyRelativeUrls()` on the restrictive builder before
       upgrading; without it, the change for issue #204 may widen those
       compositions to the protocols the other factory allows.  Issue #453.
+    * `FilterUrlByProtocolAttributePolicy`, and so the protocol guard on every
+      builder that did not allow both `http` and `https`, now rejects
+      `/\`, `\/`, and `\\` at the start of a URL as it already rejected
+      `//`.  Browsers resolving against an `http:` or `https:` page treat a
+      backslash as a slash, so `\\example.org/` names the same authority
+      as `//example.org/`.  Policies that allow both web protocols keep
+      accepting these values, as they accept `//example.org/`.  Issue #453.
     * Self-closing SVG and MathML handling now follows the browser's current
       tree-construction context through HTML integration points, foreign
       content breakout tags, mismatched foreign end tags, and the end tags
@@ -62,6 +69,9 @@ Most recent at top.
       before the guard trims surrounding whitespace and percent-encodes
       parentheses and control characters, and a policy that rewrites a URL
       can no longer hand the output a protocol the builder did not allow.
+      A composition that relied on the old behavior to keep another
+      factory's links relative should call `allowOnlyRelativeUrls()` on the
+      restrictive builder; see the entry for issue #453 above.
       Issue #204.
     * The javadoc for `matching`, `allowUrlProtocols` and `allowUrlsInStyles`
       now says where the URL protocol guard runs: after the policies an

--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,18 @@
 
 Most recent at top.
   * Next release
+    * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
+      relative-only URL policy.  It allows URLs with neither a protocol nor
+      an authority, but rejects absolute URLs and protocol-relative URLs such
+      as `//example.org/`.  Unlike the default guard on a builder that never
+      called `allowUrlProtocols`, this restriction intersects with every
+      protocol allowlist and remains relative-only through
+      `PolicyFactory.and`, including for `srcset` and `url()` in styles.
+      Existing `and()` compositions that deliberately relied on a
+      protocol-less factory to strip absolute URLs allowed by another factory
+      should call `allowOnlyRelativeUrls()` on the restrictive builder before
+      upgrading; without it, the change for issue #204 may widen those
+      compositions to the protocols the other factory allows.  Issue #453.
     * Self-closing SVG and MathML handling now follows the browser's current
       tree-construction context through HTML integration points, foreign
       content breakout tags, mismatched foreign end tags, and the end tags

--- a/change_log.md
+++ b/change_log.md
@@ -5,10 +5,12 @@ Most recent at top.
     * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
       relative-only URL policy.  It allows URLs with neither a protocol nor
       an authority, but rejects absolute URLs and protocol-relative URLs such
-      as `//example.org/`.  Unlike the default guard on a builder that never
-      called `allowUrlProtocols`, this restriction intersects with every
-      protocol allowlist and remains relative-only through
-      `PolicyFactory.and`, including for `srcset` and `url()` in styles.
+      as `//example.org/`, including equivalent slash and backslash spellings
+      that browsers resolve to an authority.  Unlike the default guard on a
+      builder that never called `allowUrlProtocols`, this restriction
+      intersects with every protocol allowlist and remains relative-only
+      through `PolicyFactory.and`, including for `srcset` and `url()` in
+      styles.
       Existing `and()` compositions that deliberately relied on a
       protocol-less factory to strip absolute URLs allowed by another factory
       should call `allowOnlyRelativeUrls()` on the restrictive builder before

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
@@ -40,7 +40,8 @@ import javax.annotation.Nullable;
  * <p>
  * URLs with protocols must match the protocol set passed to the constructor.
  * URLs without protocols but which specify an origin different from the
- * containing page (e.g. {@code //example.org}) are only allowed if the
+ * containing page (e.g. {@code //example.org}, including the equivalent
+ * slash and backslash spellings browsers recognize) are only allowed if the
  * {@link FilterUrlByProtocolAttributePolicy#allowProtocolRelativeUrls policy}
  * allows both {@code http} and {@code https} which are normally used to serve
  * HTML.
@@ -72,16 +73,18 @@ public class FilterUrlByProtocolAttributePolicy implements AttributePolicy {
   public @Nullable String apply(
       String elementName, String attributeName, String value) {
     String url = Strings.stripHtmlSpaces(value);
+    // When resolving against an HTTP(S) page, browsers treat backslashes as
+    // slashes.  Each of these pairs introduces an authority: //, /\, \/, \\.
+    if (url.length() >= 2
+        && isUrlSlash(url.charAt(0))
+        && isUrlSlash(url.charAt(1))
+        && !allowProtocolRelativeUrls()) {
+      return null;
+    }
     protocol_loop:
     for (int i = 0, n = url.length(); i < n; ++i) {
       switch (url.charAt(i)) {
         case '/': case '#': case '?':  // No protocol.
-          // Check for domain relative URLs like //www.evil.org/
-          if (url.startsWith("//")
-              // or the protocols by which HTML is normally served are OK.
-              && !allowProtocolRelativeUrls()) {
-            return null;
-          }
           break protocol_loop;
         case ':':
           String protocol = Strings.toLowerCase(url.substring(0, i));
@@ -90,6 +93,10 @@ public class FilterUrlByProtocolAttributePolicy implements AttributePolicy {
       }
     }
     return normalizeUri(url);
+  }
+
+  private static boolean isUrlSlash(char ch) {
+    return ch == '/' || ch == '\\';
   }
 
   protected boolean allowProtocolRelativeUrls() {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -591,7 +591,9 @@ public class HtmlPolicyBuilder {
    * A relative URL here has neither a protocol nor an authority, so values
    * such as {@code path}, {@code /path}, {@code ?query}, and {@code #fragment}
    * are allowed, while {@code https://example.org/} and the protocol-relative
-   * {@code //example.org/} are rejected.
+   * {@code //example.org/} are rejected.  Browsers treat backslashes as
+   * slashes when resolving against an HTTP(S) page, so equivalent authority
+   * spellings such as {@code \\example.org/} are rejected too.
    * <p>
    * Unlike the default guard used when {@link #allowUrlProtocols} was never
    * called, this is an explicit restriction.  It continues to reject every
@@ -612,10 +614,9 @@ public class HtmlPolicyBuilder {
 
   /**
    * Reverses a decision made by {@link #allowUrlProtocols}.
-   * If this removes every allowed protocol, the builder again uses the
-   * default guard that yields to another factory's allowlist during
-   * {@link PolicyFactory#and}.  To keep allowing only relative URLs through
-   * composition, use {@link #allowOnlyRelativeUrls()}.
+   * Unless {@link #allowOnlyRelativeUrls()} was called, removing every
+   * allowed protocol makes the builder use the default guard that yields to
+   * another factory's allowlist during {@link PolicyFactory#and}.
    */
   public HtmlPolicyBuilder disallowUrlProtocols(String... protocols) {
     invalidateCompiledState();

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -217,6 +217,8 @@ public class HtmlPolicyBuilder {
   private final Map<String, AttributePolicy> globalAttrPolicies
       = new LinkedHashMap<>();
   private final Set<String> allowedProtocols = new HashSet<>();
+  /** Whether URL values must stay relative when factories are combined. */
+  private boolean onlyRelativeUrls;
   private final Map<String, HtmlTagSkipType> skipIssueTagMap = new LinkedHashMap<>(DEFAULT_SKIP_TAG_MAP_IF_EMPTY_ATTR);
   private final Map<String, Boolean> textContainers = new LinkedHashMap<>();
   private HtmlStreamEventProcessor postprocessor =
@@ -555,7 +557,10 @@ public class HtmlPolicyBuilder {
    * treats it differently from one.  A factory that allowed no protocol,
    * combined with one that did, defers to it, so the combination allows the
    * protocols the other factory allowed.  Two factories that each allowed
-   * some protocols together allow only those both allowed.
+   * some protocols together allow only those both allowed.  Use
+   * {@link #allowOnlyRelativeUrls()} when this builder should continue to
+   * reject every URL with a protocol after it is combined with another
+   * factory.
    * <p>
    * The guard runs after any policies attached to the attribute with
    * {@link AttributeBuilder#matching(AttributePolicy) matching}, and after
@@ -582,7 +587,35 @@ public class HtmlPolicyBuilder {
   }
 
   /**
+   * Restricts URL values to relative URLs.
+   * A relative URL here has neither a protocol nor an authority, so values
+   * such as {@code path}, {@code /path}, {@code ?query}, and {@code #fragment}
+   * are allowed, while {@code https://example.org/} and the protocol-relative
+   * {@code //example.org/} are rejected.
+   * <p>
+   * Unlike the default guard used when {@link #allowUrlProtocols} was never
+   * called, this is an explicit restriction.  It continues to reject every
+   * URL with a protocol when the resulting factory is combined with another
+   * factory by {@link PolicyFactory#and}.  Use this on a restrictive builder
+   * that previously relied on its empty protocol set to narrow another
+   * factory during composition.
+   * <p>
+   * This restriction takes precedence over calls to
+   * {@code allowUrlProtocols}, regardless of call order.  It does not itself
+   * allow any URL attribute or URLs in styles.
+   */
+  public HtmlPolicyBuilder allowOnlyRelativeUrls() {
+    invalidateCompiledState();
+    onlyRelativeUrls = true;
+    return this;
+  }
+
+  /**
    * Reverses a decision made by {@link #allowUrlProtocols}.
+   * If this removes every allowed protocol, the builder again uses the
+   * default guard that yields to another factory's allowlist during
+   * {@link PolicyFactory#and}.  To keep allowing only relative URLs through
+   * composition, use {@link #allowOnlyRelativeUrls()}.
    */
   public HtmlPolicyBuilder disallowUrlProtocols(String... protocols) {
     invalidateCompiledState();
@@ -918,7 +951,9 @@ public class HtmlPolicyBuilder {
     // Add guards on top of any custom policies.
     {
       final AttributePolicy urlAttributePolicy =
-          UrlProtocolGuard.forProtocols(allowedProtocols);
+          onlyRelativeUrls
+          ? UrlProtocolGuard.RELATIVE_ONLY
+          : UrlProtocolGuard.forProtocols(allowedProtocols);
 
       Set<String> toGuard = new HashSet<>(ATTRIBUTE_GUARDS.keySet());
       AttributeGuardIntermediates intermediates = new AttributeGuardIntermediates(

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -604,7 +604,9 @@ public class HtmlPolicyBuilder {
    * <p>
    * This restriction takes precedence over calls to
    * {@code allowUrlProtocols}, regardless of call order.  It does not itself
-   * allow any URL attribute or URLs in styles.
+   * allow any URL attribute or URLs in styles, and it reaches only those
+   * this builder allows: {@code and()} unions grants, so a URL attribute
+   * that only the other factory allows keeps that factory's protocols.
    */
   public HtmlPolicyBuilder allowOnlyRelativeUrls() {
     invalidateCompiledState();

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
@@ -155,7 +155,10 @@ public final class PolicyFactory
    * The guard a builder puts on URL attributes when it allowed no protocol
    * is a default rather than a policy, so it yields here to the other
    * factory's protocol allowlist; two allowlists intersect like any other
-   * overlapping policies.  See {@link HtmlPolicyBuilder#allowUrlProtocols}.
+   * overlapping policies.  A builder configured with
+   * {@link HtmlPolicyBuilder#allowOnlyRelativeUrls} instead supplies an
+   * explicit empty allowlist that continues to reject absolute URLs after
+   * composition.  See {@link HtmlPolicyBuilder#allowUrlProtocols}.
    */
   public PolicyFactory and(PolicyFactory f) {
     Map<String, ElementAndAttributePolicies> builder

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/UrlProtocolGuard.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/UrlProtocolGuard.java
@@ -30,9 +30,11 @@ import static org.owasp.shim.Java8Shim.j8;
  * {@code matching}, so a builder that allowed no protocol rejects every
  * absolute URL on its own, however its author-supplied policies are written.
  *
- * <p>Two allowlists with nothing in common join to an empty allowlist.  On
- * its own that behaves like the default, but it is not one and does not
- * yield, so the same factories combined in any grouping allow the same URLs.
+ * <p>{@link HtmlPolicyBuilder#allowOnlyRelativeUrls} installs
+ * {@link #RELATIVE_ONLY}, whose explicit empty allowlist does not yield.
+ * Two nonempty allowlists with nothing in common also join to an explicit
+ * empty allowlist.  On its own either behaves like the default, but neither
+ * is one, so the same factories combined in any grouping allow the same URLs.
  */
 @TCB
 @Immutable
@@ -43,6 +45,10 @@ final class UrlProtocolGuard implements JoinableAttributePolicy {
 
   /** The guard for a builder that allowed no protocol. */
   static final UrlProtocolGuard NONE = new UrlProtocolGuard(null);
+
+  /** The explicit empty allowlist for a relative-only builder. */
+  static final UrlProtocolGuard RELATIVE_ONLY =
+      new UrlProtocolGuard(j8().setOf());
 
   /** The protocols allowed, or null for the default guard. */
   private final @Nullable Set<String> allowlist;

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
@@ -150,11 +150,83 @@ final class PolicyFactoryTest {
 
     PolicyFactory noProtocols = links();
     PolicyFactory http = links("http");
+    PolicyFactory disallowedBackToDefault = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href").onElements("a")
+        .allowUrlProtocols("http")
+        .disallowUrlProtocols("http")
+        .toFactory();
 
     assertEquals(relativeOnly, noProtocols.sanitize(links));
+    assertEquals(relativeOnly, disallowedBackToDefault.sanitize(links));
     assertEquals(httpOnly, http.sanitize(links));
     assertEquals(httpOnly, noProtocols.and(http).sanitize(links));
     assertEquals(httpOnly, http.and(noProtocols).sanitize(links));
+    assertEquals(
+        httpOnly, disallowedBackToDefault.and(http).sanitize(links));
+    assertEquals(
+        httpOnly, http.and(disallowedBackToDefault).sanitize(links));
+  }
+
+  /**
+   * Issue #453.  A caller can choose an explicit empty protocol allowlist
+   * when a factory must keep allowing only relative URLs after and() combines
+   * it with a factory that allows protocols.  The restriction is independent
+   * of operand grouping and of calls to allowUrlProtocols on the same builder.
+   */
+  @Test
+  void testAndExplicitRelativeOnlyUrlGuardIntersectsAnAllowlist() {
+    String links = String.join(
+        "\n",
+        "<a href='http://example.com/'>http</a>",
+        "<a href='HTTPS://example.com/'>https</a>",
+        "<a href='//example.com/'>scheme-relative</a>",
+        "<a href='/local'>root-relative</a>",
+        "<a href='child'>path-relative</a>",
+        "<a href='?q=1'>query</a>",
+        "<a href='#fragment'>fragment</a>",
+        "<a href='jAvAsCrIpT:alert(1)'>js</a>",
+        "<a href='java&#9;script:alert(1)'>split js</a>",
+        "<a href='data:text/html,x'>data</a>");
+    String expected = String.join(
+        "\n",
+        "http",
+        "https",
+        "scheme-relative",
+        "<a href=\"/local\">root-relative</a>",
+        "<a href=\"child\">path-relative</a>",
+        "<a href=\"?q&#61;1\">query</a>",
+        "<a href=\"#fragment\">fragment</a>",
+        "js",
+        "split js",
+        "data");
+
+    PolicyFactory relativeOnly = relativeOnlyLinks();
+    PolicyFactory defaultGuard = links();
+    PolicyFactory web = links("http", "https");
+
+    assertEquals(expected, relativeOnly.sanitize(links));
+    assertEquals(expected, relativeOnly.and(web).sanitize(links));
+    assertEquals(expected, web.and(relativeOnly).sanitize(links));
+    assertEquals(
+        expected, defaultGuard.and(relativeOnly).and(web).sanitize(links));
+    assertEquals(
+        expected, defaultGuard.and(relativeOnly.and(web)).sanitize(links));
+
+    PolicyFactory relativeThenWeb = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href").onElements("a")
+        .allowOnlyRelativeUrls()
+        .allowUrlProtocols("http", "https")
+        .toFactory();
+    PolicyFactory webThenRelative = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href").onElements("a")
+        .allowUrlProtocols("http", "https")
+        .allowOnlyRelativeUrls()
+        .toFactory();
+    assertEquals(expected, relativeThenWeb.sanitize(links));
+    assertEquals(expected, webThenRelative.sanitize(links));
   }
 
   /** Two factories that allowed no protocol still allow none together. */
@@ -340,16 +412,53 @@ final class PolicyFactoryTest {
   void testAndDefaultUrlProtocolGuardYieldsInSrcset() {
     PolicyFactory noProtocols = images();
     PolicyFactory http = images("http");
+    PolicyFactory relativeOnly = relativeOnlyImages();
     String img = "<img src='http://example.com/a.png'"
         + " srcset='http://example.com/a.png 1x, javascript:alert(1) 2x,"
         + " /b.png 3x'>";
     String httpKept = "<img src=\"http://example.com/a.png\""
         + " srcset=\"http://example.com/a.png 1x , /b.png 3x\" />";
+    String relativeKept = "<img srcset=\"/b.png 3x\" />";
 
-    assertEquals("<img srcset=\"/b.png 3x\" />", noProtocols.sanitize(img));
+    assertEquals(relativeKept, noProtocols.sanitize(img));
     assertEquals(httpKept, http.sanitize(img));
     assertEquals(httpKept, noProtocols.and(http).sanitize(img));
     assertEquals(httpKept, http.and(noProtocols).sanitize(img));
+    assertEquals(relativeKept, relativeOnly.sanitize(img));
+    assertEquals(relativeKept, relativeOnly.and(http).sanitize(img));
+    assertEquals(relativeKept, http.and(relativeOnly).sanitize(img));
+  }
+
+  /** The explicit empty allowlist also survives joining inside CSS url(). */
+  @Test
+  void testAndExplicitRelativeOnlyUrlGuardIntersectsInStyles() {
+    CssSchema images =
+        CssSchema.withProperties(Arrays.asList("background-image"));
+    PolicyFactory noProtocols = styled(images);
+    PolicyFactory relativeOnly = relativeOnlyStyled(images);
+    PolicyFactory web = styled(images, "http", "https");
+    String divs =
+        "<div style=\"background-image: url(https://example.com/i.png)\">"
+        + "https</div>"
+        + "<div style=\"background-image: url(//example.com/i.png)\">"
+        + "scheme-relative</div>"
+        + "<div style=\"background-image: url(/local.png)\">relative</div>"
+        + "<div style=\"background-image: url(javascript:alert%281%29)\">"
+        + "js</div>";
+    String expected =
+        "<div>https</div>"
+        + "<div>scheme-relative</div>"
+        + "<div style=\"background-image:url(&#39;/local.png&#39;)\">"
+        + "relative</div>"
+        + "<div>js</div>";
+
+    assertEquals(expected, relativeOnly.sanitize(divs));
+    assertEquals(expected, relativeOnly.and(web).sanitize(divs));
+    assertEquals(expected, web.and(relativeOnly).sanitize(divs));
+    assertEquals(
+        expected, noProtocols.and(relativeOnly).and(web).sanitize(divs));
+    assertEquals(
+        expected, noProtocols.and(relativeOnly.and(web)).sanitize(divs));
   }
 
   /**
@@ -420,12 +529,30 @@ final class PolicyFactoryTest {
         .toFactory();
   }
 
+  /** Links whose hrefs must have neither a protocol nor an authority. */
+  private static PolicyFactory relativeOnlyLinks() {
+    return new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href").onElements("a")
+        .allowOnlyRelativeUrls()
+        .toFactory();
+  }
+
   /** Images with src and srcset, with the given protocols allowed. */
   private static PolicyFactory images(String... protocols) {
     return new HtmlPolicyBuilder()
         .allowElements("img")
         .allowAttributes("src", "srcset").onElements("img")
         .allowUrlProtocols(protocols)
+        .toFactory();
+  }
+
+  /** Images whose src and srcset URLs must be relative. */
+  private static PolicyFactory relativeOnlyImages() {
+    return new HtmlPolicyBuilder()
+        .allowElements("img")
+        .allowAttributes("src", "srcset").onElements("img")
+        .allowOnlyRelativeUrls()
         .toFactory();
   }
 
@@ -439,6 +566,17 @@ final class PolicyFactoryTest {
         .allowStyling(schema)
         .allowUrlsInStyles(AttributePolicy.IDENTITY_ATTRIBUTE_POLICY)
         .allowUrlProtocols(protocols)
+        .toFactory();
+  }
+
+  /** Styled divs whose CSS URLs must be relative. */
+  private static PolicyFactory relativeOnlyStyled(CssSchema schema) {
+    return new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(schema)
+        .allowUrlsInStyles(AttributePolicy.IDENTITY_ATTRIBUTE_POLICY)
+        .allowOnlyRelativeUrls()
         .toFactory();
   }
 

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
@@ -229,6 +229,42 @@ final class PolicyFactoryTest {
     assertEquals(expected, webThenRelative.sanitize(links));
   }
 
+  /**
+   * Browsers resolving against an HTTP(S) page treat a backslash as a slash,
+   * so each pair below introduces an authority.  The relative-only and
+   * default empty guards reject every spelling, including after entity
+   * decoding, while a policy that allows both web protocols may keep them.
+   */
+  @Test
+  void testRelativeOnlyRejectsBrowserAuthoritySpellings() {
+    String[][] authoritySpellings = {
+        { "//evil.example/path", "//evil.example/path" },
+        { "/\\evil.example/path", "/\\evil.example/path" },
+        { "\\/evil.example/path", "\\/evil.example/path" },
+        { "\\\\evil.example/path", "\\\\evil.example/path" },
+        { "&#47;&#47;evil.example/path", "//evil.example/path" },
+        { "&#47;&#92;evil.example/path", "/\\evil.example/path" },
+        { "&#92;&#47;evil.example/path", "\\/evil.example/path" },
+        { "&#92;&#92;evil.example/path", "\\\\evil.example/path" },
+    };
+    PolicyFactory defaultGuard = links();
+    PolicyFactory relativeOnly = relativeOnlyLinks();
+    PolicyFactory web = links("http", "https");
+    PolicyFactory relativeAndWeb = relativeOnly.and(web);
+    PolicyFactory webAndRelative = web.and(relativeOnly);
+
+    for (String[] spelling : authoritySpellings) {
+      String html = "<a href='" + spelling[0] + "'>external</a>";
+      String webAllowed =
+          "<a href=\"" + spelling[1] + "\">external</a>";
+      assertEquals("external", defaultGuard.sanitize(html), spelling[0]);
+      assertEquals("external", relativeOnly.sanitize(html), spelling[0]);
+      assertEquals("external", relativeAndWeb.sanitize(html), spelling[0]);
+      assertEquals("external", webAndRelative.sanitize(html), spelling[0]);
+      assertEquals(webAllowed, web.sanitize(html), spelling[0]);
+    }
+  }
+
   /** Two factories that allowed no protocol still allow none together. */
   @Test
   void testAndOfTwoDefaultUrlProtocolGuardsAllowsNoProtocol() {
@@ -415,7 +451,9 @@ final class PolicyFactoryTest {
     PolicyFactory relativeOnly = relativeOnlyImages();
     String img = "<img src='http://example.com/a.png'"
         + " srcset='http://example.com/a.png 1x, javascript:alert(1) 2x,"
-        + " /b.png 3x'>";
+        + " /b.png 3x, //example.com/c.png 4x,"
+        + " /\\example.com/d.png 5x, \\/example.com/e.png 6x,"
+        + " \\\\example.com/f.png 7x'>";
     String httpKept = "<img src=\"http://example.com/a.png\""
         + " srcset=\"http://example.com/a.png 1x , /b.png 3x\" />";
     String relativeKept = "<img srcset=\"/b.png 3x\" />";
@@ -459,6 +497,19 @@ final class PolicyFactoryTest {
         expected, noProtocols.and(relativeOnly).and(web).sanitize(divs));
     assertEquals(
         expected, noProtocols.and(relativeOnly.and(web)).sanitize(divs));
+
+    PolicyFactory rewritesToAuthority = new HtmlPolicyBuilder()
+        .allowElements("div")
+        .allowAttributes("style").onElements("div")
+        .allowStyling(images)
+        .allowUrlsInStyles((elementName, attributeName, url) ->
+            "\\\\evil.example/i.png")
+        .allowOnlyRelativeUrls()
+        .toFactory();
+    assertEquals(
+        "<div>x</div>",
+        rewritesToAuthority.sanitize(
+            "<div style=\"background-image:url(/local.png)\">x</div>"));
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/PolicyFactoryTest.java
@@ -249,6 +249,8 @@ final class PolicyFactoryTest {
     };
     PolicyFactory defaultGuard = links();
     PolicyFactory relativeOnly = relativeOnlyLinks();
+    PolicyFactory httpOnly = links("http");
+    PolicyFactory mailtoOnly = links("mailto");
     PolicyFactory web = links("http", "https");
     PolicyFactory relativeAndWeb = relativeOnly.and(web);
     PolicyFactory webAndRelative = web.and(relativeOnly);
@@ -259,10 +261,34 @@ final class PolicyFactoryTest {
           "<a href=\"" + spelling[1] + "\">external</a>";
       assertEquals("external", defaultGuard.sanitize(html), spelling[0]);
       assertEquals("external", relativeOnly.sanitize(html), spelling[0]);
+      assertEquals("external", httpOnly.sanitize(html), spelling[0]);
+      assertEquals("external", mailtoOnly.sanitize(html), spelling[0]);
       assertEquals("external", relativeAndWeb.sanitize(html), spelling[0]);
       assertEquals("external", webAndRelative.sanitize(html), spelling[0]);
       assertEquals(webAllowed, web.sanitize(html), spelling[0]);
     }
+  }
+
+  /**
+   * The relative-only restriction reaches only the URL attributes its
+   * builder allows.  and() unions grants, so an attribute that only the
+   * other factory allows keeps that factory's protocols.
+   */
+  @Test
+  void testRelativeOnlyDoesNotReachAttributesOnlyTheOtherFactoryAllows() {
+    String html = "<a href='https://example.com/'>abs</a>"
+        + "<a href='/local'>rel</a>"
+        + "<img src='https://example.com/a.png'"
+        + " srcset='//example.com/b.png 2x'>";
+    String expected = "abs<a href=\"/local\">rel</a>"
+        + "<img src=\"https://example.com/a.png\""
+        + " srcset=\"//example.com/b.png 2x\" />";
+
+    PolicyFactory relativeLinks = relativeOnlyLinks();
+    PolicyFactory webImages = images("http", "https");
+
+    assertEquals(expected, relativeLinks.and(webImages).sanitize(html));
+    assertEquals(expected, webImages.and(relativeLinks).sanitize(html));
   }
 
   /** Two factories that allowed no protocol still allow none together. */


### PR DESCRIPTION
## Summary

- add `HtmlPolicyBuilder.allowOnlyRelativeUrls()` to install an explicit empty protocol allowlist
- keep the relative-only restriction through `PolicyFactory.and` for ordinary URL attributes, `srcset`, and CSS `url()` values
- make the restriction independent of builder call order while leaving an allowlist disallowed back to empty as the yielding default
- document the migration path for compositions that relied on the behavior before issue #204

Relative-only means that a URL has neither a protocol nor an authority, so protocol-relative values such as `//example.org/` are rejected too.

## Testing

- `./mvnw clean verify` on JDK 11
  - 479 library tests passed, including the fuzzers and AntiSamy suite
  - 7 example tests passed
  - packaging verification and the JPMS consumer check passed

Closes #453