### PR TITLE
fix: Strip Every Tag From the Text of Kept Literal-Content Elements

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,21 @@
 
 Most recent at top.
   * Next release
+    * Text kept inside a `style`, `script` or `iframe` element, or any other
+      element whose content the renderer emits unescaped, now has every tag
+      removed, end tags included, instead of only the tags of elements the
+      policy does not allow.  An allowed element's start tag was copied
+      through with its attributes unvetted, and an end tag was kept when its
+      element was allowed, so
+      `<noscript><style></noscript><img src=x onerror=alert(1)></style></noscript>`
+      came out unchanged under a policy allowing `noscript`, `style` with
+      text and `img`.  A browser with scripting on reads `noscript` as raw
+      text up to that inner `</noscript>` and then runs the handler; the
+      same holds for `noframes` and `noembed` with scripting off, and a
+      `comment` element's content is markup to every current browser.  The
+      filter also keeps the text after a start tag with no matching end tag,
+      which it used to discard to the end of the chunk, and keeps a `<` that
+      opens no tag.
     * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
       relative-only URL policy.  It allows URLs with neither a protocol nor
       an authority, but rejects absolute URLs and protocol-relative URLs such

--- a/change_log.md
+++ b/change_log.md
@@ -12,11 +12,15 @@ Most recent at top.
       came out unchanged under a policy allowing `noscript`, `style` with
       text and `img`.  A browser with scripting on reads `noscript` as raw
       text up to that inner `</noscript>` and then runs the handler; the
-      same holds for `noframes` and `noembed` with scripting off, and a
-      `comment` element's content is markup to every current browser.  The
+      same holds for `noframes` and `noembed` with scripting off.  The
       filter also keeps the text after a start tag with no matching end tag,
       which it used to discard to the end of the chunk, and keeps a `<` that
       opens no tag.
+    * The IE-only `comment` element is no longer read as raw text.  No
+      current browser reads it so, and its content was emitted unescaped, so
+      under a policy allowing `comment` with text a tag inside it reached
+      the browser unvetted.  Its content is now parsed, vetted and escaped
+      like any other element's.
     * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
       relative-only URL policy.  It allows URLs with neither a protocol nor
       an authority, but rejects absolute URLs and protocol-relative URLs such

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -27,8 +27,11 @@
 
 package org.owasp.html;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -79,9 +82,10 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    */
   transient boolean skipText = true;
   /**
-   * True while a kept {@code <style>} or {@code <script>} that is an allowed
-   * text container is open, so {@link #text} knows to vet its content for the
-   * tags the lexer hands over as text.  Maintained like {@link #skipText}.
+   * True while a kept element whose text the renderer emits unescaped, such
+   * as {@code <style>}, {@code <script>} or {@code <iframe>}, is open as an
+   * allowed text container, so {@link #text} knows to strip the tags the
+   * lexer hands over as text.  Maintained like {@link #skipText}.
    */
   private boolean inKeptCdataElement;
   /**
@@ -147,15 +151,12 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
   public void text(String textChunk) {
     if (!skipText) {
-      // Note: Only style and script are CDATA elements; noscript/noembed/noframes are PCDATA
-      // If inside a CDATA element (style/script) with allowTextIn, we need to filter out 
-      // HTML tags that aren't allowed because tags inside these blocks are reclassified 
-      // as UNESCAPED text by the lexer
+      // The renderer emits the text of a kept literal-content element as it
+      // is, so a tag in it would reach the browser as written.  stripTags
+      // says why none may.
       if (inKeptCdataElement
           && textChunk != null && textChunk.indexOf('<') >= 0) {
-        // Strip out HTML tags that aren't in the allowed elements list
-        String filtered = stripDisallowedTags(textChunk);
-        out.text(filtered);
+        out.text(stripTags(textChunk));
       } else {
         out.text(textChunk);
       }
@@ -163,142 +164,133 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   }
   
   /**
-   * Strips out HTML tags that aren't in the allowed elements list from text content.
-   * This is used when tags appear inside text containers (like style blocks) where
-   * they're treated as text but should still be validated.
+   * Removes every tag from a chunk of the text of a kept literal-content
+   * element such as {@code style}, {@code script} or {@code iframe}.
+   * <p>
+   * A browser reads such text literally, so a tag in it is at best noise.
+   * It is also where the sanitizer and a browser can disagree about which
+   * element the text is in: a browser with scripting on reads
+   * {@code noscript} as raw text up to the first {@code </noscript>}, and
+   * reads {@code noframes} and {@code noembed} that way always, while the
+   * sanitizer treats all three as ordinary containers.  A
+   * {@code </noscript>} inside a {@code style} nested in a {@code noscript}
+   * therefore ends the {@code noscript} for the browser, and whatever
+   * follows is parsed as markup (CVE-2025-66021).  So no end tag may
+   * survive, whatever element it names, and no start tag is re-emitted:
+   * an allowed element's start tag used to be copied through with its
+   * attributes unvetted, which put an event handler after the breakout.
+   * <p>
+   * A start tag goes together with everything up to its matching end tag
+   * when this chunk has one, so that {@code <script>alert(1)</script>}
+   * inside a style block goes entirely; a start tag with no matching end
+   * tag goes alone and the text after it stays.  A {@code <} that opens no
+   * tag, because no {@code >} follows it in the chunk, is text and stays,
+   * except where a later chunk could complete it into an end tag: an end tag
+   * needs its {@code </} to start here, so a {@code <} that ends the chunk
+   * or is followed by {@code /} goes.  Text arrives in chunks whose
+   * boundaries fall anywhere, so each chunk has to be safe on its own.
    */
