### PR TITLE
fix: Track HTML Stack Mutations in Foreign Content Context

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,18 @@
 
 Most recent at top.
   * Next release
+    * The context tracker behind self-closing SVG and MathML tags now fails
+      closed when an end tag reaches the HTML rules with an effect it cannot
+      derive from the elements it tracks: end tags processed with table
+      scope (`</table>`, `</td>` and the rest of the table structure),
+      `</h1>` through `</h6>`, `</form>`, a formatting end tag across a
+      special element, a stray end tag that may name an ancestor of the
+      foreign root, and table, `<template>` or `<select>` start tags at an
+      integration point.  From then on only `<svg/>` and `<math/>` close
+      themselves, as before issue #122.  Inside an integration point the
+      tracker follows the special category and the default, list-item and
+      button scopes, so `</foreignObject>` is ignored while an HTML element
+      such as `<div>` is still open inside it, as in browsers.  Issue #461.
     * Self-closing SVG and MathML handling now follows the browser's current
       tree-construction context through HTML integration points, foreign
       content breakout tags, mismatched foreign end tags, and the end tags

--- a/change_log.md
+++ b/change_log.md
@@ -2,18 +2,17 @@
 
 Most recent at top.
   * Next release
-    * The context tracker behind self-closing SVG and MathML tags now fails
-      closed when an end tag reaches the HTML rules with an effect it cannot
-      derive from the elements it tracks: end tags processed with table
-      scope (`</table>`, `</td>` and the rest of the table structure),
-      `</h1>` through `</h6>`, `</form>`, a formatting end tag across a
-      special element, a stray end tag that may name an ancestor of the
-      foreign root, and table, `<template>` or `<select>` start tags at an
-      integration point.  From then on only `<svg/>` and `<math/>` close
-      themselves, as before issue #122.  Inside an integration point the
-      tracker follows the special category and the default, list-item and
-      button scopes, so `</foreignObject>` is ignored while an HTML element
-      such as `<div>` is still open inside it, as in browsers.  Issue #461.
+    * The context tracker behind self-closing SVG and MathML tags now follows
+      the HTML start- and end-tag rules that can change the open-element
+      stack inside an integration point, including p, list, heading, button,
+      form, formatting, select and option rules.  It also tracks the form
+      pointer and inherited table or cell mode, and uses the current parser's
+      element categories rather than legacy void-element classifications.
+      When an outcome still depends on untracked table or template state or
+      on the active formatting list, it fails closed so only `<svg/>` and
+      `<math/>` close themselves.  Well-formed select and empty-table HTML
+      islands no longer make later SVG unnecessarily use that fallback.
+      Issue #461.
     * Self-closing SVG and MathML handling now follows the browser's current
       tree-construction context through HTML integration points, foreign
       content breakout tags, mismatched foreign end tags, and the end tags

--- a/change_log.md
+++ b/change_log.md
@@ -21,6 +21,11 @@ Most recent at top.
       mismatched cell or section end tag is ignored as browsers ignore it.
       Well-formed nested tables and captions no longer make later SVG use
       the fallback.  Issue #461.
+    * The same tracker now also fails closed when a walk reaches an open
+      `dialog`, which the specification and Chrome categorize differently in
+      the special category, exactly as it already did for `search`.  Without
+      this a later self-closing `<object/>` was honored, exposing text a
+      spec-compliant parser keeps inside the HTML `object`.  Issue #461.
     * Self-closing SVG and MathML handling now follows the browser's current
       tree-construction context through HTML integration points, foreign
       content breakout tags, mismatched foreign end tags, and the end tags

--- a/change_log.md
+++ b/change_log.md
@@ -13,6 +13,14 @@ Most recent at top.
       `<math/>` close themselves.  Well-formed select and empty-table HTML
       islands no longer make later SVG unnecessarily use that fallback.
       Issue #461.
