### PR TITLE
fix: Report Attributes Rejected From an Emptied Element, Their Values, and Dropped Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ String sanitizedHtml = myPolicyFactory.sanitize(
     myContext);
 ```
 
+`discardedAttributes` also fires for attributes rejected from an element that
+was then dropped for having none left, such as a link whose only `href` was
+rejected.  Two default methods carry more detail for listeners that override
+them: `discardedAttribute` receives each rejected attribute's value, and
+`discardedText` receives content the renderer could not emit from a kept
+`script` or `style` element.
+
 **Note**: If a string sanitizes with no change notifications, it is not the case
 that the input string is necessarily safe to use. Only use the output of the sanitizer.
 

--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,26 @@
 
 Most recent at top.
   * Next release
+    * `HtmlChangeListener.discardedAttributes` now also reports the
+      attributes rejected from an element the policy allowed when that
+      rejection is what left the element attribute-less and so skipped, as
+      `a`, `font`, `img`, `input` and `span` are by default.  The listener
+      used to hear only that the element was discarded, so a rejected
+      `javascript:` `href` on a link reached an intrusion detection system as
+      a dropped `a` and nothing more.  Attributes on an element the policy
+      does not allow are still covered by `discardedTag` alone.  Issue #447.
+    * `HtmlChangeListener.discardedAttribute`, a new default method, follows
+      each `discardedAttributes` report with one call per dropped attribute
+      carrying the value it had in the input, so a listener can see the URL
+      or handler that was rejected.  Listeners that do not override it are
+      unaffected.  Issue #243.
+    * `HtmlChangeListener.discardedText`, a new default method, reports the
+      content of a kept `script` or `style` element that the renderer dropped
+      because it could not be emitted safely, such as a `-->` with no comment
+      open.  Such drops were invisible to the listener.  The report comes
+      from `HtmlStreamRenderer`, which `PolicyFactory.sanitize` uses; a
+      sanitizer built with `PolicyFactory.apply` on another receiver reports
+      tags and attributes only.  Issue #155.
     * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
       relative-only URL policy.  It allows URLs with neither a protocol nor
       an authority, but rejects absolute URLs and protocol-relative URLs such

--- a/java8-shim/src/main/java/org/owasp/shim/Java8Shim.java
+++ b/java8-shim/src/main/java/org/owasp/shim/Java8Shim.java
@@ -32,77 +32,77 @@ public abstract class Java8Shim {
     }
 
     /**
-     * {@link java.util.List.of}
+     * {@code java.util.List.of}
      */
     public abstract <T> List<T> listOf();
 
     /**
-     * {@link java.util.List.of}
+     * {@code java.util.List.of}
      */
     public abstract <T> List<T> listOf(T a);
 
     /**
-     * {@link java.util.List.of}
+     * {@code java.util.List.of}
      */
     public abstract <T> List<T> listOf(T a, T b);
 
     /**
-     * {@link java.util.List.of}
+     * {@code java.util.List.of}
      */
     public abstract <T> List<T> listOf(T a, T b, T c);
 
     /**
-     * {@link java.util.List.of}
+     * {@code java.util.List.of}
      */
     public abstract <T> List<T> listOf(T... els);
 
     /**
-     * {@link java.util.List.copyOf}
+     * {@code java.util.List.copyOf}
      */
     public abstract <T> List<T> listCopyOf(Collection<? extends T> c);
 
     /**
-     * {@link java.util.Map.copyOf}
+     * {@code java.util.Map.copyOf}
      */
     public abstract <K, V> Map<K, V> mapCopyOf(Map<? extends K, ? extends V> m);
 
     /**
-     * {@link java.util.Map.entry}
+     * {@code java.util.Map.entry}
      */
     public abstract <K, V> Map.Entry<K, V> mapEntry(K key, V value);
 
     /**
-     * {@link java.util.Map.ofEntries}
+     * {@code java.util.Map.ofEntries}
      */
     public abstract <K, V> Map<K, V> mapOfEntries(Map.Entry<K, V>... entries);
 
     /**
-     * {@link java.util.Set.of}
+     * {@code java.util.Set.of}
      */
     public abstract <T> Set<T> setOf();
 
     /**
-     * {@link java.util.Set.of}
+     * {@code java.util.Set.of}
      */
     public abstract <T> Set<T> setOf(T a);
 
     /**
-     * {@link java.util.Set.of}
+     * {@code java.util.Set.of}
      */
     public abstract <T> Set<T> setOf(T a, T b);
 
     /**
-     * {@link java.util.Set.of}
+     * {@code java.util.Set.of}
      */
     public abstract <T> Set<T> setOf(T a, T b, T c);
 
     /**
-     * {@link java.util.Set.of}
+     * {@code java.util.Set.of}
      */
     public abstract <T> Set<T> setOf(T... els);
 
     /**
-     * {@link java.util.Set.copyOf}
+     * {@code java.util.Set.copyOf}
      */
     public abstract <T> Set<T> setCopyOf(Collection<? extends T> c);
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -46,7 +46,8 @@ import static org.owasp.shim.Java8Shim.j8;
 @NotThreadSafe
 class ElementAndAttributePolicyBasedSanitizerPolicy
     implements HtmlSanitizer.Policy,
-               TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy {
+               TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy,
+               HtmlChangeReporter.AttributelessSkipPolicy {
   final Map<String, ElementAndAttributePolicies> elAndAttrPolicies;
   final Set<String> allowedTextContainers;
   /**
@@ -121,9 +122,18 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
           "script", "style", "noscript", "nostyle", "noembed", "noframes",
           "iframe", "object", "frame", "frameset", "title");
 
+  /**
+   * True after {@link #openTag} allowed the element but emitted no tag
+   * because no attribute survived and the element is skipped when it has
+   * none.  {@link HtmlChangeReporter} asks, so that it can report the
+   * rejected attributes as the policy's doing rather than the element's.
+   */
+  private transient boolean skippedLastTagAsAttributeless;
+
   public void openDocument() {
     skipText = false;
     inKeptCdataElement = false;
+    skippedLastTagAsAttributeless = false;
     openElementStack.clear();
     skipTextBeforeOpen.clear();
     inKeptCdataBeforeOpen.clear();
@@ -307,12 +317,20 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     // check the override of it in that class.
     ElementAndAttributePolicies policies = elAndAttrPolicies.get(elementName);
     String adjustedElementName = applyPolicies(elementName, attrs, policies);
-    if (adjustedElementName != null
-        && !(attrs.isEmpty() && policies.htmlTagSkipType.skipAvailability())) {
-      writeOpenTag(policies, adjustedElementName, attrs);
-      return;
+    skippedLastTagAsAttributeless = false;
+    if (adjustedElementName != null) {
+      if (!(attrs.isEmpty() && policies.htmlTagSkipType.skipAvailability())) {
+        writeOpenTag(policies, adjustedElementName, attrs);
+        return;
+      }
+      // The element was allowed; it goes only because no attribute survived.
+      skippedLastTagAsAttributeless = true;
     }
     deferOpenTag(elementName);
+  }
+
+  public boolean skippedLastTagAsAttributeless() {
+    return skippedLastTagAsAttributeless;
   }
 
   static final @Nullable String applyPolicies(

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -157,10 +157,11 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
   public void text(String textChunk) {
     if (!skipText) {
-      // Note: Only style and script are CDATA elements; noscript/noembed/noframes are PCDATA
-      // If inside a CDATA element (style/script) with allowTextIn, we need to filter out 
-      // HTML tags that aren't allowed because tags inside these blocks are reclassified 
-      // as UNESCAPED text by the lexer
+      // Note: Only style and script are CDATA elements; noscript, noembed
+      // and noframes are PCDATA.
+      // If inside a CDATA element (style/script) with allowTextIn, we need
+      // to filter out HTML tags that aren't allowed because tags inside
+      // these blocks are reclassified as UNESCAPED text by the lexer
       if (inKeptCdataElement
           && textChunk != null && textChunk.indexOf('<') >= 0) {
         // Strip out HTML tags that aren't in the allowed elements list
@@ -173,9 +174,10 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   }
   
   /**
-   * Strips out HTML tags that aren't in the allowed elements list from text content.
-   * This is used when tags appear inside text containers (like style blocks) where
-   * they're treated as text but should still be validated.
+   * Strips out HTML tags that aren't in the allowed elements list from text
+   * content.  This is used when tags appear inside text containers (like
+   * style blocks) where they're treated as text but should still be
+   * validated.
    */
   private String stripDisallowedTags(String text) {
     if (text == null) {
@@ -280,7 +282,8 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
               i = len;
               break;
             }
-            String nextTagContent = text.substring(nextTagStart + 1, nextTagEnd);
+            String nextTagContent =
+                text.substring(nextTagStart + 1, nextTagEnd);
             String trimmedNextTagContent = nextTagContent.trim();
             String nextTagName = trimmedNextTagContent.split("\\s")[0];
             if (trimmedNextTagContent.startsWith("/")) {
@@ -366,7 +369,8 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
       adjustedElementName = policies.elPolicy.apply(elementName, attrs);
       if (adjustedElementName != null) {
-        adjustedElementName = HtmlLexer.canonicalElementName(adjustedElementName);
+        adjustedElementName =
+            HtmlLexer.canonicalElementName(adjustedElementName);
       }
     } else {
       adjustedElementName = null;

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
@@ -255,7 +255,8 @@ public final class Encoding {
    *     would leave an HTML parser in the Data state if it were to encounter a space
    *     character as the next character.  In practice this means that the buffer
    *     does not contain partial tags or comments, and the most recently opened
-   *     element is `<textarea>` or `<title>` and that element is still open.
+   *     element is {@code <textarea>} or {@code <title>} and that element is
+   *     still open.
    */
   public static void encodeRcdataOnto(String plainText, Appendable output)
       throws IOException {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeListener.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeListener.java
@@ -49,9 +49,58 @@ public interface HtmlChangeListener<T> {
   public void discardedTag(@Nullable T context, String elementName);
 
   /**
-   * Called when attributes are discarded
-   * from the input but the containing tag is not.
+   * Called when attributes are discarded from a tag that the policy allowed.
+   * <p>
+   * Usually the tag itself survives without them.  When every attribute is
+   * rejected and the element is one the policy skips when it has none, as
+   * {@code a}, {@code font}, {@code img}, {@code input} and {@code span} are
+   * by default, the tag is discarded as a consequence: {@link #discardedTag}
+   * reports the tag, and this method still reports the attributes, since
+   * rejecting them is what the policy did.  Attributes on a tag that the
+   * policy did not allow are not reported; {@code discardedTag} covers the
+   * whole tag.
+   * <p>
+   * A repeated attribute name counts once per dropped copy.
    */
   public void discardedAttributes(
       @Nullable T context, String tagName, String... attributeNames);
+
+  /**
+   * Called once for each attribute named in a {@link #discardedAttributes}
+   * report, after that report, with the value the attribute had in the input.
+   * The value is as the author wrote it, after character references have
+   * been decoded, and has not been vetted by any policy, so treat it as
+   * untrusted.
+   * <p>
+   * The default implementation does nothing.
+   */
+  public default void discardedAttribute(
+      @Nullable T context, String tagName, String attributeName,
+      String attributeValue) {
+    // Listeners that do not need values need not override this.
+  }
+
+  /**
+   * Called when the content of an element the policy kept could not be
+   * rendered and was dropped, leaving the element empty.  A {@code script}
+   * or {@code style} element cannot hold content that a browser would read
+   * as ending the element early or as opening a comment it never closes,
+   * such as a {@code -->} with no {@code <!--} before it, so the renderer
+   * drops the whole content rather than emit it.
+   * <p>
+   * Text inside a discarded element is not reported here; the
+   * {@link #discardedTag} report covers it.  These reports come from
+   * {@link HtmlStreamRenderer}, which
+   * {@link PolicyFactory#sanitize(String, HtmlChangeListener, Object)}
+   * always uses; a sanitizer built on another receiver does not send them.
+   * <p>
+   * The default implementation does nothing.
+   *
+   * @param elementName the element whose content was dropped.
+   * @param text the content that was dropped.
+   */
+  public default void discardedText(
+      @Nullable T context, String elementName, String text) {
+    // Listeners that do not need text need not override this.
+  }
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeListener.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeListener.java
@@ -52,9 +52,11 @@ public interface HtmlChangeListener<T> {
    * Called when attributes are discarded from a tag that the policy allowed.
    * <p>
    * Usually the tag itself survives without them.  When every attribute is
-   * rejected and the element is one the policy skips when it has none, as
-   * {@code a}, {@code font}, {@code img}, {@code input} and {@code span} are
-   * by default, the tag is discarded as a consequence: {@link #discardedTag}
+   * rejected and the element is one the policy skips when it has none, the
+   * {@link HtmlPolicyBuilder#DEFAULT_SKIP_IF_EMPTY default set} unless
+   * {@link HtmlPolicyBuilder#allowWithoutAttributes} or
+   * {@link HtmlPolicyBuilder#disallowWithoutAttributes} said otherwise, the
+   * tag is discarded as a consequence: {@link #discardedTag}
    * reports the tag, and this method still reports the attributes, since
    * rejecting them is what the policy did.  Attributes on a tag that the
    * policy did not allow are not reported; {@code discardedTag} covers the
@@ -92,7 +94,8 @@ public interface HtmlChangeListener<T> {
    * {@link #discardedTag} report covers it.  These reports come from
    * {@link HtmlStreamRenderer}, which
    * {@link PolicyFactory#sanitize(String, HtmlChangeListener, Object)}
-   * always uses; a sanitizer built on another receiver does not send them.
+   * always uses, seen through any {@link HtmlStreamEventReceiverWrapper}
+   * around it; a sanitizer built on some other receiver does not send them.
    * <p>
    * The default implementation does nothing.
    *

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -83,10 +83,27 @@ public final class HtmlChangeReporter<T> {
    */
   public HtmlSanitizer.Policy getWrappedPolicy() { return input; }
 
+  /**
+   * Implemented by a policy that can say, after
+   * {@link HtmlSanitizer.Policy#openTag}, whether it allowed the element but
+   * emitted no tag because every attribute had been rejected and the element
+   * is skipped when it has none.  Attributes rejected from such an element
+   * are the policy's doing and are reported; attributes on a rejected
+   * element go with it and are not.
+   */
+  interface AttributelessSkipPolicy {
+    /**
+     * @return true if the most recent start tag was allowed by the element
+     *     policy and dropped only for having no attributes left.
+     */
+    boolean skippedLastTagAsAttributeless();
+  }
+
   private static final class InputChannel<T>
       implements HtmlSanitizer.Policy,
                  TagBalancingHtmlStreamEventReceiver.NestingLimitListener,
-                 TextSuppressionPolicy {
+                 TextSuppressionPolicy,
+                 HtmlStreamRenderer.DroppedTextListener {
     HtmlStreamEventReceiver policy;
     final OutputChannel output;
     final T context;
@@ -120,20 +137,37 @@ public final class HtmlChangeReporter<T> {
               .suppressesTextWhenDropped(canonElementName);
     }
 
+    /**
+     * The renderer sits downstream and drops literal content it cannot emit
+     * without a browser reading it differently.  It tells us directly, as
+     * the balancer does for the nesting limit.
+     */
+    public void droppedText(String elementName, String text) {
+      listener.discardedText(context, elementName, text);
+    }
+
     public void openDocument() {
+      // The renderer decides on its own to drop literal content it cannot
+      // emit, so it has to tell us; any other receiver keeps that to itself.
+      // Bound for this document only, so that a renderer reused without this
+      // reporter does not go on reporting to it.
+      output.listenForDroppedText(this);
       policy.openDocument();
     }
 
     public void closeDocument() {
+      // Closing may flush and drop pending literal content, so listen until
+      // the renderer is done.
       policy.closeDocument();
+      output.listenForDroppedText(null);
     }
 
     public void openTag(String elementName, List<String> attrs) {
       output.openedElementName = null;
-      output.expectedAttrNames.clear();
-      for (int i = 0, n = attrs.size(); i < n; i += 2) {
-        output.expectedAttrNames.add(attrs.get(i));
-      }
+      output.expectedAttrs.clear();
+      // Copied before the policy runs: it removes rejected attributes from
+      // attrs in place, and their values are wanted for the report.
+      output.expectedAttrs.addAll(attrs);
       policy.openTag(elementName, attrs);
       {
         // Gather the notification details to avoid any problems with the
@@ -145,20 +179,38 @@ public final class HtmlChangeReporter<T> {
         // rename the element, and a renamed element was kept, not dropped.
         boolean discarded = output.openedElementName == null;
         output.openedElementName = null;
-        int nExpected = output.expectedAttrNames.size();
-        String[] discardedAttrNames =
-            nExpected != 0 && !discarded
-            ? output.expectedAttrNames.toArray(new String[nExpected])
+        // Attributes go unreported with a tag the policy rejected: the tag
+        // report covers them.  Not so when the policy allowed the element and
+        // dropped it only because none of its attributes survived: rejecting
+        // them was the policy's decision, and the tag went as a consequence.
+        boolean attrsRejectedOnTheirOwn = !discarded
+            || (policy instanceof AttributelessSkipPolicy
+                && ((AttributelessSkipPolicy) policy)
+                    .skippedLastTagAsAttributeless());
+        int nDiscarded = attrsRejectedOnTheirOwn
+            ? output.expectedAttrs.size() / 2
+            : 0;
+        String[] discardedAttrs = nDiscarded != 0
+            ? output.expectedAttrs.toArray(new String[nDiscarded * 2])
             : ZERO_STRINGS;
-        output.expectedAttrNames.clear();
+        output.expectedAttrs.clear();
         // Dispatch notifications to the listener, under the input name,
         // which is the one the listener can relate to what came in.
         if (discarded) {
           listener.discardedTag(context, elementName);
         }
-        if (discardedAttrNames.length != 0) {
+        if (nDiscarded != 0) {
+          String[] discardedAttrNames = new String[nDiscarded];
+          for (int i = 0; i < nDiscarded; ++i) {
+            discardedAttrNames[i] = discardedAttrs[i * 2];
+          }
           listener.discardedAttributes(
               context, elementName, discardedAttrNames);
+          for (int i = 0; i < nDiscarded; ++i) {
+            listener.discardedAttribute(
+                context, elementName,
+                discardedAttrs[i * 2], discardedAttrs[i * 2 + 1]);
+          }
         }
       }
     }
@@ -182,17 +234,29 @@ public final class HtmlChangeReporter<T> {
      */
     String openedElementName;
     /**
-     * Names of the attributes on the tag being opened that have not turned up
-     * in the output yet.  A list rather than a set: a name repeated on one tag
-     * is two attributes, and HTML forbids that, so the sanitizer keeps the
-     * first and drops the rest.  Collapsing the copies here would leave the
-     * surviving one accounting for all of them, and the drops would go
-     * unreported.
+     * The attributes on the tag being opened, as name and value pairs, that
+     * have not turned up in the output yet.  A list rather than a map: a
+     * name repeated on one tag is two attributes, and HTML forbids that, so
+     * the sanitizer keeps the first and drops the rest.  Collapsing the copies
+     * here would leave the surviving one accounting for all of them, and the
+     * drops would go unreported.  The values ride along so that the drops can
+     * be reported with them.
      */
-    List<String> expectedAttrNames = new ArrayList<>();
+    List<String> expectedAttrs = new ArrayList<>();
 
     OutputChannel(HtmlStreamEventReceiver renderer) {
       this.renderer = renderer;
+    }
+
+    /**
+     * Has the renderer report dropped literal content to {@code listener},
+     * or to nobody when null, if it is one that can.
+     */
+    void listenForDroppedText(
+        @Nullable HtmlStreamRenderer.DroppedTextListener listener) {
+      if (renderer instanceof HtmlStreamRenderer) {
+        ((HtmlStreamRenderer) renderer).reportDroppedTextTo(listener);
+      }
     }
 
     public void openDocument() {
@@ -208,9 +272,19 @@ public final class HtmlChangeReporter<T> {
       for (int i = 0, n = attrs.size(); i < n; i += 2) {
         // Accounts for one copy of the name, so repeats the policy dropped
         // stay behind to be reported.
-        expectedAttrNames.remove(attrs.get(i));
+        removeFirstNamed(expectedAttrs, attrs.get(i));
       }
       renderer.openTag(elementName, attrs);
+    }
+
+    /** Removes the first pair in pairs whose name is name, if there is one. */
+    private static void removeFirstNamed(List<String> pairs, String name) {
+      for (int i = 0, n = pairs.size(); i < n; i += 2) {
+        if (name.equals(pairs.get(i))) {
+          pairs.subList(i, i + 2).clear();
+          return;
+        }
+      }
     }
 
     public void closeTag(String elementName) {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -147,12 +147,13 @@ public final class HtmlChangeReporter<T> {
     }
 
     public void openDocument() {
+      policy.openDocument();
       // The renderer decides on its own to drop literal content it cannot
       // emit, so it has to tell us; any other receiver keeps that to itself.
-      // Bound for this document only, so that a renderer reused without this
-      // reporter does not go on reporting to it.
+      // Bound once the renderer has opened the document, which forgets any
+      // earlier listener, and for this document only, so that a renderer
+      // reused without this reporter does not go on reporting to it.
       output.listenForDroppedText(this);
-      policy.openDocument();
     }
 
     public void closeDocument() {
@@ -250,12 +251,18 @@ public final class HtmlChangeReporter<T> {
 
     /**
      * Has the renderer report dropped literal content to {@code listener},
-     * or to nobody when null, if it is one that can.
+     * or to nobody when null, if it is one that can.  The library's own
+     * decorator, which a postprocessor or a logging wrapper is likely to
+     * extend, is seen through.
      */
     void listenForDroppedText(
         @Nullable HtmlStreamRenderer.DroppedTextListener listener) {
-      if (renderer instanceof HtmlStreamRenderer) {
-        ((HtmlStreamRenderer) renderer).reportDroppedTextTo(listener);
+      HtmlStreamEventReceiver r = renderer;
+      while (r instanceof HtmlStreamEventReceiverWrapper) {
+        r = ((HtmlStreamEventReceiverWrapper) r).underlying;
+      }
+      if (r instanceof HtmlStreamRenderer) {
+        ((HtmlStreamRenderer) r).reportDroppedTextTo(listener);
       }
     }
 

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -50,7 +50,7 @@ import static org.owasp.shim.Java8Shim.j8;
 /**
  * Conveniences for configuring policies for the {@link HtmlSanitizer}.
  *
- * <h3>Usage</h3>
+ * <h2>Usage</h2>
  * <p>
  * To create a policy, first construct an instance of this class; then call
  * <code>allow&hellip;</code> methods to turn on tags, attributes, and other

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.annotation.WillCloseWhenClosed;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -55,6 +56,8 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   private final Appendable output;
   private final Handler<? super IOException> ioExHandler;
   private final Handler<? super String> badHtmlHandler;
+  /** Told about dropped literal content; null while nobody is listening. */
+  private @Nullable DroppedTextListener droppedTextListener;
   private String lastTagOpened;
   private StringBuilder pendingUnescaped;
   private HtmlTextEscapingMode escapingMode = HtmlTextEscapingMode.PCDATA;
@@ -128,6 +131,26 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     if (badHtmlHandler != Handler.DO_NOTHING) {   // Avoid string append.
       badHtmlHandler.handle(message + " : " + identifier);
     }
+  }
+
+  /**
+   * Told when the content of a literal-content element such as
+   * {@code script} or {@code style} is dropped because it cannot be emitted
+   * without a browser reading it differently.  The bad HTML handler hears
+   * of it too, as a message; this carries the content itself, so that
+   * {@link HtmlChangeReporter} can report the loss to its listener.
+   */
+  interface DroppedTextListener {
+    /**
+     * @param elementName the element whose content was dropped.
+     * @param text the content that was dropped.
+     */
+    void droppedText(String elementName, String text);
+  }
+
+  /** Sends dropped literal content to {@code listener}, or to nobody. */
+  final void reportDroppedTextTo(@Nullable DroppedTextListener listener) {
+    this.droppedTextListener = listener;
   }
 
   public final void openDocument() throws IllegalStateException {
@@ -304,6 +327,10 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
             cdataContent.subSequence(
                 problemIndex,
                 Math.min(problemIndex + 10, cdataContent.length())));
+        if (droppedTextListener != null) {
+          droppedTextListener.droppedText(
+              elementName, cdataContent.toString());
+        }
         // Still output the close tag.
       }
       if ("plaintext".equals(elementName)) { return; }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -62,7 +62,10 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   private StringBuilder pendingUnescaped;
   private HtmlTextEscapingMode escapingMode = HtmlTextEscapingMode.PCDATA;
   private boolean open;
-  /** The count of {@link #foreignContentRootElementNames} opened and not subsequently closed. */
+  /**
+   * The count of {@link #foreignContentRootElementNames} opened and not
+   * subsequently closed.
+   */
   private int foreignContentDepth = 0;
   /**
    * True when the current element is one whose content the HTML lexer treats
@@ -207,7 +210,8 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
       foreignContentDepth += 1;
     }
 
-    HtmlTextEscapingMode tentativeEscapingMode = HtmlTextEscapingMode.getModeForTag(elementName);
+    HtmlTextEscapingMode tentativeEscapingMode =
+        HtmlTextEscapingMode.getModeForTag(elementName);
     decodeTextBeforeEscaping = false;
     if (foreignContentDepth == 0) {
       escapingMode = tentativeEscapingMode;
@@ -303,7 +307,8 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
       return;
     }
 
-    if (foreignContentDepth != 0 && foreignContentRootElementNames.contains(elementName)) {
+    if (foreignContentDepth != 0
+        && foreignContentRootElementNames.contains(elementName)) {
       foreignContentDepth -= 1;
     }
     decodeTextBeforeEscaping = false;
@@ -366,13 +371,16 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     // www.w3.org/TR/html51/semantics-scripting.html#restrictions-for-contents-of-script-elements
     // www.w3.org/TR/html5/scripting-1.html#restrictions-for-contents-of-script-elements
     // 4.12.1.3. Restrictions for contents of script elements
-    // The textContent of a script element must match the script production in the following ABNF, the character set for which is Unicode. [ABNF]
+    // The textContent of a script element must match the script production
+    // in the following ABNF, the character set for which is Unicode. [ABNF]
     //
     // script = outer *( comment-open inner comment-close outer )
     //
-    // outer = < any string that doesn’t contain a substring that matches not-in-outer >
+    // outer = < any string that doesn’t contain a substring that matches
+    //           not-in-outer >
     // not-in-outer = comment-open
-    // inner = < any string that doesn’t contain a substring that matches not-in-inner >
+    // inner = < any string that doesn’t contain a substring that matches
+    //           not-in-inner >
     // not-in-inner = comment-close / script-open
     //
     // comment-open = "<!--"
@@ -398,8 +406,8 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
             } else if (innerStart < 0) {
               break;
             }
-            // We don't need to do any suffix checks to preserve concatenation safety
-            // since we buffer pending unescaped above.
+            // We don't need to do any suffix checks to preserve concatenation
+            // safety since we buffer pending unescaped above.
             int end = start + localName.length();
             if (end <= n
                 && Strings.regionMatchesIgnoreCase(
@@ -531,5 +539,6 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     return ch < 63 && 0 != (TAG_ENDS & (1L << ch));
   }
 
-  private static final Set<String> foreignContentRootElementNames = j8().setOf("svg", "math");
+  private static final Set<String> foreignContentRootElementNames =
+      j8().setOf("svg", "math");
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -151,7 +151,11 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     void droppedText(String elementName, String text);
   }
 
-  /** Sends dropped literal content to {@code listener}, or to nobody. */
+  /**
+   * Sends dropped literal content to {@code listener}, or to nobody, until
+   * the next {@link #openDocument}, which starts a document with nobody
+   * listening.
+   */
   final void reportDroppedTextTo(@Nullable DroppedTextListener listener) {
     this.droppedTextListener = listener;
   }
@@ -159,6 +163,9 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   public final void openDocument() throws IllegalStateException {
     if (open) { throw new IllegalStateException(); }
     open = true;
+    // A listener is for one document; whoever wants this one's drops
+    // registers after this, so an earlier document's cannot linger.
+    droppedTextListener = null;
   }
 
   public final void closeDocument() throws IllegalStateException {

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
@@ -95,6 +95,12 @@ public final class PolicyFactory
   /**
    * Produces a sanitizer that emits tokens to {@code out} and that notifies
    * any {@code listener} of any dropped tags and attributes.
+   * Content that {@code out} cannot render, such as a {@code -->} inside a
+   * kept {@code script} element, is reported through
+   * {@link HtmlChangeListener#discardedText} only when {@code out} is an
+   * {@link HtmlStreamRenderer}, since that is where the decision to drop it
+   * is made; {@link #sanitize(String, HtmlChangeListener, Object)} always
+   * uses one.
    * @param out a renderer that receives approved tokens only.
    * @param listener if non-null, receives notifications of tags and attributes
    *     that were rejected by the policy.  This may tie into intrusion
@@ -122,7 +128,9 @@ public final class PolicyFactory
 
   /**
    * A convenience function that sanitizes a string of HTML and reports
-   * the names of rejected element and attributes to listener.
+   * the names of rejected elements and attributes to listener, along with
+   * the rejected attributes' values and any content the renderer could not
+   * emit.
    * @param html the string of HTML to sanitize.
    * @param listener if non-null, receives notifications of tags and attributes
    *     that were rejected by the policy.  This may tie into intrusion

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
@@ -98,9 +98,10 @@ public final class PolicyFactory
    * Content that {@code out} cannot render, such as a {@code -->} inside a
    * kept {@code script} element, is reported through
    * {@link HtmlChangeListener#discardedText} only when {@code out} is an
-   * {@link HtmlStreamRenderer}, since that is where the decision to drop it
-   * is made; {@link #sanitize(String, HtmlChangeListener, Object)} always
-   * uses one.
+   * {@link HtmlStreamRenderer}, possibly behind
+   * {@link HtmlStreamEventReceiverWrapper} decorators, since that is where
+   * the decision to drop it is made;
+   * {@link #sanitize(String, HtmlChangeListener, Object)} always uses one.
    * @param out a renderer that receives approved tokens only.
    * @param listener if non-null, receives notifications of tags and attributes
    *     that were rejected by the policy.  This may tie into intrusion

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
@@ -336,14 +336,94 @@ class HtmlChangeReporterTest {
 
   /**
    * The convenience method renders with HtmlStreamRenderer, so dropped
-   * content reaches the listener.  A sanitizer built on another receiver
+   * content reaches the listener, as it does through the library's own
+   * receiver wrapper around one.  A sanitizer built on some other receiver
    * has no renderer to hear from and reports tags and attributes only.
    */
   @Test
   void testDroppedTextReachesTheListenerOnlyThroughTheRenderer() {
     final List<String> dropped = new ArrayList<>();
     final List<String> tags = new ArrayList<>();
-    HtmlChangeListener<Object> listener = new HtmlChangeListener<Object>() {
+    HtmlChangeListener<Object> listener =
+        textAndTagCollector(dropped, tags);
+    PolicyFactory p = scriptAndStyleWithText();
+    String html = "<script>x --> y</script><b>z</b>";
+
+    assertEquals("<script></script>z", p.sanitize(html, listener, null));
+    assertEquals(Arrays.asList("script:x --> y"), dropped);
+    assertEquals(Arrays.asList("b"), tags);
+
+    // Through the library's wrapper, which a postprocessor would extend.
+    dropped.clear();
+    tags.clear();
+    StringBuilder out = new StringBuilder();
+    HtmlStreamEventReceiver wrapped = new HtmlStreamEventReceiverWrapper(
+        HtmlStreamRenderer.create(out, Handler.DO_NOTHING)) {
+      // Forwards everything; only its type differs from the renderer's.
+    };
+    HtmlSanitizer.sanitize(html, p.apply(wrapped, listener, null));
+
+    assertEquals("<script></script>z", out.toString());
+    assertEquals(Arrays.asList("script:x --> y"), dropped);
+    assertEquals(Arrays.asList("b"), tags);
+
+    // Through a receiver of some other kind, which cannot be seen through.
+    dropped.clear();
+    tags.clear();
+    final StringBuilder out2 = new StringBuilder();
+    final HtmlStreamRenderer renderer =
+        HtmlStreamRenderer.create(out2, Handler.DO_NOTHING);
+    HtmlStreamEventReceiver foreign = new HtmlStreamEventReceiver() {
+      public void openDocument() { renderer.openDocument(); }
+
+      public void closeDocument() { renderer.closeDocument(); }
+
+      public void openTag(String elementName, List<String> attrs) {
+        renderer.openTag(elementName, attrs);
+      }
+
+      public void closeTag(String elementName) {
+        renderer.closeTag(elementName);
+      }
+
+      public void text(String text) { renderer.text(text); }
+    };
+    HtmlSanitizer.sanitize(html, p.apply(foreign, listener, null));
+
+    assertEquals("<script></script>z", out2.toString());
+    assertEquals(Arrays.asList(), dropped);
+    assertEquals(Arrays.asList("b"), tags);
+  }
+
+  /**
+   * A reporter listens to the renderer for one document.  The renderer,
+   * reused for another document without that reporter, must not go on
+   * reporting to it under the old context.
+   */
+  @Test
+  void testARenderersNextDocumentDoesNotReportToTheLastReporter() {
+    final List<String> dropped = new ArrayList<>();
+    HtmlChangeListener<Object> listener =
+        textAndTagCollector(dropped, new ArrayList<String>());
+    PolicyFactory p = scriptAndStyleWithText();
+    StringBuilder out = new StringBuilder();
+    HtmlStreamRenderer renderer =
+        HtmlStreamRenderer.create(out, Handler.DO_NOTHING);
+    String html = "<script>x --> y</script>";
+
+    HtmlSanitizer.sanitize(html, p.apply(renderer, listener, null));
+    assertEquals(Arrays.asList("script:x --> y"), dropped);
+
+    dropped.clear();
+    HtmlSanitizer.sanitize(html, p.apply(renderer));
+    assertEquals("<script></script><script></script>", out.toString());
+    assertEquals(Arrays.asList(), dropped);
+  }
+
+  /** Collects dropped text as {@code element:text} and discarded tags. */
+  private static HtmlChangeListener<Object> textAndTagCollector(
+      final List<String> dropped, final List<String> tags) {
+    return new HtmlChangeListener<Object>() {
       public void discardedTag(Object context, String elementName) {
         tags.add(elementName);
       }
@@ -359,25 +439,6 @@ class HtmlChangeReporterTest {
         dropped.add(elementName + ":" + text);
       }
     };
-    PolicyFactory p = scriptAndStyleWithText();
-    String html = "<script>x --> y</script><b>z</b>";
-
-    assertEquals("<script></script>z", p.sanitize(html, listener, null));
-    assertEquals(Arrays.asList("script:x --> y"), dropped);
-    assertEquals(Arrays.asList("b"), tags);
-
-    dropped.clear();
-    tags.clear();
-    StringBuilder out = new StringBuilder();
-    HtmlStreamEventReceiver wrapped = new HtmlStreamEventReceiverWrapper(
-        HtmlStreamRenderer.create(out, Handler.DO_NOTHING)) {
-      // Forwards everything; only its type differs from the renderer's.
-    };
-    HtmlSanitizer.sanitize(html, p.apply(wrapped, listener, null));
-
-    assertEquals("<script></script>z", out.toString());
-    assertEquals(Arrays.asList(), dropped);
-    assertEquals(Arrays.asList("b"), tags);
   }
 
   /** Keeps script and style with their content, as a template host might. */

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
@@ -27,6 +27,8 @@
 
 package org.owasp.html;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -194,6 +196,198 @@ class HtmlChangeReporterTest {
         .toFactory();
   }
 
+  /**
+   * An element the policy allows but skips when attribute-less goes when
+   * every attribute on it is rejected.  The attributes are still reported:
+   * rejecting them was the policy's decision, and the tag went as a
+   * consequence (#447).  Each is also reported with its value (#243).
+   */
+  @Test
+  void testAttributesRejectedFromAnElementThenSkippedAreReported() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("span")
+        .allowAttributes("id").onElements("span")
+        .toFactory();
+    Result result = sanitizeVerbose(p, "<span onclick=x>hi</span>");
+
+    assertEquals("hi", result.html);
+    assertEquals("<span> <span onclick> span.onclick=\"x\" ", result.log);
+  }
+
+  /** The intrusion-detection case from #447: the rejected URL is the signal. */
+  @Test
+  void testRejectedUrlOnASkippedLinkIsReportedWithItsValue() {
+    Result result = sanitizeVerbose(
+        Sanitizers.LINKS, "<a href=\"javascript:alert(1)\">x</a>");
+
+    assertEquals("x", result.html);
+    assertEquals(
+        "<a> <a href> a.href=\"javascript:alert(1)\" ", result.log);
+  }
+
+  /** Attributes on an element the policy does not allow go with the tag. */
+  @Test
+  void testAttributesOnADisallowedElementAreNotReported() {
+    Result result = sanitizeVerbose(
+        Sanitizers.FORMATTING, "<div onclick=x>hi</div>");
+
+    assertEquals("hi", result.html);
+    assertEquals("<div> ", result.log);
+  }
+
+  /** Nothing to report but the tag when it had no attributes to begin with. */
+  @Test
+  void testSkippedAttributelessElementReportsOnlyTheTag() {
+    Result result = sanitizeVerbose(Sanitizers.LINKS, "<a>x</a>");
+
+    assertEquals("x", result.html);
+    assertEquals("<a> ", result.log);
+  }
+
+  /** A kept element reports as before, and now with the values. */
+  @Test
+  void testRejectedAttributesOnAKeptElementAreReportedWithValues() {
+    Result result = sanitizeVerbose(
+        Sanitizers.FORMATTING, "<b onclick=\"alert(42)\" title=t>x</b>");
+
+    assertEquals("<b>x</b>", result.html);
+    assertEquals(
+        "<b onclick title> b.onclick=\"alert(42)\" b.title=\"t\" ",
+        result.log);
+  }
+
+  /** Each dropped copy of a repeated attribute carries its own value. */
+  @Test
+  void testEachDroppedCopyOfARepeatedAttributeReportsItsOwnValue() {
+    Result result = sanitizeVerbose(
+        Sanitizers.LINKS,
+        "<a href=\"https://www.example.org/\" href=\"/one\" href=\"/two\">"
+        + "link</a>");
+
+    assertEquals(
+        "<a href=\"https://www.example.org/\" rel=\"nofollow\">link</a>",
+        result.html);
+    assertEquals(
+        "<a href href> a.href=\"/one\" a.href=\"/two\" ", result.log);
+  }
+
+  /** The value reported is the input value after character references. */
+  @Test
+  void testReportedValueIsTheDecodedInputValue() {
+    Result result = sanitizeVerbose(
+        Sanitizers.FORMATTING, "<b onclick=\"a&amp;b&lt;c\">x</b>");
+
+    assertEquals("<b>x</b>", result.html);
+    assertEquals("<b onclick> b.onclick=\"a&b<c\" ", result.log);
+  }
+
+  /** An attribute the policy rewrote was kept, so nothing is reported. */
+  @Test
+  void testARewrittenAttributeIsNotReported() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("a")
+        .allowAttributes("href")
+            .matching(
+                (element, attribute, url) -> "https://example.com/go?u=" + url)
+            .onElements("a")
+        .allowUrlProtocols("https")
+        .toFactory();
+    Result result = sanitizeVerbose(p, "<a href=\"x\">l</a>");
+
+    assertEquals(
+        "<a href=\"https://example.com/go?u&#61;x\">l</a>", result.html);
+    assertEquals("", result.log);
+  }
+
+  /**
+   * The renderer drops the content of a script or style element that it
+   * cannot emit without a browser reading it differently, such as a
+   * {@code -->} with no comment open.  That loss happens downstream of the
+   * policy and used to be invisible to the listener (#155, from #153).
+   */
+  @Test
+  void testUnrenderableScriptContentIsReported() {
+    Result result = sanitizeVerbose(
+        scriptAndStyleWithText(), "<script>x --> y</script>");
+
+    assertEquals("<script></script>", result.html);
+    assertEquals("script{x --> y} ", result.log);
+  }
+
+  /** A comment opened and never closed is the other unrenderable shape. */
+  @Test
+  void testUnrenderableStyleContentIsReported() {
+    Result result = sanitizeVerbose(
+        scriptAndStyleWithText(), "<style>a{} <!-- b > c</style>");
+
+    assertEquals("<style></style>", result.html);
+    assertEquals("style{a{} <!-- b > c} ", result.log);
+  }
+
+  /** Content the renderer can emit is not reported. */
+  @Test
+  void testRenderableScriptContentIsNotReported() {
+    Result result = sanitizeVerbose(
+        scriptAndStyleWithText(), "<script><!-- x --></script>");
+
+    assertEquals("<script><!-- x --></script>", result.html);
+    assertEquals("", result.log);
+  }
+
+  /**
+   * The convenience method renders with HtmlStreamRenderer, so dropped
+   * content reaches the listener.  A sanitizer built on another receiver
+   * has no renderer to hear from and reports tags and attributes only.
+   */
+  @Test
+  void testDroppedTextReachesTheListenerOnlyThroughTheRenderer() {
+    final List<String> dropped = new ArrayList<>();
+    final List<String> tags = new ArrayList<>();
+    HtmlChangeListener<Object> listener = new HtmlChangeListener<Object>() {
+      public void discardedTag(Object context, String elementName) {
+        tags.add(elementName);
+      }
+
+      public void discardedAttributes(
+          Object context, String tagName, String... attributeNames) {
+        // Not under test.
+      }
+
+      @Override
+      public void discardedText(
+          Object context, String elementName, String text) {
+        dropped.add(elementName + ":" + text);
+      }
+    };
+    PolicyFactory p = scriptAndStyleWithText();
+    String html = "<script>x --> y</script><b>z</b>";
+
+    assertEquals("<script></script>z", p.sanitize(html, listener, null));
+    assertEquals(Arrays.asList("script:x --> y"), dropped);
+    assertEquals(Arrays.asList("b"), tags);
+
+    dropped.clear();
+    tags.clear();
+    StringBuilder out = new StringBuilder();
+    HtmlStreamEventReceiver wrapped = new HtmlStreamEventReceiverWrapper(
+        HtmlStreamRenderer.create(out, Handler.DO_NOTHING)) {
+      // Forwards everything; only its type differs from the renderer's.
+    };
+    HtmlSanitizer.sanitize(html, p.apply(wrapped, listener, null));
+
+    assertEquals("<script></script>z", out.toString());
+    assertEquals(Arrays.asList(), dropped);
+    assertEquals(Arrays.asList("b"), tags);
+  }
+
+  /** Keeps script and style with their content, as a template host might. */
+  private static PolicyFactory scriptAndStyleWithText() {
+    return new HtmlPolicyBuilder()
+        .allowElements("script", "style")
+        .allowTextIn("script", "style")
+        .toFactory();
+  }
+
   /** The sanitized HTML and the log of what the listener was told about it. */
   static final class Result {
     final String html;
@@ -207,13 +401,29 @@ class HtmlChangeReporterTest {
 
   /** Sanitizes html under policy, recording every listener notification. */
   private static Result sanitize(PolicyFactory policy, String html) {
+    return sanitize(policy, html, false);
+  }
+
+  /**
+   * Like {@link #sanitize} but also records each discarded attribute's value
+   * and any dropped text; see {@link #verboseListener}.
+   */
+  private static Result sanitizeVerbose(PolicyFactory policy, String html) {
+    return sanitize(policy, html, true);
+  }
+
+  private static Result sanitize(
+      PolicyFactory policy, String html, boolean verbose) {
     Context testContext = new Context();
     StringBuilder out = new StringBuilder();
     StringBuilder log = new StringBuilder();
     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(
         out, Handler.DO_NOTHING);
+    HtmlChangeListener<Context> listener = verbose
+        ? verboseListener(testContext, log)
+        : loggingListener(testContext, log);
     HtmlChangeReporter<Context> hcr = new HtmlChangeReporter<>(
-        renderer, loggingListener(testContext, log), testContext);
+        renderer, listener, testContext);
     hcr.setPolicy(policy.apply(hcr.getWrappedRenderer()));
     HtmlSanitizer.sanitize(html, hcr.getWrappedPolicy());
     return new Result(out.toString(), log.toString());
@@ -239,6 +449,43 @@ class HtmlChangeReporterTest {
           log.append(' ').append(attributeName);
         }
         log.append("> ");
+      }
+    };
+  }
+
+  /**
+   * Logs as {@link #loggingListener} does, and additionally each discarded
+   * attribute's value as {@code tag.attr="value"} and dropped text as
+   * {@code element{text}}.
+   */
+  private static HtmlChangeListener<Context> verboseListener(
+      final Context expectedContext, final StringBuilder log) {
+    final HtmlChangeListener<Context> base =
+        loggingListener(expectedContext, log);
+    return new HtmlChangeListener<Context>() {
+      public void discardedTag(Context context, String elementName) {
+        base.discardedTag(context, elementName);
+      }
+
+      public void discardedAttributes(
+          Context context, String tagName, String... attributeNames) {
+        base.discardedAttributes(context, tagName, attributeNames);
+      }
+
+      @Override
+      public void discardedAttribute(
+          Context context, String tagName, String attributeName,
+          String attributeValue) {
+        assertSame(expectedContext, context);
+        log.append(tagName).append('.').append(attributeName)
+            .append("=\"").append(attributeValue).append("\" ");
+      }
+
+      @Override
+      public void discardedText(
+          Context context, String elementName, String text) {
+        assertSame(expectedContext, context);
+        log.append(elementName).append('{').append(text).append("} ");
       }
     };
   }


### PR DESCRIPTION
## Summary

Fixes #447. Closes #243 and #155.

`HtmlChangeReporter` threw the attribute diff away whenever the policy emitted no tag, so a listener never heard which attributes were rejected from an element the policy allowed and then skipped for having none left. A link whose only `href` was `javascript:` reached an intrusion-detection listener as a dropped `a` and nothing more.

- `discardedAttributes` now also fires for attributes rejected from an element the policy allowed when that rejection is what emptied it, the first direction proposed in #447. The policy records that it skipped an allowed element as attribute-less and the reporter asks, through a package-private interface in the same style as the balancer's text-suppression question. An element the policy never allowed still reports the tag alone, so the existing test pinning that behaviour is unchanged.
- `discardedAttribute`, a new default method, follows each `discardedAttributes` report with one call per dropped attribute carrying its input value, one copy of a repeated name at a time (#243). Rejected tag content is not offered: the sanitizer streams and never holds an element's content, and the discussion on #243 concluded values matter for attributes rejected on their value.
- `discardedText`, a new default method, reports the content of a kept `script` or `style` element that `HtmlStreamRenderer` dropped because it could not be emitted safely, the case behind #153 (#155). The renderer gains a package-private hook beside its bad-HTML handler, and the reporter listens through it for the duration of a document when the receiver is that renderer, which `PolicyFactory.sanitize` always uses. A sanitizer built with `PolicyFactory.apply` on another receiver reports tags and attributes only, and the javadoc says so.

Both new methods are Java 8 default methods that do nothing unless overridden, so existing listeners compile and behave as before apart from the emptied-element case. No public signature changed.

This bundles three issues at the maintainer's request; each has its own change log entry. A second commit, also at the maintainer's request, tidies pre-existing problems in the touched files with no code change: the shim's unresolvable `{@link java.util.List.of}` references, a class-level `<h3>` and two literal tags that failed doclint, and lines over 80 columns.

## Test plan

- New tests in `HtmlChangeReporterTest` cover the emptied-element report for a `span` and for a `javascript:` link, the unchanged tag-only report for a disallowed element and for an element that arrived attribute-less, values on kept and on emptied elements, one value per dropped copy of a repeated attribute, entity decoding of the reported value, no report for a rewritten attribute, dropped `script` and `style` content, renderable content going unreported, and the convenience path against a foreign receiver.
- All existing tests pass unchanged, including the one pinning that a discarded tag reports only the tag.
- `./mvnw clean verify` passes on JDK 11, 17, 21, and 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYF1WjZmwbGNrph7RDw2BS