-  private String stripDisallowedTags(String text) {
-    if (text == null) {
-      return text;
-    }
-    
-    StringBuilder result = new StringBuilder();
+  private static String stripTags(String text) {
     int len = text.length();
+    // Find every tag, and pair each start tag with the end tag that matches
+    // it, counting nested tags of the same name, the way brackets pair.  One
+    // pass, so that a chunk full of unmatched start tags stays linear.
+    List<int[]> tags = new ArrayList<>();
+    Map<String, Deque<Integer>> unmatchedStarts = new HashMap<>();
     int i = 0;
-    
     while (i < len) {
       int tagStart = text.indexOf('<', i);
-      if (tagStart < 0) {
-        // No more tags, append the rest
-        result.append(text.substring(i));
-        break;
-      }
-      
-      // Append text before the tag
-      if (tagStart > i) {
-        result.append(text.substring(i, tagStart));
-      }
-      
-      // Find the end of the tag (either '>' or end of string)
+      if (tagStart < 0) { break; }
       int tagEnd = text.indexOf('>', tagStart + 1);
-      if (tagEnd < 0) {
-        // Unclosed tag, skip it
-        i = tagStart + 1;
-        continue;
-      }
-      
-      // Extract the tag content (between < and >)
-      String tagContent = text.substring(tagStart + 1, tagEnd);
-      
-      // Only process if this looks like a valid HTML element tag
-      // Valid tags start with a letter or / followed by a letter
-      // Skip things like <, </>, <3, etc.
-      // Also handle tags with leading whitespace like < script>
-      boolean isValidTag = false;
-      String tagName = null;
-      
-      // Trim leading whitespace for tag name detection
-      String trimmedTagContent = tagContent.trim();
-      
-      if (trimmedTagContent.startsWith("/")) {
-        // Closing tag - must have / followed by a letter
-        if (trimmedTagContent.length() > 1) {
-          char firstChar = trimmedTagContent.charAt(1);
-          if (Character.isLetter(firstChar)) {
-            isValidTag = true;
-            tagName = trimmedTagContent.substring(1).trim().split("\\s")[0];
-            tagName = HtmlLexer.canonicalElementName(tagName);
-          }
+      if (tagEnd < 0) { break; }  // No '<' from here on starts a tag.
+      String trimmed = text.substring(tagStart + 1, tagEnd).trim();
+      boolean isEndTag = trimmed.startsWith("/");
+      String tagName = tagNameOf(trimmed, isEndTag);
+      int kind = tagName == null ? NOT_A_TAG : isEndTag ? END_TAG : START_TAG;
+      int[] tag = { tagStart, tagEnd + 1, -1, kind };
+      if (kind == START_TAG) {
+        Deque<Integer> starts = unmatchedStarts.get(tagName);
+        if (starts == null) {
+          starts = new ArrayDeque<>();
+          unmatchedStarts.put(tagName, starts);
         }
-      } else {
-        // Opening tag - must start with a letter (after trimming whitespace)
-        if (trimmedTagContent.length() > 0) {
-          char firstChar = trimmedTagContent.charAt(0);
-          if (Character.isLetter(firstChar)) {
-            isValidTag = true;
-            tagName = trimmedTagContent.split("\\s")[0];
-            tagName = HtmlLexer.canonicalElementName(tagName);
-          }
+        starts.push(tags.size());
+      } else if (kind == END_TAG) {
+        Deque<Integer> starts = unmatchedStarts.get(tagName);
+        if (starts != null && !starts.isEmpty()) {
+          tags.get(starts.pop())[MATCH_END] = tagEnd + 1;
         }
       }
-      
-      if (!isValidTag) {
-        // Not a valid HTML tag, just append it as-is
-        result.append('<').append(tagContent).append('>');
-        i = tagEnd + 1;
-        continue;
-      }
-      
-      // Check if it's a closing tag
-      if (tagContent.startsWith("/")) {
-        // Only allow closing tags if the element is allowed
-        if (elAndAttrPolicies.containsKey(tagName)) {
-          result.append('<').append(tagContent).append('>');
-        }
-        // Otherwise skip the closing tag
-        i = tagEnd + 1;
-      } else {
-        // Opening tag - only allow tags if the element is in the allowed list
-        if (elAndAttrPolicies.containsKey(tagName)) {
-          result.append('<').append(tagContent).append('>');
-          i = tagEnd + 1;
-        } else {
-          // Skip disallowed tag and its content until matching closing tag
-          i = tagEnd + 1;
-          // Track nesting level to find the matching closing tag
-          int nestingLevel = 1;
-          while (i < len && nestingLevel > 0) {
-            int nextTagStart = text.indexOf('<', i);
-            if (nextTagStart < 0) {
-              // No more tags, skip to end
-              i = len;
-              break;
-            }
-            int nextTagEnd = text.indexOf('>', nextTagStart + 1);
-            if (nextTagEnd < 0) {
-              // Unclosed tag, skip to end
-              i = len;
-              break;
-            }
-            String nextTagContent = text.substring(nextTagStart + 1, nextTagEnd);
-            String trimmedNextTagContent = nextTagContent.trim();
-            String nextTagName = trimmedNextTagContent.split("\\s")[0];
-            if (trimmedNextTagContent.startsWith("/")) {
-              // Closing tag
-              nextTagName = nextTagName.substring(1);
-              nextTagName = HtmlLexer.canonicalElementName(nextTagName);
-              if (nextTagName.equals(tagName)) {
-                nestingLevel--;
-                if (nestingLevel == 0) {
-                  // Found matching closing tag, skip it and continue
-                  i = nextTagEnd + 1;
-                  break;
-                }
-              }
-            } else {
-              // Opening tag
-              nextTagName = HtmlLexer.canonicalElementName(nextTagName);
-              if (nextTagName.equals(tagName)) {
-                nestingLevel++;
-              }
-            }
-            i = nextTagEnd + 1;
-          }
-        }
+      tags.add(tag);
+      i = tagEnd + 1;
+    }
+
+    StringBuilder result = new StringBuilder(len);
+    int pos = 0;
+    for (int[] tag : tags) {
+      if (tag[TAG_START] < pos) { continue; }  // Inside dropped content.
+      result.append(text, pos, tag[TAG_START]);
+      switch (tag[KIND]) {
+        case NOT_A_TAG:
+          // "<!-- -->", "</>", "<3" and the like are text.
+          result.append(text, tag[TAG_START], tag[TAG_END]);
+          pos = tag[TAG_END];
+          break;
+        case END_TAG:
+          pos = tag[TAG_END];
+          break;
+        default:
+          pos = tag[MATCH_END] >= 0 ? tag[MATCH_END] : tag[TAG_END];
+          break;
       }
     }
-    
+    // The rest holds no tag.  Each '<' in it is text, unless a later chunk
+    // could complete it into an end tag.
+    for (int c = pos; c < len; ++c) {
+      char ch = text.charAt(c);
+      if (ch != '<' || (c + 1 < len && text.charAt(c + 1) != '/')) {
+        result.append(ch);
+      }
+    }
     return result.toString();
+  }
+
+  /** Indices into the records {@link #stripTags} keeps for each tag. */
+  private static final int TAG_START = 0, TAG_END = 1, MATCH_END = 2, KIND = 3;
+  /** The kinds of record. */
+  private static final int NOT_A_TAG = 0, START_TAG = 1, END_TAG = 2;
+
+  /**
+   * The canonical name of the tag whose trimmed content between the angle
+   * brackets is {@code trimmed}, or null if it is not a tag.  A tag name
+   * starts with a letter; whitespace between {@code <} or {@code </} and the
+   * name is tolerated, which is stricter than a browser.
+   */
+  private static @Nullable String tagNameOf(String trimmed, boolean isEndTag) {
+    String body = isEndTag ? trimmed.substring(1).trim() : trimmed;
+    if (body.isEmpty() || !Character.isLetter(body.charAt(0))) {
+      return null;
+    }
+    return HtmlLexer.canonicalElementName(body.split("\\s")[0]);
+  }
+
+  /**
+   * True if the renderer emits the element's text as it is, without
+   * escaping, so that a tag in that text would reach the browser as written.
+   * Judged by the name the renderer emits: it renames {@code xmp},
+   * {@code listing} and {@code plaintext} to {@code pre} and escapes their
+   * text.
+   */
+  private static boolean isLiteralContentElement(String elementName) {
+    switch (HtmlTextEscapingMode.getModeForTag(
+                HtmlStreamRenderer.safeName(elementName))) {
+      case CDATA:
+      case CDATA_SOMETIMES:
+      case PLAIN_TEXT:
+        return true;
+      default:
+        return false;
+    }
   }
 
   public void openTag(String elementName, List<String> attrs) {
@@ -387,8 +379,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       skipText = !allowedTextContainers.contains(adjustedElementName)
           || disallowedTextContainers.contains(policies.elementName);
       inKeptCdataElement = inKeptCdataElement
-          || (("style".equals(adjustedElementName)
-               || "script".equals(adjustedElementName))
+          || (isLiteralContentElement(adjustedElementName)
               && allowedTextContainers.contains(adjustedElementName));
     }
     out.openTag(adjustedElementName, attrs);

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlTextEscapingMode.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlTextEscapingMode.java
@@ -98,7 +98,10 @@ public enum HtmlTextEscapingMode {
       //.put("noembed", CDATA_SOMETIMES)
       //.put("noframes", CDATA_SOMETIMES)
       //.put("noscript", CDATA_SOMETIMES)
-      j8().mapEntry("comment", CDATA_SOMETIMES),  // IE only
+      // The IE-only comment element is not here either: no current browser
+      // reads its content as raw text, so treating it so let markup inside
+      // it reach the browser unvetted and unescaped.  It is an unknown
+      // element, whose content is parsed and escaped like any other.
 
       // Runs till end of file.
       j8().mapEntry("plaintext", PLAIN_TEXT),

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -671,14 +671,16 @@ class HtmlSanitizerTest {
 
   /**
    * Test #3:
-   * Ensure that, if <div> is allowed, then <div> injected inside <style>
-   * is retained by the sanitizer (since it is now in the policy).
+   * A tag inside style text is text to a browser, never markup, so even an
+   * allowed element's tag goes, content and all.  It used to be copied
+   * through with its attributes unvetted, which is how an event handler
+   * could follow the breakout in test #7.
    */
   @Test
   void testCVE202566021_3() {
-    // Arrange: <div> is now allowed, so it should survive sanitization inside <style>.
+    // Arrange: <div> is allowed as an element, which buys it nothing as style text.
     String actualPayload = "<noscript><style>/* user content */.x { font-size: 12px; }<div id=\"good\">ALLOWED?</div></style></noscript>";
-    String expectedPayload = "<noscript><style>/* user content */.x { font-size: 12px; }<div id=\"good\">ALLOWED?</div></style></noscript>";
+    String expectedPayload = "<noscript><style>/* user content */.x { font-size: 12px; }</style></noscript>";
 
     HtmlPolicyBuilder htmlPolicyBuilder = new HtmlPolicyBuilder();
     PolicyFactory policy = htmlPolicyBuilder
@@ -696,13 +698,16 @@ class HtmlSanitizerTest {
   /**
    * Test #4:
    * Confirm that an attempt to prematurely close <style> with </noscript>, then inject a script,
-   * does not allow the injected script. Sanitizer closes elements properly and only emits allowed tags.
+   * does not allow the injected script.  The </noscript> goes too: a browser
+   * with scripting on reads noscript as raw text up to the first </noscript>
+   * and parses whatever follows as markup, so no end tag may survive in
+   * style text, whatever element it names.
    */
   @Test
   void testCVE202566021_4() {
     // Arrange: Try to break out of <style> and <noscript>, then add a script. Only style/noscript/p allowed.
     String actualPayload = "<noscript><style></noscript><script>alert(1)</script>";
-    String expectedPayload = "<noscript><style></noscript></style></noscript>";
+    String expectedPayload = "<noscript><style></style></noscript>";
 
     HtmlPolicyBuilder htmlPolicyBuilder = new HtmlPolicyBuilder();
     PolicyFactory policy = htmlPolicyBuilder
@@ -720,13 +725,14 @@ class HtmlSanitizerTest {
   /**
    * Test #5:
    * Like Test #4, but with <p> instead of <noscript>. Ensures sanitizer emits correctly closed tags
-   * and strips the injected script tag completely.
+   * and strips the injected script tag completely.  The </p> in the style
+   * text goes like every other end tag there, allowed element or not.
    */
   @Test
   void testCVE202566021_5() {
     // Arrange: Try to break out of <style> through <p>, then add a script. Only style/noscript/p allowed.
     String actualPayload = "<p><style></p><script>alert(1)</script>";
-    String expectedPayload = "<p><style></p></style></p>";
+    String expectedPayload = "<p><style></style></p>";
 
     HtmlPolicyBuilder htmlPolicyBuilder = new HtmlPolicyBuilder();
     PolicyFactory policy = htmlPolicyBuilder
@@ -761,6 +767,182 @@ class HtmlSanitizerTest {
 
     // Assert
     assertEquals(expectedPayload, sanitized);
+  }
+
+  /**
+   * Test #7:
+   * An allowed element's start tag inside style text used to be copied
+   * through with its attributes unvetted, and an end tag was kept when its
+   * element was allowed.  Together they let an event handler follow a
+   * {@code </noscript>} that a browser with scripting on honours as the end
+   * of the raw-text noscript.  Neither survives.
+   */
+  @Test
+  void testCVE202566021_7AllowedElementInStyleTextKeepsNoAttributes() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("noscript", "style", "img", "b")
+        .allowTextIn("style")
+        .allowAttributes("src").onElements("img")
+        .allowUrlProtocols("https")
+        .toFactory();
+
+    assertEquals(
+        "<noscript><style></style></noscript>",
+        policy.sanitize(
+            "<noscript><style></noscript>"
+            + "<img src=x onerror=alert(1)></style></noscript>"));
+    assertEquals(
+        "<noscript><style></style></noscript>",
+        policy.sanitize(
+            "<noscript><style></noscript>"
+            + "<b onmouseover=alert(1)>x</b></style></noscript>"));
+    // Outside any noscript the same tag is harmless, and treated the same.
+    assertEquals(
+        "<style></style>",
+        policy.sanitize("<style><img src=x onerror=alert(1)></style>"));
+  }
+
+  /**
+   * Test #8:
+   * noframes and noembed are raw text to a browser whether or not scripting
+   * is on, so they break out the same way, and every spelling of an end tag
+   * a browser accepts has to go: any case, trailing whitespace, or a slash
+   * before the {@code >}.
+   */
+  @Test
+  void testCVE202566021_8EveryEndTagLeavesStyleText() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("noframes", "noembed", "style", "b")
+        .allowTextIn("style")
+        .toFactory();
+
+    assertEquals(
+        "<noframes><style></style></noframes>",
+        policy.sanitize(
+            "<noframes><style></noframes>"
+            + "<b onmouseover=alert(1)>x</b></style></noframes>"));
+    assertEquals(
+        "<noembed><style></style></noembed>",
+        policy.sanitize(
+            "<noembed><style></NOEMBED ><b onclick=alert(1)>x</b>"
+            + "</style></noembed>"));
+    assertEquals(
+        "<style>a{} b{}</style>",
+        policy.sanitize("<style>a{} </noembed/></div></ b>b{}</style>"));
+  }
+
+  /**
+   * Test #9:
+   * iframe and comment content is literal to the renderer too, and used to
+   * escape the filter, which looked only for style and script.  A browser
+   * today parses the content of a comment element as markup outright.
+   */
+  @Test
+  void testCVE202566021_9OtherLiteralContentElements() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("noscript", "iframe", "comment", "img")
+        .allowTextIn("iframe", "comment")
+        .allowAttributes("src").onElements("img")
+        .allowUrlProtocols("https")
+        .toFactory();
+
+    assertEquals(
+        "<noscript><iframe></iframe></noscript>",
+        policy.sanitize(
+            "<noscript><iframe></noscript>"
+            + "<img src=x onerror=alert(1)></iframe></noscript>"));
+    assertEquals(
+        "<comment></comment>",
+        policy.sanitize("<comment><img src=x onerror=alert(1)></comment>"));
+  }
+
+  /**
+   * Test #10:
+   * Text reaches the policy in chunks whose boundaries fall anywhere, so a
+   * chunk that ends in {@code <}, or holds {@code </} with no {@code >},
+   * must not combine with the next chunk into an end tag.  A preprocessor
+   * that delivers one character at a time is the extreme case.
+   */
+  @Test
+  void testCVE202566021_10ChunkBoundariesCannotAssembleAnEndTag() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("noscript", "style", "img")
+        .allowTextIn("style")
+        .allowAttributes("src").onElements("img")
+        .withPreprocessor(r -> new HtmlStreamEventReceiverWrapper(r) {
+          @Override
+          public void text(String text) {
+            for (int i = 0, n = text.length(); i < n; ++i) {
+              underlying.text(text.substring(i, i + 1));
+            }
+          }
+        })
+        .toFactory();
+
+    assertEquals(
+        "<noscript><style>/noscript>img src=x onerror=alert(1)>"
+        + "</style></noscript>",
+        policy.sanitize(
+            "<noscript><style></noscript>"
+            + "<img src=x onerror=alert(1)></style></noscript>"));
+  }
+
+  /**
+   * A chunk of literal text full of start tags with no end tags is the
+   * worst case for pairing tags, since every one is searched for a match.
+   * Pairing is done in one pass, so this takes a fraction of a second; a
+   * search restarted from each tag takes minutes.
+   */
+  @Test
+  void testLongRunOfUnmatchedTagsInLiteralTextIsLinear() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("style").allowTextIn("style").toFactory();
+    int n = 200_000;
+    StringBuilder html = new StringBuilder("<style>");
+    StringBuilder expected = new StringBuilder("<style>");
+    for (int i = 0; i < n; ++i) {
+      html.append("<b>x");
+      expected.append('x');
+    }
+    html.append("</style>");
+    expected.append("</style>");
+
+    assertEquals(expected.toString(), p.sanitize(html.toString()));
+  }
+
+  /**
+   * The filter no longer discards the rest of a chunk after a start tag with
+   * no matching end tag, and keeps a {@code <} that opens no tag, so script
+   * and style text with a bare comparison survives.
+   */
+  @Test
+  void testLiteralTextKeepsWhatIsNotATag() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("script", "style")
+        .allowTextIn("script", "style")
+        .toFactory();
+
+    assertEquals(
+        "<script>if (a < b) x();</script>",
+        policy.sanitize("<script>if (a < b) x();</script>"));
+    assertEquals(
+        "<script>if (a<b) x();</script>",
+        policy.sanitize("<script>if (a<b) x();</script>"));
+    // A tag with no matching end tag goes alone; the text after it stays.
+    assertEquals(
+        "<script>var s = 'ad';</script>",
+        policy.sanitize("<script>var s = 'a<b'; var t = 'c>d';</script>"));
+    assertEquals(
+        "<style>a{}c{}</style>",
+        policy.sanitize("<style>a{}<b>c{}</style>"));
+    // With one, it goes with its content, as a script in a style block does.
+    assertEquals(
+        "<style>a{}c{}</style>",
+        policy.sanitize("<style>a{}<b>x<b>y</b>z</b>c{}</style>"));
+    // Not tags: a comment, an empty end tag, a bare bracket.
+    assertEquals(
+        "<style>a{}<!-- x --></>c<3{}</style>",
+        policy.sanitize("<style>a{}<!-- x --></>c<3{}</style>"));
   }
 
   @Test

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -833,15 +833,14 @@ class HtmlSanitizerTest {
 
   /**
    * Test #9:
-   * iframe and comment content is literal to the renderer too, and used to
-   * escape the filter, which looked only for style and script.  A browser
-   * today parses the content of a comment element as markup outright.
+   * iframe content is literal to the renderer too, and used to escape the
+   * filter, which looked only for style and script.
    */
   @Test
-  void testCVE202566021_9OtherLiteralContentElements() {
+  void testCVE202566021_9IframeContent() {
     PolicyFactory policy = new HtmlPolicyBuilder()
-        .allowElements("noscript", "iframe", "comment", "img")
-        .allowTextIn("iframe", "comment")
+        .allowElements("noscript", "iframe", "img")
+        .allowTextIn("iframe")
         .allowAttributes("src").onElements("img")
         .allowUrlProtocols("https")
         .toFactory();
@@ -851,20 +850,47 @@ class HtmlSanitizerTest {
         policy.sanitize(
             "<noscript><iframe></noscript>"
             + "<img src=x onerror=alert(1)></iframe></noscript>"));
-    assertEquals(
-        "<comment></comment>",
-        policy.sanitize("<comment><img src=x onerror=alert(1)></comment>"));
   }
 
   /**
    * Test #10:
+   * The IE-only comment element was read as raw text, but no current
+   * browser reads it so: its content is markup to all of them.  It used to
+   * be emitted unescaped, so a tag inside it reached the browser unvetted,
+   * and a start tag with no {@code >} of its own was completed by the
+   * {@code >} of the sanitizer's own end tag.  Its content is now parsed,
+   * vetted and escaped like any other element's.
+   */
+  @Test
+  void testCVE202566021_10CommentElementIsNotLiteralContent() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("comment", "img")
+        .allowTextIn("comment")
+        .allowAttributes("src").onElements("img")
+        .allowUrlProtocols("https")
+        .toFactory();
+
+    assertEquals(
+        "<comment><img src=\"x\" /></comment>",
+        policy.sanitize("<comment><img src=x onerror=alert(1)></comment>"));
+    assertEquals(
+        "<comment>x<img src=\"x\" /></comment>",
+        policy.sanitize(
+            "<comment>x<img src=x onerror=alert(1)//</comment>"));
+    assertEquals(
+        "<comment>a &lt;b&gt; c</comment>",
+        policy.sanitize("<comment>a &lt;b&gt; c</comment>"));
+  }
+
+  /**
+   * Test #11:
    * Text reaches the policy in chunks whose boundaries fall anywhere, so a
    * chunk that ends in {@code <}, or holds {@code </} with no {@code >},
    * must not combine with the next chunk into an end tag.  A preprocessor
    * that delivers one character at a time is the extreme case.
    */
   @Test
-  void testCVE202566021_10ChunkBoundariesCannotAssembleAnEndTag() {
+  void testCVE202566021_11ChunkBoundariesCannotAssembleAnEndTag() {
     PolicyFactory policy = new HtmlPolicyBuilder()
         .allowElements("noscript", "style", "img")
         .allowTextIn("style")


### PR DESCRIPTION
## Summary

Found while working on #463 and reported to the maintainer, who asked for a public PR.

The filter that the CVE-2025-66021 fix (d6e0463) put on the text of a kept `style` or `script` element re-emitted the start tag of any element the policy allowed, attributes and all, with no attribute policy run over it, and kept an end tag whenever its element was allowed. A browser with scripting on reads `noscript` as raw text up to the first `</noscript>` and parses what follows as markup, so under a policy allowing `noscript`, `style` with text and `img`:

```html
<noscript><style></noscript><img src=x onerror=alert(1)></style></noscript>
```

came out unchanged and runs the handler. The normal path strips `onerror`. `noframes` and `noembed` break out the same way regardless of scripting, and `iframe` content is literal to the renderer too but never reached the filter, which looked only for `style` and `script`.

The IE-only `comment` element was a separate hole: the sanitizer read its content as raw text and emitted it unescaped, while every current browser parses that content as markup, so a tag inside it reached the browser unvetted with no breakout needed. A reviewer also showed that, with the filter in place, a start tag with no `>` of its own inside `comment` text was completed by the `>` of the sanitizer's own `</comment>`. The element is no longer classified as literal content at all: its content is lexed as markup, vetted by the policy and escaped by the renderer, like any unknown element's.

- The filter now removes every tag from the text of any element whose content the renderer emits unescaped, end tags first of all, judged by the escaping mode of the name the renderer will use. `xmp`, `listing` and `plaintext` become `pre` and are escaped, so they are not affected.
- A start tag still goes with its content through a matching end tag in the same chunk, so `<script>alert(1)</script>` inside a style block goes entirely, but a start tag with no matching end tag now goes alone instead of taking the rest of the chunk with it, and a `<` that opens no tag stays, except where a following chunk could complete it into an end tag. That also fixes the pre-existing loss of `if (a < b)` in kept script text.
- Text arrives in chunks with boundaries anywhere, so each chunk is made safe on its own; a test delivers the content one character at a time through a preprocessor.
- Tests #3, #4 and #5 from the original fix pinned the re-emitted `div` and the kept `</noscript>` and `</p>`; their expectations now show those gone, with the reason in each javadoc.

## Test plan

- New tests in `HtmlSanitizerTest`: the `img` and `b` handler payloads through `noscript`, the same through `noframes` and `noembed` with every end tag spelling a browser accepts, `iframe` content, the `comment` element with a complete and with an unterminated start tag inside it, the one-character-chunk case, a chunk of 200,000 unmatched tags staying linear, and the fidelity cases for a bare `<`, an unmatched start tag and a matched one.
- All existing tests pass, with the three expectation changes above.
- `./mvnw clean verify` passes on JDK 11, 17, 21 and 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYF1WjZmwbGNrph7RDw2BS