+    * The same tracker now closes p for `xmp`, honors only the first of
+      duplicate `type` attributes on `input`, fails closed for `table` after
+      an open p (whose fate depends on quirks mode) and for `search` (which
+      the specification and Chrome categorize differently), and follows
+      untracked cells, captions, sections and nested tables so that a
+      mismatched cell or section end tag is ignored as browsers ignore it.
+      Well-formed nested tables and captions no longer make later SVG use
+      the fallback.  Issue #461.
     * Self-closing SVG and MathML handling now follows the browser's current
       tree-construction context through HTML integration points, foreign
       content breakout tags, mismatched foreign end tags, and the end tags

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -1029,9 +1029,10 @@ public final class HtmlSanitizer {
       = j8().setOf(
           "address", "applet", "area", "article", "aside", "base",
           "basefont", "bgsound", "blockquote", "body", "br", "button",
-          "caption", "center", "col", "colgroup", "dd", "details", "dir",
-          "div", "dl", "dt", "embed", "fieldset", "figcaption", "figure",
-          "footer", "form", "frame", "frameset", "h1", "h2", "h3", "h4",
+          "caption", "center", "col", "colgroup", "dd", "details",
+          "dialog", "dir", "div", "dl", "dt", "embed", "fieldset",
+          "figcaption", "figure", "footer", "form", "frame", "frameset",
+          "h1", "h2", "h3", "h4",
           "h5", "h6", "head", "header", "hgroup", "hr", "html", "iframe",
           "img", "input", "keygen", "li", "link", "listing", "main",
           "marquee", "menu", "meta", "nav", "noembed", "noframes",
@@ -1044,9 +1045,11 @@ public final class HtmlSanitizer {
   /**
    * Elements the specification puts in the special category but current
    * Chrome does not, so a walk that reaches one has an uncertain outcome.
+   * {@code dialog} and {@code search} are both special in the WHATWG parsing
+   * algorithm but absent from Chrome's special-node set.
    */
   private static final Set<String> AMBIGUOUSLY_SPECIAL_HTML_ELEMENT_NAMES
-      = j8().setOf("search");
+      = j8().setOf("dialog", "search");
 
   /** Start tags whose HTML stack effect this bounded tracker cannot derive. */
   private static final Set<String> UNMODELED_CONTEXT_CHANGING_START_TAG_NAMES

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -242,6 +242,25 @@ public final class HtmlSanitizer {
     /** Elements from the first open foreign root through the current node. */
     private final List<OpenElement> openElements = new ArrayList<>();
 
+    /** The form pointer is not bounded by an integration point. */
+    private boolean formElementPointerSet;
+
+    /** The form pointer's target, when that element is in the tracked region. */
+    private @Nullable OpenElement trackedFormElement;
+
+    /** A table inserted in known in-body mode, before any child tag. */
+    private @Nullable OpenElement simpleTable;
+
+    /** The mode to restore when {@link #simpleTable} closes. */
+    private HtmlInsertionMode simpleTableReturnMode
+        = HtmlInsertionMode.IN_BODY;
+
+    /** The HTML mode that remains in force while foreign rules run. */
+    private HtmlInsertionMode htmlInsertionMode = HtmlInsertionMode.IN_BODY;
+
+    /** Whether an untracked table is known to be in table scope. */
+    private boolean untrackedTableInScope;
+
     /**
      * True once the browser's context can no longer be derived from the
      * tracked elements: the bounded stack was exhausted, or a tag's effect
@@ -283,7 +302,15 @@ public final class HtmlSanitizer {
 
     /** Updates the context using the foreign-content or HTML end-tag rules. */
     void processEndTag(String elementName) {
-      if (unknown || openElements.isEmpty()) { return; }
+      if (unknown) { return; }
+      if (openElements.isEmpty()) {
+        if ("form".equals(elementName)) {
+          formElementPointerSet = false;
+          trackedFormElement = null;
+        }
+        trackUntrackedHtmlEndTag(elementName);
+        return;
+      }
 
       if (currentElement().namespace == Namespace.HTML) {
         processEndTagUnderHtmlRules(elementName);
@@ -320,6 +347,17 @@ public final class HtmlSanitizer {
      * which fails closed: self-closing flags are no longer honored.
      */
     private void processEndTagUnderHtmlRules(String elementName) {
+      if (simpleTable != null) {
+        if ("table".equals(elementName)
+            && currentElement() == simpleTable) {
+          openElements.remove(openElements.size() - 1);
+          simpleTable = null;
+          htmlInsertionMode = simpleTableReturnMode;
+        } else {
+          becomeUnknown();
+        }
+        return;
+      }
       if (TABLE_SCOPED_ELEMENT_NAMES.contains(elementName)
           || "template".equals(elementName)) {
         // Table scope is bounded only by html, table and template, so these
@@ -329,6 +367,21 @@ public final class HtmlSanitizer {
         return;
       }
       if (IGNORED_HTML_END_TAG_NAMES.contains(elementName)) {
+        return;
+      }
+      if ("form".equals(elementName)) {
+        OpenElement form = trackedFormElement;
+        formElementPointerSet = false;
+        trackedFormElement = null;
+        if (form != null) {
+          int formIndex = openElements.indexOf(form);
+          if (formIndex >= 0 && isInDefaultScope(formIndex)) {
+            // Outside template contents, </form> removes the form without
+            // popping the elements above it.
+            generateImpliedEndTags(null);
+            openElements.remove(formIndex);
+          }
+        }
         return;
       }
       boolean anyOther = !SPECIFIC_END_TAG_RULE_NAMES.contains(elementName);
@@ -346,12 +399,11 @@ public final class HtmlSanitizer {
         String openName = open.elementName;
         if (asciiEqualsIgnoreCase(openName, elementName)
             || (heading && isHeadingName(openName))) {
-          if ("form".equals(elementName)) {
-            // </form> removes the form element without popping the
-            // elements above it.
-            openElements.remove(i);
-          } else {
-            openElements.subList(i, openElements.size()).clear();
+          if (!popTrackedElementsFrom(
+              i,
+              ACTIVE_FORMATTING_MARKER_ELEMENT_NAMES.contains(elementName),
+              formatting ? open : null)) {
+            return;
           }
           return;
         }
@@ -376,7 +428,7 @@ public final class HtmlSanitizer {
           return;
         }
       }
-      if (openElements.isEmpty() || "form".equals(elementName)) {
+      if (openElements.isEmpty()) {
         return;
       }
       // Nothing tracked bounded the search, so whether the token closes the
@@ -386,21 +438,154 @@ public final class HtmlSanitizer {
 
     private boolean processHtmlStartTag(
         String elementName, List<String> attrs, boolean selfClosing) {
+      if (simpleTable != null) {
+        // A child start tag is where the in-table modes start implying or
+        // foster-parenting elements.  Keep the empty-table case exact and
+        // fail closed for the rest.
+        becomeUnknown();
+        return false;
+      }
+
       Namespace namespace;
       if ("svg".equals(elementName)) {
         namespace = Namespace.SVG;
       } else if ("math".equals(elementName)) {
         namespace = Namespace.MATHML;
       } else {
-        if (!openElements.isEmpty()) {
-          if (CONTEXT_CHANGING_START_TAG_NAMES.contains(elementName)) {
-            // Table structure, templates and selects change the insertion
-            // mode or pop the stack in ways that depend on untracked state.
-            becomeUnknown();
-          } else if (!HtmlTextEscapingMode.isVoidElement(elementName)
-                     && !IGNORED_HTML_START_TAG_NAMES.contains(elementName)) {
-            push(new OpenElement(elementName, Namespace.HTML, attrs));
+        if (openElements.isEmpty()) {
+          trackUntrackedHtmlStartTag(elementName);
+        }
+        if (htmlInsertionMode == HtmlInsertionMode.UNKNOWN) {
+          becomeUnknown();
+          return false;
+        }
+        if (UNMODELED_CONTEXT_CHANGING_START_TAG_NAMES.contains(elementName)) {
+          becomeUnknown();
+          return false;
+        }
+        if ("form".equals(elementName)) {
+          if (htmlInsertionMode == HtmlInsertionMode.IN_TABLE) {
+            // "In table" inserts a new form and immediately pops it.
+            if (!formElementPointerSet) {
+              formElementPointerSet = true;
+              trackedFormElement = null;
+            }
+            return false;
           }
+          processFormStartTag(attrs);
+          return false;
+        }
+        if (openElements.isEmpty()) {
+          return false;
+        }
+        if (TABLE_STRUCTURE_START_TAG_NAMES.contains(elementName)) {
+          if (htmlInsertionMode != HtmlInsertionMode.IN_BODY) {
+            becomeUnknown();
+          }
+          return false;
+        }
+        if (P_CLOSING_START_TAG_NAMES.contains(elementName)
+            || "pre".equals(elementName)
+            || "listing".equals(elementName)
+            || "plaintext".equals(elementName)) {
+          if (!closePIfInButtonScope()) { return false; }
+        } else if (isHeadingName(elementName)) {
+          if (!closePIfInButtonScope()) { return false; }
+          OpenElement current = currentElement();
+          if (current.namespace == Namespace.HTML
+              && isHeadingName(current.elementName)) {
+            openElements.remove(openElements.size() - 1);
+          }
+        } else if ("li".equals(elementName)) {
+          if (!closeListOrDescriptionItemForStart(true)
+              || !closePIfInButtonScope()) {
+            return false;
+          }
+        } else if ("dd".equals(elementName) || "dt".equals(elementName)) {
+          if (!closeListOrDescriptionItemForStart(false)
+              || !closePIfInButtonScope()) {
+            return false;
+          }
+        } else if ("button".equals(elementName)) {
+          int buttonIndex = findHtmlElementInDefaultScope("button", true);
+          if (buttonIndex >= 0) {
+            if (!popTrackedElementsFrom(buttonIndex, false, null)) {
+              return false;
+            }
+          }
+        } else if ("a".equals(elementName)) {
+          if (findOpenHtmlElement("a") >= 0) {
+            becomeUnknown();
+            return false;
+          }
+        } else if ("nobr".equals(elementName)) {
+          if (findHtmlElementInDefaultScope("nobr", false) >= 0) {
+            becomeUnknown();
+            return false;
+          }
+        } else if ("select".equals(elementName)) {
+          int selectIndex = findHtmlElementInDefaultScope("select", false);
+          if (selectIndex >= 0) {
+            // A nested select start tag is ignored after popping the first.
+            if (!popTrackedElementsFrom(selectIndex, false, null)) {
+              return false;
+            }
+            return false;
+          }
+        } else if ("option".equals(elementName)) {
+          if (findHtmlElementInDefaultScope("select", false) >= 0) {
+            generateImpliedEndTags("optgroup");
+          } else if (isCurrentHtmlElement("option")) {
+            openElements.remove(openElements.size() - 1);
+          }
+        } else if ("optgroup".equals(elementName)) {
+          if (findHtmlElementInDefaultScope("select", false) >= 0) {
+            generateImpliedEndTags(null);
+          } else if (isCurrentHtmlElement("option")) {
+            openElements.remove(openElements.size() - 1);
+          }
+        } else if ("input".equals(elementName)) {
+          if (htmlInsertionMode == HtmlInsertionMode.IN_TABLE
+              && hasHiddenInputType(attrs)) {
+            return false;
+          }
+          int selectIndex = findHtmlElementInDefaultScope("select", false);
+          if (selectIndex >= 0) {
+            if (!popTrackedElementsFrom(selectIndex, false, null)) {
+              return false;
+            }
+          }
+        } else if ("hr".equals(elementName)) {
+          if (!closePIfInButtonScope()) { return false; }
+          if (findHtmlElementInDefaultScope("select", false) >= 0) {
+            generateImpliedEndTags(null);
+          }
+        } else if (UNMODELED_HTML_START_TAG_NAMES.contains(elementName)) {
+          becomeUnknown();
+          return false;
+        } else if ("image".equals(elementName)) {
+          // The in-body rules rewrite image to the void img element.
+          return false;
+        } else if ("table".equals(elementName)) {
+          if (htmlInsertionMode == HtmlInsertionMode.IN_TABLE) {
+            becomeUnknown();
+            return false;
+          }
+          if (!closePIfInButtonScope()) { return false; }
+          OpenElement table = new OpenElement(
+              elementName, Namespace.HTML, attrs);
+          push(table);
+          if (!unknown) {
+            simpleTable = table;
+            simpleTableReturnMode = htmlInsertionMode;
+            htmlInsertionMode = HtmlInsertionMode.IN_TABLE;
+          }
+          return false;
+        }
+
+        if (!HTML_TREE_BUILDER_VOID_ELEMENT_NAMES.contains(elementName)
+            && !IGNORED_HTML_START_TAG_NAMES.contains(elementName)) {
+          push(new OpenElement(elementName, Namespace.HTML, attrs));
         }
         // HTML ignores the self-closing flag on ordinary non-void elements.
         // Void elements are already empty and need no synthetic close event.
@@ -413,8 +598,182 @@ public final class HtmlSanitizer {
       return selfClosing;
     }
 
+    private void trackUntrackedHtmlStartTag(String elementName) {
+      if ("table".equals(elementName)) {
+        if (!untrackedTableInScope) {
+          untrackedTableInScope = true;
+          htmlInsertionMode = HtmlInsertionMode.IN_TABLE;
+        } else if (htmlInsertionMode == HtmlInsertionMode.IN_CELL) {
+          // This is a nested table; its eventual end tag needs a mode stack.
+          htmlInsertionMode = HtmlInsertionMode.UNKNOWN;
+        }
+        return;
+      }
+      if (!untrackedTableInScope) { return; }
+      if ("td".equals(elementName) || "th".equals(elementName)) {
+        htmlInsertionMode = HtmlInsertionMode.IN_CELL;
+      } else if ("caption".equals(elementName)) {
+        // Caption uses body rules for most tokens, but not for table-family
+        // starts, so keep the distinction conservative.
+        htmlInsertionMode = HtmlInsertionMode.UNKNOWN;
+      } else if (TABLE_STRUCTURE_START_TAG_NAMES.contains(elementName)) {
+        htmlInsertionMode = HtmlInsertionMode.IN_TABLE;
+      }
+    }
+
+    private void trackUntrackedHtmlEndTag(String elementName) {
+      if (!untrackedTableInScope) { return; }
+      if ("table".equals(elementName)) {
+        if (htmlInsertionMode != HtmlInsertionMode.UNKNOWN) {
+          untrackedTableInScope = false;
+          htmlInsertionMode = HtmlInsertionMode.IN_BODY;
+        }
+      } else if (TABLE_SCOPED_ELEMENT_NAMES.contains(elementName)) {
+        htmlInsertionMode = HtmlInsertionMode.IN_TABLE;
+      }
+    }
+
+    private void processFormStartTag(List<String> attrs) {
+      if (formElementPointerSet) { return; }
+      formElementPointerSet = true;
+      if (openElements.isEmpty()) { return; }
+      if (!closePIfInButtonScope()) { return; }
+      OpenElement form = new OpenElement("form", Namespace.HTML, attrs);
+      push(form);
+      if (!unknown) { trackedFormElement = form; }
+    }
+
+    private boolean closePIfInButtonScope() {
+      int pIndex = findHtmlElementInDefaultScope("p", true);
+      if (pIndex >= 0) {
+        return popTrackedElementsFrom(pIndex, false, null);
+      }
+      return true;
+    }
+
+    private boolean closeListOrDescriptionItemForStart(boolean listItem) {
+      for (int i = openElements.size(); --i >= 0;) {
+        OpenElement open = openElements.get(i);
+        if (open.namespace == Namespace.HTML
+            && (listItem
+                ? "li".equals(open.elementName)
+                : "dd".equals(open.elementName)
+                    || "dt".equals(open.elementName))) {
+          return popTrackedElementsFrom(i, false, null);
+        }
+        if (isSpecial(open)
+            && !isHtmlElement(open, "address")
+            && !isHtmlElement(open, "div")
+            && !isHtmlElement(open, "p")) {
+          return true;
+        }
+      }
+      return true;
+    }
+
+    /**
+     * Pops a known suffix, or fails closed if doing so leaves formatting
+     * elements only in the active formatting list.  A later start tag could
+     * reconstruct those elements and put Chrome back in HTML content while
+     * this bounded tracker believed that the current node was foreign.
+     */
+    private boolean popTrackedElementsFrom(
+        int fromIndex,
+        boolean allFormattingEntriesAreCleared,
+        @Nullable OpenElement oneFormattingEntryRemoved) {
+      if (!allFormattingEntriesAreCleared) {
+        for (int i = openElements.size(); --i >= fromIndex;) {
+          OpenElement open = openElements.get(i);
+          if (open.namespace == Namespace.HTML
+              && FORMATTING_ELEMENT_NAMES.contains(open.elementName)
+              && open != oneFormattingEntryRemoved) {
+            becomeUnknown();
+            return false;
+          }
+        }
+      }
+      openElements.subList(fromIndex, openElements.size()).clear();
+      return true;
+    }
+
+    private void generateImpliedEndTags(@Nullable String except) {
+      while (!openElements.isEmpty()) {
+        OpenElement current = currentElement();
+        if (current.namespace != Namespace.HTML
+            || !IMPLIED_END_TAG_NAMES.contains(current.elementName)
+            || current.elementName.equals(except)) {
+          return;
+        }
+        openElements.remove(openElements.size() - 1);
+      }
+    }
+
+    private int findHtmlElementInDefaultScope(
+        String elementName, boolean buttonScope) {
+      for (int i = openElements.size(); --i >= 0;) {
+        OpenElement open = openElements.get(i);
+        if (isHtmlElement(open, elementName)) { return i; }
+        if (open.namespace != Namespace.HTML) {
+          if (open.special) { return -1; }
+        } else if (DEFAULT_SCOPE_BOUNDARY_NAMES.contains(open.elementName)
+                   || (buttonScope && "button".equals(open.elementName))) {
+          return -1;
+        }
+      }
+      return -1;
+    }
+
+    private boolean isInDefaultScope(int targetIndex) {
+      for (int i = openElements.size(); --i > targetIndex;) {
+        OpenElement open = openElements.get(i);
+        if (open.namespace != Namespace.HTML) {
+          if (open.special) { return false; }
+        } else if (DEFAULT_SCOPE_BOUNDARY_NAMES.contains(open.elementName)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private int findOpenHtmlElement(String elementName) {
+      for (int i = openElements.size(); --i >= 0;) {
+        if (isHtmlElement(openElements.get(i), elementName)) { return i; }
+      }
+      return -1;
+    }
+
+    private boolean isCurrentHtmlElement(String elementName) {
+      return isHtmlElement(currentElement(), elementName);
+    }
+
+    private static boolean isHtmlElement(
+        OpenElement open, String elementName) {
+      return open.namespace == Namespace.HTML
+          && elementName.equals(open.elementName);
+    }
+
+    private static boolean isSpecial(OpenElement open) {
+      return open.namespace == Namespace.HTML
+          ? SPECIAL_HTML_ELEMENT_NAMES.contains(open.elementName)
+          : open.special;
+    }
+
+    private static boolean hasHiddenInputType(List<String> attrs) {
+      for (int i = 0; i + 1 < attrs.size(); i += 2) {
+        if ("type".equals(attrs.get(i))
+            && asciiEqualsIgnoreCase("hidden", attrs.get(i + 1))) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     private void becomeUnknown() {
       openElements.clear();
+      formElementPointerSet = false;
+      trackedFormElement = null;
+      simpleTable = null;
+      untrackedTableInScope = false;
       unknown = true;
     }
 
@@ -458,6 +817,13 @@ public final class HtmlSanitizer {
               && "annotation-xml".equals(current.elementName)
               && "svg".equals(elementName));
     }
+  }
+
+  private enum HtmlInsertionMode {
+    IN_BODY,
+    IN_TABLE,
+    IN_CELL,
+    UNKNOWN,
   }
 
   private enum Namespace {
@@ -568,8 +934,9 @@ public final class HtmlSanitizer {
           "address", "article", "aside", "blockquote", "button", "center",
           "details", "dialog", "dir", "div", "dl", "fieldset", "figcaption",
           "figure", "footer", "header", "hgroup", "listing", "main", "menu",
-          "nav", "ol", "pre", "search", "section", "summary", "ul", "form",
-          "p", "li", "dd", "dt", "h1", "h2", "h3", "h4", "h5", "h6",
+          "nav", "ol", "pre", "search", "section", "select", "summary",
+          "ul", "form", "p", "li", "dd", "dt", "h1", "h2", "h3", "h4",
+          "h5", "h6",
           "a", "b", "big", "code", "em", "font", "i", "nobr", "s", "small",
           "strike", "strong", "tt", "u", "applet", "marquee", "object");
 
@@ -577,6 +944,10 @@ public final class HtmlSanitizer {
       = j8().setOf(
           "a", "b", "big", "code", "em", "font", "i", "nobr", "s", "small",
           "strike", "strong", "tt", "u");
+
+  /** Elements whose end tags clear the active formatting list to a marker. */
+  private static final Set<String> ACTIVE_FORMATTING_MARKER_ELEMENT_NAMES
+      = j8().setOf("applet", "marquee", "object");
 
   /** The HTML elements that bound the default scope. */
   private static final Set<String> DEFAULT_SCOPE_BOUNDARY_NAMES
@@ -601,15 +972,44 @@ public final class HtmlSanitizer {
           "tfoot", "th", "thead", "title", "tr", "track", "ul", "wbr",
           "xmp");
 
-  /** Start tags inside foreign content whose effect depends on the mode. */
-  private static final Set<String> CONTEXT_CHANGING_START_TAG_NAMES
+  /** Start tags whose HTML stack effect this bounded tracker cannot derive. */
+  private static final Set<String> UNMODELED_CONTEXT_CHANGING_START_TAG_NAMES
+      = j8().setOf("template", "frameset");
+
+  /** Ruby starts generate implied end tags using state outside this tracker. */
+  private static final Set<String> UNMODELED_HTML_START_TAG_NAMES
+      = j8().setOf("rb", "rtc", "rp", "rt");
+
+  /** Start tags that close a p element in button scope before insertion. */
+  private static final Set<String> P_CLOSING_START_TAG_NAMES
       = j8().setOf(
-          "table", "caption", "col", "colgroup", "tbody", "thead", "tfoot",
-          "tr", "td", "th", "template", "select", "frameset");
+          "address", "article", "aside", "blockquote", "center", "details",
+          "dialog", "dir", "div", "dl", "fieldset", "figcaption", "figure",
+          "footer", "header", "hgroup", "main", "menu", "nav", "ol", "p",
+          "search", "section", "summary", "ul");
+
+  private static final Set<String> IMPLIED_END_TAG_NAMES
+      = j8().setOf(
+          "dd", "dt", "li", "optgroup", "option", "p", "rb", "rp", "rt",
+          "rtc");
+
+  private static final Set<String> TABLE_STRUCTURE_START_TAG_NAMES
+      = j8().setOf(
+          "caption", "col", "colgroup", "tbody", "thead", "tfoot", "tr",
+          "td", "th");
+
+  /** Start tags the current HTML tree builder inserts and immediately pops. */
+  private static final Set<String> HTML_TREE_BUILDER_VOID_ELEMENT_NAMES
+      = j8().setOf(
+          "area", "base", "basefont", "bgsound", "br", "embed", "hr",
+          "img", "input", "keygen", "link", "meta", "param", "source",
+          "track", "wbr");
 
   /** Start tags that "in body" ignores or merges rather than inserting. */
   private static final Set<String> IGNORED_HTML_START_TAG_NAMES
-      = j8().setOf("html", "body", "head", "frame");
+      = j8().setOf(
+          "html", "body", "head", "frame", "caption", "col", "colgroup",
+          "tbody", "thead", "tfoot", "tr", "td", "th");
 
   private static final Set<String> MATHML_TEXT_INTEGRATION_POINT_NAMES
       = j8().setOf("mi", "mo", "mn", "ms", "mtext");

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -243,8 +243,11 @@ public final class HtmlSanitizer {
     private final List<OpenElement> openElements = new ArrayList<>();
 
     /**
-     * True once the bounded stack is exhausted.  The legacy HTML behavior is
-     * the conservative fallback for ordinary tags from that point onward.
+     * True once the browser's context can no longer be derived from the
+     * tracked elements: the bounded stack was exhausted, or a tag's effect
+     * depended on untracked ancestors or on the insertion mode.  The legacy
+     * HTML behavior is the conservative fallback for ordinary tags from that
+     * point onward.
      */
     private boolean unknown;
 
@@ -282,58 +285,103 @@ public final class HtmlSanitizer {
     void processEndTag(String elementName) {
       if (unknown || openElements.isEmpty()) { return; }
 
-      OpenElement current = currentElement();
-      if (current.namespace == Namespace.HTML) {
-        processHtmlEndTag(elementName);
+      if (currentElement().namespace == Namespace.HTML) {
+        processEndTagUnderHtmlRules(elementName);
         return;
       }
 
       if ("br".equals(elementName) || "p".equals(elementName)) {
         popToHtmlOrIntegrationPoint();
-        processHtmlEndTag(elementName);
+        processEndTagUnderHtmlRules(elementName);
         return;
       }
 
       // The foreign-content end-tag algorithm walks down from the current
       // node.  A foreign node with the tag name closes, along with every
       // node above it.  At the first HTML node the browser reprocesses the
-      // token under the HTML rules instead, where an HTML node with the tag
-      // name closes the same way, but a node in the special category, which
-      // among foreign elements means an integration point, ends the search
-      // and the token is ignored.
-      boolean htmlRules = false;
-      boolean sawIntegrationPoint = false;
+      // token under the rules of its current HTML insertion mode instead.
       for (int i = openElements.size(); --i >= 0;) {
         OpenElement open = openElements.get(i);
-        boolean isHtml = open.namespace == Namespace.HTML;
-        boolean isIntegrationPoint
-            = open.mathTextIntegrationPoint || open.htmlIntegrationPoint;
-        if (isHtml) {
-          htmlRules = true;
-        } else if (htmlRules && isIntegrationPoint) {
-          return;
-        }
-        if (isHtml == htmlRules
-            && asciiEqualsIgnoreCase(open.elementName, elementName)) {
+        if (open.namespace == Namespace.HTML) { break; }
+        if (asciiEqualsIgnoreCase(open.elementName, elementName)) {
           openElements.subList(i, openElements.size()).clear();
           return;
         }
-        sawIntegrationPoint |= isIntegrationPoint;
       }
-      // Nothing tracked matched, so the token now applies to the HTML
-      // elements below the first foreign root, which are not tracked.  No
-      // HTML element is named svg or math, and an integration point in
-      // between is special and stops the search, so the browser ignores the
-      // token in those cases.  Otherwise the named element may well be
-      // open below, in which case the browser closes it and every foreign
-      // element above it.  Assume that it is: the cost of guessing wrong is
-      // only that self-closing flags stop being honored in the rest of an
-      // svg or math element whose author wrote a stray end tag, which is
-      // how those tags were always processed before the flag was honored.
-      if (isForeignContentRoot(elementName) || sawIntegrationPoint) {
+      processEndTagUnderHtmlRules(elementName);
+    }
+
+    /**
+     * Applies an end tag that a browser processes under the rules of its
+     * current HTML insertion mode.  Only outcomes that follow from the
+     * tracked elements alone are modeled.  Anything that depends on the
+     * untracked ancestors of the foreign root, on the insertion mode, or on
+     * the list of active formatting elements makes the context unknown,
+     * which fails closed: self-closing flags are no longer honored.
+     */
+    private void processEndTagUnderHtmlRules(String elementName) {
+      if (TABLE_SCOPED_ELEMENT_NAMES.contains(elementName)
+          || "template".equals(elementName)) {
+        // Table scope is bounded only by html, table and template, so these
+        // end tags reach past integration points to untracked ancestors,
+        // and what they close depends on the insertion mode.
+        becomeUnknown();
         return;
       }
-      openElements.clear();
+      if (IGNORED_HTML_END_TAG_NAMES.contains(elementName)) {
+        return;
+      }
+      boolean anyOther = !SPECIFIC_END_TAG_RULE_NAMES.contains(elementName);
+      boolean formatting = FORMATTING_ELEMENT_NAMES.contains(elementName);
+      boolean heading = isHeadingName(elementName);
+      for (int i = openElements.size(); --i >= 0;) {
+        OpenElement open = openElements.get(i);
+        if (open.namespace != Namespace.HTML) {
+          // Integration points and annotation-xml are in the special
+          // category and bound every scope.  Other foreign elements are
+          // transparent to both kinds of search.
+          if (open.special) { return; }
+          continue;
+        }
+        String openName = open.elementName;
+        if (asciiEqualsIgnoreCase(openName, elementName)
+            || (heading && isHeadingName(openName))) {
+          if ("form".equals(elementName)) {
+            // </form> removes the form element without popping the
+            // elements above it.
+            openElements.remove(i);
+          } else {
+            openElements.subList(i, openElements.size()).clear();
+          }
+          return;
+        }
+        if (anyOther) {
+          // "Any other end tag" stops at any element in the special
+          // category.
+          if (SPECIAL_HTML_ELEMENT_NAMES.contains(openName)) { return; }
+          continue;
+        }
+        if (DEFAULT_SCOPE_BOUNDARY_NAMES.contains(openName)
+            || ("li".equals(elementName)
+                && ("ol".equals(openName) || "ul".equals(openName)))
+            || ("p".equals(elementName) && "button".equals(openName))) {
+          // Not in scope: the token is ignored, or for </p> an empty p is
+          // inserted and closed at once.
+          return;
+        }
+        if (formatting && SPECIAL_HTML_ELEMENT_NAMES.contains(openName)) {
+          // The adoption agency algorithm restructures the stack around
+          // this "furthest block", dropping the foreign nodes above it.
+          becomeUnknown();
+          return;
+        }
+      }
+      if (openElements.isEmpty() || "form".equals(elementName)) {
+        return;
+      }
+      // Nothing tracked bounded the search, so whether the token closes the
+      // whole foreign region depends on the untracked HTML ancestors.
+      becomeUnknown();
     }
 
     private boolean processHtmlStartTag(
@@ -344,9 +392,15 @@ public final class HtmlSanitizer {
       } else if ("math".equals(elementName)) {
         namespace = Namespace.MATHML;
       } else {
-        if (!openElements.isEmpty()
-            && !HtmlTextEscapingMode.isVoidElement(elementName)) {
-          push(new OpenElement(elementName, Namespace.HTML, attrs));
+        if (!openElements.isEmpty()) {
+          if (CONTEXT_CHANGING_START_TAG_NAMES.contains(elementName)) {
+            // Table structure, templates and selects change the insertion
+            // mode or pop the stack in ways that depend on untracked state.
+            becomeUnknown();
+          } else if (!HtmlTextEscapingMode.isVoidElement(elementName)
+                     && !IGNORED_HTML_START_TAG_NAMES.contains(elementName)) {
+            push(new OpenElement(elementName, Namespace.HTML, attrs));
+          }
         }
         // HTML ignores the self-closing flag on ordinary non-void elements.
         // Void elements are already empty and need no synthetic close event.
@@ -359,15 +413,9 @@ public final class HtmlSanitizer {
       return selfClosing;
     }
 
-    private void processHtmlEndTag(String elementName) {
-      for (int i = openElements.size(); --i >= 0;) {
-        OpenElement open = openElements.get(i);
-        if (open.namespace != Namespace.HTML) { return; }
-        if (asciiEqualsIgnoreCase(open.elementName, elementName)) {
-          openElements.subList(i, openElements.size()).clear();
-          return;
-        }
-      }
+    private void becomeUnknown() {
+      openElements.clear();
+      unknown = true;
     }
 
     private void popToHtmlOrIntegrationPoint() {
@@ -384,8 +432,7 @@ public final class HtmlSanitizer {
 
     private void push(OpenElement element) {
       if (openElements.size() == MAX_DEPTH) {
-        openElements.clear();
-        unknown = true;
+        becomeUnknown();
       } else {
         openElements.add(element);
       }
@@ -425,6 +472,8 @@ public final class HtmlSanitizer {
     final Namespace namespace;
     final boolean mathTextIntegrationPoint;
     final boolean htmlIntegrationPoint;
+    /** In the special category, which bounds every scope. */
+    final boolean special;
 
     OpenElement(
         String elementName, Namespace namespace, List<String> attrs) {
@@ -434,6 +483,9 @@ public final class HtmlSanitizer {
           && MATHML_TEXT_INTEGRATION_POINT_NAMES.contains(elementName);
       this.htmlIntegrationPoint = isHtmlIntegrationPoint(
           elementName, namespace, attrs);
+      this.special = mathTextIntegrationPoint || htmlIntegrationPoint
+          || (namespace == Namespace.MATHML
+              && "annotation-xml".equals(elementName));
     }
   }
 
@@ -485,6 +537,79 @@ public final class HtmlSanitizer {
     }
     return false;
   }
+
+
+  /** True for h1 through h6, any of which an h1 through h6 end tag closes. */
+  private static boolean isHeadingName(String canonElementName) {
+    if (canonElementName.length() != 2 || canonElementName.charAt(0) != 'h') {
+      return false;
+    }
+    char digit = canonElementName.charAt(1);
+    return digit >= '1' && digit <= '6';
+  }
+
+  /** End tags whose effect is decided by table scope or the insertion mode. */
+  private static final Set<String> TABLE_SCOPED_ELEMENT_NAMES
+      = j8().setOf(
+          "table", "caption", "tbody", "thead", "tfoot", "tr", "td", "th");
+
+  /** HTML end tags that never pop the stack. */
+  private static final Set<String> IGNORED_HTML_END_TAG_NAMES
+      = j8().setOf(
+          "svg", "math", "body", "html", "br", "col", "colgroup", "frame",
+          "head");
+
+  /**
+   * End tags with their own "in body" rules, which search a scope rather
+   * than stopping at the first element in the special category.
+   */
+  private static final Set<String> SPECIFIC_END_TAG_RULE_NAMES
+      = j8().setOf(
+          "address", "article", "aside", "blockquote", "button", "center",
+          "details", "dialog", "dir", "div", "dl", "fieldset", "figcaption",
+          "figure", "footer", "header", "hgroup", "listing", "main", "menu",
+          "nav", "ol", "pre", "search", "section", "summary", "ul", "form",
+          "p", "li", "dd", "dt", "h1", "h2", "h3", "h4", "h5", "h6",
+          "a", "b", "big", "code", "em", "font", "i", "nobr", "s", "small",
+          "strike", "strong", "tt", "u", "applet", "marquee", "object");
+
+  private static final Set<String> FORMATTING_ELEMENT_NAMES
+      = j8().setOf(
+          "a", "b", "big", "code", "em", "font", "i", "nobr", "s", "small",
+          "strike", "strong", "tt", "u");
+
+  /** The HTML elements that bound the default scope. */
+  private static final Set<String> DEFAULT_SCOPE_BOUNDARY_NAMES
+      = j8().setOf(
+          "applet", "caption", "html", "table", "td", "th", "marquee",
+          "object", "select", "template");
+
+  /** The HTML elements in the special category. */
+  private static final Set<String> SPECIAL_HTML_ELEMENT_NAMES
+      = j8().setOf(
+          "address", "applet", "area", "article", "aside", "base",
+          "basefont", "bgsound", "blockquote", "body", "br", "button",
+          "caption", "center", "col", "colgroup", "dd", "details", "dir",
+          "div", "dl", "dt", "embed", "fieldset", "figcaption", "figure",
+          "footer", "form", "frame", "frameset", "h1", "h2", "h3", "h4",
+          "h5", "h6", "head", "header", "hgroup", "hr", "html", "iframe",
+          "img", "input", "keygen", "li", "link", "listing", "main",
+          "marquee", "menu", "meta", "nav", "noembed", "noframes",
+          "noscript", "object", "ol", "p", "param", "plaintext", "pre",
+          "script", "search", "section", "select", "source", "style",
+          "summary", "table", "tbody", "td", "template", "textarea",
+          "tfoot", "th", "thead", "title", "tr", "track", "ul", "wbr",
+          "xmp");
+
+  /** Start tags inside foreign content whose effect depends on the mode. */
+  private static final Set<String> CONTEXT_CHANGING_START_TAG_NAMES
+      = j8().setOf(
+          "table", "caption", "col", "colgroup", "tbody", "thead", "tfoot",
+          "tr", "td", "th", "template", "select", "frameset");
+
+  /** Start tags that "in body" ignores or merges rather than inserting. */
+  private static final Set<String> IGNORED_HTML_START_TAG_NAMES
+      = j8().setOf("html", "body", "head", "frame");
 
   private static final Set<String> MATHML_TEXT_INTEGRATION_POINT_NAMES
       = j8().setOf("mi", "mo", "mn", "ms", "mtext");

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -258,8 +258,14 @@ public final class HtmlSanitizer {
     /** The HTML mode that remains in force while foreign rules run. */
     private HtmlInsertionMode htmlInsertionMode = HtmlInsertionMode.IN_BODY;
 
-    /** Whether an untracked table is known to be in table scope. */
-    private boolean untrackedTableInScope;
+    /** Bound the memory spent on untracked tables that never close. */
+    private static final int MAX_UNTRACKED_TABLES = 32;
+
+    /**
+     * The tables open below the tracked region, innermost last.  Each is in
+     * table scope, since a template makes the context unknown.
+     */
+    private final List<UntrackedTable> untrackedTables = new ArrayList<>();
 
     /**
      * True once the browser's context can no longer be derived from the
@@ -410,6 +416,10 @@ public final class HtmlSanitizer {
         if (anyOther) {
           // "Any other end tag" stops at any element in the special
           // category.
+          if (AMBIGUOUSLY_SPECIAL_HTML_ELEMENT_NAMES.contains(openName)) {
+            becomeUnknown();
+            return;
+          }
           if (SPECIAL_HTML_ELEMENT_NAMES.contains(openName)) { return; }
           continue;
         }
@@ -443,7 +453,7 @@ public final class HtmlSanitizer {
         // foster-parenting elements.  Keep the empty-table case exact and
         // fail closed for the rest.
         becomeUnknown();
-        return false;
+        return selfClosing && isForeignContentRoot(elementName);
       }
 
       Namespace namespace;
@@ -454,10 +464,7 @@ public final class HtmlSanitizer {
       } else {
         if (openElements.isEmpty()) {
           trackUntrackedHtmlStartTag(elementName);
-        }
-        if (htmlInsertionMode == HtmlInsertionMode.UNKNOWN) {
-          becomeUnknown();
-          return false;
+          if (unknown) { return false; }
         }
         if (UNMODELED_CONTEXT_CHANGING_START_TAG_NAMES.contains(elementName)) {
           becomeUnknown();
@@ -487,7 +494,8 @@ public final class HtmlSanitizer {
         if (P_CLOSING_START_TAG_NAMES.contains(elementName)
             || "pre".equals(elementName)
             || "listing".equals(elementName)
-            || "plaintext".equals(elementName)) {
+            || "plaintext".equals(elementName)
+            || "xmp".equals(elementName)) {
           if (!closePIfInButtonScope()) { return false; }
         } else if (isHeadingName(elementName)) {
           if (!closePIfInButtonScope()) { return false; }
@@ -571,7 +579,12 @@ public final class HtmlSanitizer {
             becomeUnknown();
             return false;
           }
-          if (!closePIfInButtonScope()) { return false; }
+          if (findHtmlElementInDefaultScope("p", true) >= 0) {
+            // Only a no-quirks document closes the p, and the sanitizer
+            // cannot know the mode of the document that embeds its output.
+            becomeUnknown();
+            return false;
+          }
           OpenElement table = new OpenElement(
               elementName, Namespace.HTML, attrs);
           push(table);
@@ -598,39 +611,82 @@ public final class HtmlSanitizer {
       return selfClosing;
     }
 
-    private void trackUntrackedHtmlStartTag(String elementName) {
-      if ("table".equals(elementName)) {
-        if (!untrackedTableInScope) {
-          untrackedTableInScope = true;
-          htmlInsertionMode = HtmlInsertionMode.IN_TABLE;
-        } else if (htmlInsertionMode == HtmlInsertionMode.IN_CELL) {
-          // This is a nested table; its eventual end tag needs a mode stack.
-          htmlInsertionMode = HtmlInsertionMode.UNKNOWN;
-        }
-        return;
-      }
-      if (!untrackedTableInScope) { return; }
-      if ("td".equals(elementName) || "th".equals(elementName)) {
+    private @Nullable UntrackedTable currentUntrackedTable() {
+      int size = untrackedTables.size();
+      return size != 0 ? untrackedTables.get(size - 1) : null;
+    }
+
+    /** Derives the HTML insertion mode from the innermost untracked table. */
+    private void syncInsertionMode() {
+      UntrackedTable table = currentUntrackedTable();
+      if (table == null) {
+        htmlInsertionMode = HtmlInsertionMode.IN_BODY;
+      } else if (table.cellName != null) {
+        // The cell and caption modes hand everything else to the in-body
+        // rules, but hand table structure to the table rules.
         htmlInsertionMode = HtmlInsertionMode.IN_CELL;
-      } else if ("caption".equals(elementName)) {
-        // Caption uses body rules for most tokens, but not for table-family
-        // starts, so keep the distinction conservative.
-        htmlInsertionMode = HtmlInsertionMode.UNKNOWN;
-      } else if (TABLE_STRUCTURE_START_TAG_NAMES.contains(elementName)) {
+      } else {
         htmlInsertionMode = HtmlInsertionMode.IN_TABLE;
       }
     }
 
-    private void trackUntrackedHtmlEndTag(String elementName) {
-      if (!untrackedTableInScope) { return; }
+    private void trackUntrackedHtmlStartTag(String elementName) {
+      UntrackedTable table = currentUntrackedTable();
       if ("table".equals(elementName)) {
-        if (htmlInsertionMode != HtmlInsertionMode.UNKNOWN) {
-          untrackedTableInScope = false;
-          htmlInsertionMode = HtmlInsertionMode.IN_BODY;
+        if (table != null && table.cellName == null) {
+          // The table modes pop the open table before reprocessing the
+          // token; a cell or caption nests the new table instead.
+          untrackedTables.remove(untrackedTables.size() - 1);
         }
-      } else if (TABLE_SCOPED_ELEMENT_NAMES.contains(elementName)) {
-        htmlInsertionMode = HtmlInsertionMode.IN_TABLE;
+        if (untrackedTables.size() == MAX_UNTRACKED_TABLES) {
+          becomeUnknown();
+          return;
+        }
+        untrackedTables.add(new UntrackedTable());
+      } else if (table == null) {
+        return;
+      } else if ("td".equals(elementName) || "th".equals(elementName)) {
+        table.cellName = elementName;
+        if (table.sectionName == null) { table.sectionName = "tbody"; }
+      } else if ("caption".equals(elementName)) {
+        table.cellName = elementName;
+        table.sectionName = null;
+      } else if ("tr".equals(elementName)) {
+        table.cellName = null;
+        if (table.sectionName == null) { table.sectionName = "tbody"; }
+      } else if ("tbody".equals(elementName) || "thead".equals(elementName)
+                 || "tfoot".equals(elementName)) {
+        table.cellName = null;
+        table.sectionName = elementName;
+      } else if ("col".equals(elementName) || "colgroup".equals(elementName)) {
+        table.cellName = null;
+        table.sectionName = null;
       }
+      syncInsertionMode();
+    }
+
+    private void trackUntrackedHtmlEndTag(String elementName) {
+      UntrackedTable table = currentUntrackedTable();
+      if (table == null) { return; }
+      if ("table".equals(elementName)) {
+        untrackedTables.remove(untrackedTables.size() - 1);
+      } else if ("td".equals(elementName) || "th".equals(elementName)
+                 || "caption".equals(elementName)) {
+        // Ignored unless it names the open cell or caption.
+        if (elementName.equals(table.cellName)) { table.cellName = null; }
+      } else if ("tr".equals(elementName)) {
+        // A caption ignores it; a cell closes along with the row.
+        if (!"caption".equals(table.cellName)) { table.cellName = null; }
+      } else if ("tbody".equals(elementName) || "thead".equals(elementName)
+                 || "tfoot".equals(elementName)) {
+        // A caption ignores it, and so does a cell in another section.
+        if (!"caption".equals(table.cellName)
+            && elementName.equals(table.sectionName)) {
+          table.cellName = null;
+          table.sectionName = null;
+        }
+      }
+      syncInsertionMode();
     }
 
     private void processFormStartTag(List<String> attrs) {
@@ -660,6 +716,12 @@ public final class HtmlSanitizer {
                 : "dd".equals(open.elementName)
                     || "dt".equals(open.elementName))) {
           return popTrackedElementsFrom(i, false, null);
+        }
+        if (open.namespace == Namespace.HTML
+            && AMBIGUOUSLY_SPECIAL_HTML_ELEMENT_NAMES.contains(
+                open.elementName)) {
+          becomeUnknown();
+          return false;
         }
         if (isSpecial(open)
             && !isHtmlElement(open, "address")
@@ -760,9 +822,9 @@ public final class HtmlSanitizer {
 
     private static boolean hasHiddenInputType(List<String> attrs) {
       for (int i = 0; i + 1 < attrs.size(); i += 2) {
-        if ("type".equals(attrs.get(i))
-            && asciiEqualsIgnoreCase("hidden", attrs.get(i + 1))) {
-          return true;
+        if ("type".equals(attrs.get(i))) {
+          // The tokenizer drops all but the first of duplicate attributes.
+          return asciiEqualsIgnoreCase("hidden", attrs.get(i + 1));
         }
       }
       return false;
@@ -773,7 +835,7 @@ public final class HtmlSanitizer {
       formElementPointerSet = false;
       trackedFormElement = null;
       simpleTable = null;
-      untrackedTableInScope = false;
+      untrackedTables.clear();
       unknown = true;
     }
 
@@ -823,7 +885,6 @@ public final class HtmlSanitizer {
     IN_BODY,
     IN_TABLE,
     IN_CELL,
-    UNKNOWN,
   }
 
   private enum Namespace {
@@ -853,6 +914,14 @@ public final class HtmlSanitizer {
           || (namespace == Namespace.MATHML
               && "annotation-xml".equals(elementName));
     }
+  }
+
+  /** A table open below the tracked region, and the part of it being filled. */
+  private static final class UntrackedTable {
+    /** td, th or caption while one is open. */
+    @Nullable String cellName;
+    /** tbody, thead or tfoot while one is open. */
+    @Nullable String sectionName;
   }
 
   private static boolean isForeignContentRoot(String canonElementName) {
@@ -971,6 +1040,13 @@ public final class HtmlSanitizer {
           "summary", "table", "tbody", "td", "template", "textarea",
           "tfoot", "th", "thead", "title", "tr", "track", "ul", "wbr",
           "xmp");
+
+  /**
+   * Elements the specification puts in the special category but current
+   * Chrome does not, so a walk that reaches one has an uncertain outcome.
+   */
+  private static final Set<String> AMBIGUOUSLY_SPECIAL_HTML_ELEMENT_NAMES
+      = j8().setOf("search");
 
   /** Start tags whose HTML stack effect this bounded tracker cannot derive. */
   private static final Set<String> UNMODELED_CONTEXT_CHANGING_START_TAG_NAMES

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1382,6 +1382,178 @@ class HtmlSanitizerTest {
         p.sanitize("<svg><g></foo></g></svg><svg/>x"));
   }
 
+  /**
+   * Issue #461.  More start-tag rules that change the tracked stack, and
+   * those whose outcome the sanitizer cannot know.
+   */
+  @Test
+  void testMoreHtmlStartTagRulesInForeignContentContext() {
+    PolicyFactory p = foreignContentPolicy();
+    // xmp closes a p in button scope, as pre and listing do.
+    assertEquals(
+        "<svg><foreignObject><p></p><math></math></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><p><xmp></xmp><math></svg><object/>hidden"));
+    assertEquals(
+        "<svg><foreignObject><p></p></foreignObject></svg>"
+        + "<svg><path></path></svg>",
+        p.sanitize(
+            "<svg><foreignObject><p><xmp></xmp></foreignObject></svg>"
+            + "<svg><path/></p></foreignObject><object/>hidden"));
+    // Whether a table start closes an open p depends on the quirks mode of
+    // the document that embeds the output, so the context fails closed.
+    assertEquals(
+        "<svg><foreignObject><p></p></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><p><table></table></foreignObject>"
+            + "<object/>hidden"));
+    // The tokenizer keeps only the first of duplicate attributes, so this
+    // input is not hidden: in table mode it still pops the open select.
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>",
+        p.sanitize(
+            "<table><svg><foreignObject><select><input type=text type=hidden>"
+            + "</foreignObject></svg></select></foreignObject>"
+            + "<object/>hidden"));
+    // A table inside a cell's foreign content is tracked exactly and hands
+    // the cell's in-body rules back when it closes.
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>",
+        p.sanitize(
+            "<table><tr><td><svg><foreignObject><table></table>"
+            + "<object/>hidden"));
+    // A self-closing root closes itself even where the tracker gives up.
+    assertEquals(
+        "<svg><foreignObject><svg></svg>x</foreignObject></svg>",
+        p.sanitize("<svg><foreignObject><table><svg/>x"));
+  }
+
+  /**
+   * Issue #461.  The specification puts search in the special category but
+   * Chrome does not, so an end-tag or list-item walk that reaches one has
+   * no single right answer, and the context fails closed.
+   */
+  @Test
+  void testSearchElementCategoryIsNotReliedOn() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<svg><foreignObject><cite></cite></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><cite><search><span></cite></foreignObject>"
+            + "</svg></span></search></cite></foreignObject><object/>hidden"));
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><li><search><li></li></foreignObject></svg>"
+            + "</search></li></foreignObject><object/>hidden"));
+  }
+
+  /**
+   * Issue #461.  The insertion mode inherited from an untracked table
+   * depends on which cell, caption or section is open, and browsers ignore
+   * the end tags that name something else.
+   */
+  @Test
+  void testUntrackedTableEndTagsMustNameTheOpenPart() {
+    PolicyFactory p = foreignContentPolicy();
+    String svgForm
+        = "<svg><foreignObject><form></foreignObject><object/>hidden";
+    // Inside a cell or caption the in-body rules insert the form, which
+    // stays open and keeps the object's fallback text hidden.
+    String hidden = "<svg><foreignObject><form></form></foreignObject></svg>";
+    for (String context : new String[] {
+             "<table><tr><th></td>", "<table><tr><td></th>",
+             "<table><thead><tr><td></tbody>", "<table><tr><td></tfoot>",
+             "<table><tr><td></caption>", "<table><caption></tr>",
+             "<table><caption></tbody>", "<table><caption></td>",
+             "<table><caption>", "<table><tr><td><table></table>",
+             "<table><tr><td><table><tr><td></table>",
+             "<table><tr><td><table><tr><td></td></tr></table>" }) {
+      assertEquals(hidden, p.sanitize(context + svgForm), context);
+    }
+    // Back in the table modes the form is inserted and popped at once, so
+    // the foreignObject closes and the object is foreign.
+    String shown
+        = "<svg><foreignObject><form></form></foreignObject>hidden</svg>";
+    for (String context : new String[] {
+             "<table><tr><td></td>", "<table><tr><td></tr>",
+             "<table><thead><tr><td></thead>", "<table><caption></caption>",
+             "<table><tr><td><table></table></td>",
+             "<table><tr><td><table><tr><td></td></tr></table></td>" }) {
+      assertEquals(shown, p.sanitize(context + svgForm), context);
+    }
+    // Table structure inside a caption closes the caption and everything
+    // above it, which the tracker does not follow.
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>",
+        p.sanitize(
+            "<table><caption><svg><foreignObject><td></foreignObject>"
+            + "<object/>hidden"));
+  }
+
+  /** Well-formed nested tables and captions do not poison later SVG. */
+  @Test
+  void testForeignContentContextRecoversAfterNestedTables() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "x<svg><path></path><rect></rect></svg>",
+        p.sanitize(
+            "<table><tr><td><table><tr><td>x</td></tr></table></td></tr>"
+            + "</table><svg><path/><rect/></svg>"));
+    assertEquals(
+        "x<svg><path></path><rect></rect></svg>",
+        p.sanitize(
+            "<table><caption>x</caption></table><svg><path/><rect/></svg>"));
+    assertEquals(
+        "<svg><path></path><rect></rect></svg>",
+        p.sanitize(
+            "<table><caption><table></table></caption></table>"
+            + "<svg><path/><rect/></svg>"));
+  }
+
+  /**
+   * Issue #461.  The modeled transitions are followed exactly rather than
+   * by failing closed: a self-closing tag is still honored in later SVG.
+   */
+  @Test
+  void testModeledTransitionsKeepHonoringSelfClosingTags() {
+    PolicyFactory p = foreignContentPolicy();
+    String[] inputs = {
+        "<svg><foreignObject><p><div></div><math></svg><svg><path/>x",
+        "<svg><foreignObject><h2><h1></h1><math></svg><svg><path/>x",
+        "<svg><foreignObject><button><div><button></button></div><math>"
+        + "</svg><svg><path/>x",
+        "<svg><foreignObject><form><div><form></form></div><math></svg>"
+        + "<svg><path/>x",
+        "<svg><foreignObject><li><div><li></li></div><math></svg>"
+        + "<svg><path/>x",
+        "<svg><foreignObject><dd><div><dt></dt></div><math></svg>"
+        + "<svg><path/>x",
+        "<svg><foreignObject><option><option></option><math></svg>"
+        + "<svg><path/>x",
+        "<svg><foreignObject><select><input><math></svg><svg><path/>x",
+        "<svg><foreignObject><p><hr><math></svg><svg><path/>x",
+        "<svg><foreignObject><p><xmp></xmp><math></svg><svg><path/>x",
+        "<svg><foreignObject><image><math></svg><svg><path/>x",
+        "<svg><foreignObject><form><option></form><image><math></svg>"
+        + "<svg><path/>x",
+        "<svg><foreignObject><h2><svg></h1><svg><path/>x",
+        "<svg><foreignObject><form><cite></form></foreignObject>"
+        + "<svg><path/>x",
+        "<svg><foreignObject><cite><div></cite></foreignObject>"
+        + "<svg><path/>x",
+        "<table><svg><foreignObject><form><math></svg><svg><path/>x",
+        "<table><tr><th></td><svg><foreignObject><form></foreignObject>"
+        + "</svg><svg><path/>x",
+        "<table><tr><td><table><tr><td>x</td></tr></table></td></tr></table>"
+        + "<svg><foreignObject><form></foreignObject></svg><svg><path/>x",
+    };
+    for (String input : inputs) {
+      String output = p.sanitize(input);
+      assertTrue(output.contains("<path></path>x"), input + " -> " + output);
+    }
+  }
+
   /** The bounded context tracker falls back to suppressing dropped content. */
   @Test
   void testDeepForeignContentContextFailsClosed() {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1449,6 +1449,37 @@ class HtmlSanitizerTest {
   }
 
   /**
+   * Issue #461.  Like {@code search}, {@code dialog} is in the special
+   * category of the WHATWG parsing algorithm but not in Chrome's special-node
+   * set, so a walk that reaches an open {@code dialog} has no single right
+   * answer across browsers and the context must fail closed.  Without this a
+   * following {@code <object/>} was honored as self-closing, exposing text
+   * that a spec-compliant parser keeps inside the HTML {@code object}.
+   */
+  @Test
+  void testDialogElementCategoryIsNotReliedOn() {
+    PolicyFactory p = foreignContentPolicy();
+    // "Any other end tag" (</cite>) walks past the open dialog.
+    assertEquals(
+        "<svg><foreignObject><cite></cite></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><cite><dialog></cite></foreignObject>"
+            + "<object/>hidden"));
+    // A list-item start (<li>) walks past the open dialog.
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><li><dialog><li></li></foreignObject>"
+            + "<object/>hidden"));
+    // The adoption agency's furthest-block search (</b>) reaches the dialog.
+    assertEquals(
+        "<svg><foreignObject><b><svg></svg></b></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><b><dialog><svg></b></foreignObject>"
+            + "<object/>hidden"));
+  }
+
+  /**
    * Issue #461.  The insertion mode inherited from an untracked table
    * depends on which cell, caption or section is open, and browsers ignore
    * the end tags that name something else.

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -972,9 +972,9 @@ class HtmlSanitizerTest {
 
   /**
    * Issue #457.  An end tag that names none of the open foreign elements
-   * may close an HTML ancestor of the foreign root, which is not tracked,
-   * so the parser is assumed to be back in HTML content unless the browser
-   * would ignore the tag.
+   * may close an HTML ancestor of the foreign root, which is not tracked.
+   * The context is then unknown and the sanitizer falls back to the HTML
+   * rules, unless the browser would ignore the tag.
    */
   @Test
   void testEndTagsOfHtmlAncestorsEndForeignContent() {
@@ -1134,6 +1134,154 @@ class HtmlSanitizerTest {
         events);
   }
 
+  /**
+   * Issue #461.  Browsers process the end tags of table structure with
+   * table scope, which no integration point bounds, so they close the
+   * foreign content around a cell along with the cell.  The tracker cannot
+   * see the table, so it fails closed for the rest of the input.
+   */
+  @Test
+  void testTableScopeEndTagsEndForeignContent() {
+    PolicyFactory p = foreignContentPolicy();
+    for (String endTag
+         : new String[] { "</table>", "</tbody>", "</tr>", "</td>" }) {
+      assertEquals(
+          "<svg><foreignObject><svg></svg></foreignObject></svg>",
+          p.sanitize(
+              "<table><tbody><tr><td><svg><foreignObject><svg>" + endTag
+              + "<object/>hidden"),
+          endTag);
+    }
+    assertEquals(
+        "<svg><foreignObject><svg></svg></foreignObject></svg>",
+        p.sanitize(
+            "<table><caption><svg><foreignObject><svg></caption>"
+            + "<object/>hidden"));
+    assertEquals(
+        "<svg><desc><svg></svg></desc></svg>",
+        p.sanitize("<table><tr><td><svg><desc><svg></table><object/>hidden"));
+    assertEquals(
+        "<math><mi><svg></svg></mi></math>",
+        p.sanitize("<table><tr><td><math><mi><svg></table><object/>hidden"));
+    assertEquals(
+        "<math><annotation-xml encoding=\"text/html\"><svg></svg>"
+        + "</annotation-xml></math>",
+        p.sanitize(
+            "<table><tr><td><math><annotation-xml encoding=text/html><svg>"
+            + "</table><object/>hidden"));
+    // The context stays unknown, so a later self-closing tag is not honored
+    // either.
+    assertEquals(
+        "<svg><foreignObject><svg></svg></foreignObject></svg>"
+        + "<svg><path>x</path></svg>",
+        p.sanitize(
+            "<table><tr><td><svg><foreignObject><svg></table><svg><path/>x"));
+    // Table structure inside an integration point implies elements the
+    // tracker does not see, so it fails closed at the start tag.
+    assertEquals(
+        "<svg><foreignObject><svg></svg></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><table><tr><td><svg></tbody>"
+            + "<object/>hidden"));
+    assertEquals(
+        "<svg><foreignObject><svg></svg></foreignObject></svg>",
+        p.sanitize("<svg><foreignObject><select><svg><object/>hidden"));
+    // An end tag searched in the default or list-item scope stops at the
+    // integration point, so a browser ignores it and the dropped element
+    // still closes itself in foreign content.
+    assertEquals(
+        "<svg><foreignObject><svg></svg></foreignObject></svg>shown",
+        p.sanitize(
+            "<ul><li><svg><foreignObject><svg></li><object/>shown"));
+  }
+
+  /**
+   * Issue #461.  Under the HTML rules an end tag search stops at an element
+   * in the special category, so the elements above it stay open, and the
+   * end tag of the integration point holding them is ignored while they do.
+   */
+  @Test
+  void testSpecialElementsBlockHtmlEndTagsInForeignContent() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<svg><foreignObject><cite><div></div></cite></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><cite><div></cite></foreignObject>"
+            + "<object/>hidden"));
+    assertEquals(
+        "<math><mi><cite><div></div></cite></mi></math>",
+        p.sanitize("<math><mi><cite><div></cite></mi><object/>hidden"));
+    // A td start tag is ignored in body, but the div it seems to hold is
+    // still special.
+    assertEquals(
+        "<svg><foreignObject><div></div></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><td><div></td></foreignObject>"
+            + "<object/>hidden"));
+    // Without a special element in the way the end tags match, the
+    // integration point closes, and the flag is honored again.
+    assertEquals(
+        "<svg><foreignObject><cite><kbd></kbd></cite></foreignObject>"
+        + "<path></path>x</svg>",
+        p.sanitize(
+            "<svg><foreignObject><cite><kbd></cite></foreignObject>"
+            + "<path/>x"));
+    // Any h1 through h6 end tag closes an open heading.
+    assertEquals(
+        "<svg><foreignObject><h2><svg></svg></h2></foreignObject></svg>",
+        p.sanitize("<svg><foreignObject><h2><svg></h1><object/>hidden"));
+    // </form> removes the form without closing what it holds.
+    assertEquals(
+        "<svg><foreignObject><form><cite></cite></form></foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><form><cite></form></foreignObject>"
+            + "<object/>hidden"));
+    assertEquals(
+        "<svg><foreignObject><form><svg></svg></form>shown</foreignObject>"
+        + "</svg>",
+        p.sanitize(
+            "<svg><foreignObject><form><svg></form><object/>shown"));
+    // The adoption agency algorithm rebuilds the stack around a special
+    // element and drops the foreign nodes above it.
+    assertEquals(
+        "<svg><foreignObject><b><div><svg></svg></div></b></foreignObject>"
+        + "</svg>",
+        p.sanitize(
+            "<svg><foreignObject><b><div><svg></b></foreignObject>"
+            + "<object/>hidden"));
+    // When a special element blocks the end tag, the foreign element above
+    // it is still the current node, where the flag is honored.
+    assertEquals(
+        "<svg><foreignObject><cite><div><svg></svg></div></cite>shown"
+        + "</foreignObject></svg>",
+        p.sanitize(
+            "<svg><foreignObject><cite><div><svg></cite><object/>shown"));
+  }
+
+  /**
+   * Issue #461.  After a stray end tag the tracker cannot tell whether the
+   * browser left the foreign content, and the next svg start tag inside
+   * MathML is a MathML element whose foreignObject is not an integration
+   * point, so the tracker stays unknown rather than starting over.
+   */
+  @Test
+  void testStrayEndTagLeavesForeignContentContextUnknown() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<math><mrow><svg><foreignObject><div></div></foreignObject></svg>"
+        + "</mrow></math>",
+        p.sanitize(
+            "<math><mrow></foo><svg><foreignObject><div></div>"
+            + "</foreignObject><object/>hidden"));
+    assertEquals(
+        "<svg><g></g></svg><svg><path>x</path></svg>",
+        p.sanitize("<svg><g></foo></g></svg><svg><path/>x</svg>"));
+    // A self-closing root is still empty in every context.
+    assertEquals(
+        "<svg><g></g></svg><svg></svg>x",
+        p.sanitize("<svg><g></foo></g></svg><svg/>x"));
+  }
+
   /** The bounded context tracker falls back to suppressing dropped content. */
   @Test
   void testDeepForeignContentContextFailsClosed() {
@@ -1150,7 +1298,8 @@ class HtmlSanitizerTest {
         .allowElements(
             "svg", "math", "path", "g", "rect", "clipPath", "foreignObject",
             "desc", "annotation-xml", "textArea", "textarea", "mi", "mrow",
-            "mglyph", "a", "div", "p", "font", "br", "style", "title")
+            "mglyph", "a", "div", "p", "font", "br", "style", "title",
+            "cite", "kbd", "b", "h2", "form")
         .allowAttributes("width", "height", "viewBox").onElements("svg")
         .allowAttributes("id", "opacity", "d").onElements("path")
         .allowAttributes("href").onElements("a")

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1136,9 +1136,8 @@ class HtmlSanitizerTest {
 
   /**
    * Issue #461.  Browsers process the end tags of table structure with
-   * table scope, which no integration point bounds, so they close the
-   * foreign content around a cell along with the cell.  The tracker cannot
-   * see the table, so it fails closed for the rest of the input.
+   * table scope, which no integration point bounds, so they can close the
+   * foreign content around a cell along with the cell.
    */
   @Test
   void testTableScopeEndTagsEndForeignContent() {
@@ -1169,22 +1168,22 @@ class HtmlSanitizerTest {
         p.sanitize(
             "<table><tr><td><math><annotation-xml encoding=text/html><svg>"
             + "</table><object/>hidden"));
-    // The context stays unknown, so a later self-closing tag is not honored
-    // either.
+    // This table began below the tracked foreign root, so the context stays
+    // unknown after the end tag.
     assertEquals(
         "<svg><foreignObject><svg></svg></foreignObject></svg>"
         + "<svg><path>x</path></svg>",
         p.sanitize(
             "<table><tr><td><svg><foreignObject><svg></table><svg><path/>x"));
-    // Table structure inside an integration point implies elements the
-    // tracker does not see, so it fails closed at the start tag.
+    // Table structure inside an integration point follows the inherited
+    // table insertion mode, including implied elements and cell closing.
     assertEquals(
         "<svg><foreignObject><svg></svg></foreignObject></svg>",
         p.sanitize(
             "<svg><foreignObject><table><tr><td><svg></tbody>"
             + "<object/>hidden"));
     assertEquals(
-        "<svg><foreignObject><svg></svg></foreignObject></svg>",
+        "<svg><foreignObject><svg>hidden</svg></foreignObject></svg>",
         p.sanitize("<svg><foreignObject><select><svg><object/>hidden"));
     // An end tag searched in the default or list-item scope stops at the
     // integration point, so a browser ignores it and the dropped element
@@ -1193,6 +1192,107 @@ class HtmlSanitizerTest {
         "<svg><foreignObject><svg></svg></foreignObject></svg>shown",
         p.sanitize(
             "<ul><li><svg><foreignObject><svg></li><object/>shown"));
+  }
+
+  /** Issue #461.  HTML start-tag rules can remove tracked stack entries. */
+  @Test
+  void testHtmlStartTagsUpdateForeignContentContext() {
+    PolicyFactory p = foreignContentPolicy();
+    String[] inputs = {
+        // image is rewritten to the void img element.
+        "<svg><foreignObject><image><math></svg><object/>hidden",
+        // command and isindex are ordinary elements in the current parser,
+        // despite legacy serialization tables classifying them as void.
+        "<svg><foreignObject><command><math></math></foreignObject>"
+        + "<object/>hidden",
+        "<svg><foreignObject><isindex><math></math></foreignObject>"
+        + "<object/>hidden",
+        // A block start closes p in button scope.
+        "<svg><foreignObject><p><div></div><math></svg><object/>hidden",
+        "<svg><foreignObject><p><hr><math></svg><object/>hidden",
+        // A heading start pops a heading current node.
+        "<svg><foreignObject><h2><h1></h1><math></svg><object/>hidden",
+        // A second button pops the first button and everything above it.
+        "<svg><foreignObject><button><div><button></button></div>"
+        + "<math></svg><object/>hidden",
+        // Duplicate formatting elements invoke the adoption agency rules.
+        "<svg><foreignObject><a><div><a></a></div><math></svg>"
+        + "<object/>hidden",
+        "<svg><foreignObject><nobr><div><nobr></nobr></div><math></svg>"
+        + "<object/>hidden",
+        // A non-formatting end tag can strand b in the active formatting
+        // list, from which a later start tag reconstructs it.
+        "<svg><foreignObject><div><b></div><math></math>"
+        + "</foreignObject><object/>hidden",
+        // An adoption-agency end tag removes only its own formatting entry;
+        // other formatting elements it pops can still be reconstructed.
+        "<svg><foreignObject><b><i></b><math></math></foreignObject>"
+        + "<object/>hidden",
+        // A duplicate form is ignored while the form pointer is non-null.
+        "<svg><foreignObject><form><div><form></form></div><math></svg>"
+        + "<object/>hidden",
+        // A form start closes p before inserting the form.
+        "<svg><foreignObject><p><form></form><math></svg><object/>hidden",
+        // A form end generates implied end tags before removing the form.
+        "<svg><foreignObject><form><option></form><image><math></svg>"
+        + "<object/>hidden",
+        // New list and description items close an earlier item.
+        "<svg><foreignObject><li><div><li></li></div><math></svg>"
+        + "<object/>hidden",
+        "<svg><foreignObject><dd><div><dt></dt></div><math></svg>"
+        + "<object/>hidden",
+        // A second option closes the current option even without a select.
+        "<svg><foreignObject><option><option></option><math></svg>"
+        + "<object/>hidden",
+        // input pops a select that is in scope under the current rules.
+        "<svg><foreignObject><select><input><math></svg><object/>hidden",
+        // In table mode a form is inserted and immediately popped.
+        "<table><svg><foreignObject><form><math></svg><object/>hidden",
+    };
+    for (String input : inputs) {
+      String output = p.sanitize(input);
+      assertFalse(output.contains("hidden"), input + " -> " + output);
+    }
+    // bgsound is still inserted and immediately popped by the tree builder,
+    // even though it is absent from the sanitizer's legacy void table.
+    assertEquals(
+        "<svg><foreignObject><math></math></foreignObject>hidden</svg>",
+        p.sanitize(
+            "<svg><foreignObject><bgsound><math></math></foreignObject>"
+            + "<object/>hidden"));
+  }
+
+  /** Issue #461.  {@code </form>} has a different effect in a template. */
+  @Test
+  void testFormEndTagInTemplatePopsThroughForm() {
+    assertEquals(
+        "<form><svg></svg></form>",
+        foreignContentPolicy().sanitize(
+            "<body><template><form><svg></form><object/>hidden"));
+  }
+
+  /** Well-formed HTML islands do not poison later foreign-content tracking. */
+  @Test
+  void testForeignContentContextRecoversAfterHtmlIsland() {
+    PolicyFactory p = foreignContentPolicy();
+    assertEquals(
+        "<svg><path></path><rect></rect></svg>"
+        + "<svg><path></path></svg>",
+        p.sanitize(
+            "<table><tr><td><svg><path/><rect/></svg></td></tr></table>"
+            + "<svg><path/></svg>"));
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>"
+        + "<svg><path></path><rect></rect></svg>",
+        p.sanitize(
+            "<svg><foreignObject><table></table></foreignObject></svg>"
+            + "<svg><path/><rect/></svg>"));
+    assertEquals(
+        "<svg><foreignObject></foreignObject></svg>"
+        + "<svg><title></title><path></path></svg><p>after</p>",
+        p.sanitize(
+            "<svg><foreignObject><select></select></foreignObject></svg>"
+            + "<svg><title/><path/></svg><p>after</p>"));
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #461.

The bounded foreign-content context tracker now models the HTML tree-builder transitions that can change whether a self-closing flag is honored inside SVG or MathML. It follows the current in-body rules for p, headings, list items, buttons, forms, formatting elements, select/option/optgroup, `image`, and current tree-builder void elements. It also tracks the form pointer and the inherited in-body, in-table, or in-cell mode across a foreign root.

When the correct result still depends on state outside the bounded tracker—table/template state, a complex table transition, or reconstructing the active formatting list—the tracker enters its sticky fail-closed state. In that state only self-closing `<svg/>` and `<math/>` roots close themselves.

The element sets now match the current WHATWG rules: `select` is both a default-scope boundary and a specifically handled end tag, but its start tag no longer changes the insertion mode. The tracker also uses a tree-builder-specific immediate-pop set, since Chrome treats `command` and `isindex` as ordinary HTML elements while still immediately popping `bgsound`.

Known, well-formed transitions recover precisely: a foreign root in a table cell, a completed `select` island, and an empty `table` island do not poison later SVG self-closing tags.

No shipped release contains the affected context-tracker code.

## Chrome oracle cases

Each hostile transition is followed by `<object/>hidden`. An uppercase HTML `OBJECT` owning `hidden` means Chrome is in HTML content and the sanitizer must suppress that fallback text.

Representative cases fixed here:

```html
<body><template><form><svg></form><object/>hidden
<!-- template contents: FORM > svg, then OBJECT > #text "hidden" -->

<svg><foreignObject><image><math></svg><object/>hidden
<!-- BODY: svg > foreignObject > (IMG, math), then OBJECT > #text "hidden" -->

<svg><foreignObject><div><b></div><math></math></foreignObject><object/>hidden
<!-- foreignObject: DIV > B, then reconstructed B > (math, OBJECT > "hidden") -->

<svg><foreignObject><b><i></b><math></math></foreignObject><object/>hidden
<!-- foreignObject: B > I, then reconstructed I > (math, OBJECT > "hidden") -->

<svg><foreignObject><command><math></math></foreignObject><object/>hidden
<!-- foreignObject: COMMAND > (math, OBJECT > "hidden") -->
```

The current-select behavior is intentionally different:

```html
<svg><foreignObject><select><svg><object/>hidden
<!-- SELECT > svg > object, with "hidden" in foreign content -->
```

## Test plan

- Added hostile regressions for table-scope and close-cell transitions, templates, form-pointer behavior, adoption-agency and active-formatting reconstruction, p/list/heading/button stack changes, `image`, select/option rules, and current parser element categories.
- Added positive fidelity regressions for completed select/empty-table islands and SVG in a table cell.
- Cross-checked the directed cases against current Chrome and the current WHATWG parsing algorithm.
- Ran 200,000 deterministic differential cases against the prior PR head: 8,183 newly suppressed mismatches and zero cases where the branch exposed text that the parser kept inside an HTML object.
- `./mvnw clean verify` passes on JDK 11, 17, 21, and 25 (490 reactor tests per run, including fuzzers and the JPMS consumer check).

## Review follow-up (f9819fa)

An independent review against the current WHATWG tree-construction rules and Chrome 152 found five cases where the tracker stayed in foreign content while Chrome was in HTML content, plus one avoidable fidelity loss. Each was reproduced with `<object/>hidden` as the oracle and is fixed with a regression test:

- `<xmp>` now closes an open `p`, like `pre` and `listing`: `<svg><foreignObject><p><xmp></xmp><math></svg><object/>hidden`
- `<table>` after an open `p` fails closed, since only a no-quirks document closes the `p` and the embedding document's mode is unknown: `<svg><foreignObject><p><table></table></foreignObject><object/>hidden`
- Only the first of duplicate `type` attributes decides whether an `input` is hidden, as the tokenizer drops the later ones: `<table><svg><foreignObject><select><input type=text type=hidden></foreignObject></svg></select></foreignObject><object/>hidden`
- Untracked cell, caption and section end tags must name the open part; `</td>` inside a `th`, `</tbody>` under `thead`, or `</caption>` inside a cell is ignored as browsers ignore it: `<table><tr><th></td><svg><foreignObject><form></foreignObject><object/>hidden`
- `search` is in the specification's special category but not in Chrome's, so an end-tag or list-item walk that reaches one fails closed: `<svg><foreignObject><cite><search><span></cite></foreignObject></svg></span></search></cite></foreignObject><object/>hidden`
- Nested tables and captions are followed with a bounded stack instead of making the context permanently unknown, so `<table><tr><td><table><tr><td>x</td></tr></table></td></tr></table><svg><path/><rect/></svg>` keeps its self-closing tags.

A positive test also checks that each modeled transition still honors a later `<path/>`, so the transitions are tracked rather than failed closed. Cross-checked with 438 element-category probes and about 78,000 random differential cases in Chrome 152, in quirks and no-quirks mode: zero cases where the branch exposes text that Chrome keeps inside an HTML object. `./mvnw clean verify` passes on JDK 21 (495 reactor tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RajvH16nNkgw9TJS6nEpTT
