### PR TITLE
fix: Stop a Link Inside a Table Cell From Ending a Link Outside the Table

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,14 @@
 
 Most recent at top.
   * Next release
+    * A link inside a table cell, caption or template element, or an applet,
+      marquee or object, no longer ends a link open outside that element.
+      Browsers clear their active formatting elements to a marker on
+      entering those, so `<a><table><tr><td><a>` nests, as it does in the
+      DOM; the tag balancer used to close back to the outer link, taking the
+      inner table's cell, row and table with it, so a nested table's later
+      rows landed in the outer table.  A second link with no such element
+      between still ends the first, as in a browser.  Issue #333.
     * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
       relative-only URL policy.  It allows URLs with neither a protocol nor
       an authority, but rejects absolute URLs and protocol-relative URLs such

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -53,6 +53,20 @@ public class TagBalancingHtmlStreamEventReceiver
       METADATA.indexForName(HtmlElementNames.CUSTOM_ELEMENT_NAME);
   private static final int A_TAG = METADATA.indexForName("a");
   private static final int BODY_TAG = METADATA.indexForName("body");
+  /**
+   * Elements on entering which a browser puts a marker on its list of
+   * active formatting elements, so that an {@code a} opened inside one of
+   * them does not end an {@code a} open outside it: the cell, caption and
+   * template elements, and the legacy applet, marquee and object.
+   */
+  private static final BitSet FORMATTING_MARKERS = new BitSet();
+  static {
+    for (String name : new String[] {
+             "applet", "caption", "marquee", "object", "td", "template", "th",
+         }) {
+      FORMATTING_MARKERS.set(METADATA.indexForName(name));
+    }
+  }
 
   private static final boolean DEBUG = false;
 
@@ -187,6 +201,22 @@ public class TagBalancingHtmlStreamEventReceiver
     }
   }
 
+  /**
+   * True if an {@code a} is open above the nearest formatting marker, which
+   * is when a browser ends it before opening another {@code a}: the
+   * adoption agency algorithm runs for an {@code a} on the list of active
+   * formatting elements after the last marker, and a link inside a table
+   * cell leaves one outside the table alone.
+   */
+  private boolean hasOpenLinkInFormattingScope() {
+    for (int i = openElements.size(); --i >= 0;) {
+      int openElementIndex = openElements.get(i);
+      if (openElementIndex == A_TAG) { return true; }
+      if (FORMATTING_MARKERS.get(openElementIndex)) { return false; }
+    }
+    return false;
+  }
+
   private void prepareForContent(int elIndex) {
     int nOpen = openElements.size();
     {
@@ -223,8 +253,7 @@ public class TagBalancingHtmlStreamEventReceiver
       // Close all the elements that cannot contain the content to open.
       while (true) {
         boolean canContain = canContain(elIndex, top, nOpen - 1)
-            && !(elIndex == A_TAG
-                 && openElements.lastIndexOf(A_TAG) >= 0);
+            && !(elIndex == A_TAG && hasOpenLinkInFormattingScope());
         if (canContain) {
           break;
         }

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -810,7 +810,8 @@ class HtmlSanitizerTest {
             + "</a></th></tr></table></a>",
             "<a href=\"http://u\">x<a href=\"http://v\">y</a>z</a>",
          }) {
-      assertEquals(parseAsBrowser(html), parseAsBrowser(p.sanitize(html)), html);
+      assertEquals(
+          parseAsBrowser(html), parseAsBrowser(p.sanitize(html)), html);
     }
   }
 

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -33,7 +33,13 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 
+import java.io.StringReader;
+
+import nu.validator.htmlparser.dom.HtmlDocumentBuilder;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -761,6 +767,86 @@ class HtmlSanitizerTest {
 
     // Assert
     assertEquals(expectedPayload, sanitized);
+  }
+
+  /**
+   * A link inside a table cell inside a link stays where it is: a browser
+   * clears its active formatting elements to a marker on entering the cell,
+   * so the inner {@code a} does not end the outer one.  The balancer used to
+   * close back to the outer {@code a}, taking the inner table's cell, row
+   * and table with it, so that table's second row landed in the outer table
+   * (#333).  The parser check reads both the input and the output the way a
+   * browser does and compares the trees.
+   */
+  @Test
+  void testLinkInsideCellInsideLinkKeepsTheTableTogether() throws Exception {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("a", "table", "tbody", "tr", "td", "th", "caption")
+        .allowAttributes("href").onElements("a")
+        .allowUrlProtocols("http")
+        .toFactory();
+    String input = "<table><tr><td><a href=\"http://b.example\">"
+        + "<table><tbody>"
+        + "<tr><td><a href=\"http://b.example\">11111</a></td></tr>"
+        + "<tr><td><a href=\"http://b.example\">22222</a></td></tr>"
+        + "</tbody></table></a></td></tr></table>";
+    String out = p.sanitize(input);
+
+    assertEquals(
+        "<table><tbody><tr><td><a href=\"http://b.example\">"
+        + "<table><tbody>"
+        + "<tr><td><a href=\"http://b.example\">11111</a></td></tr>"
+        + "<tr><td><a href=\"http://b.example\">22222</a></td></tr>"
+        + "</tbody></table></a></td></tr></tbody></table>",
+        out);
+    assertEquals(parseAsBrowser(input), parseAsBrowser(out));
+
+    // caption and th are markers too; a link straight inside a link is not,
+    // and the second still ends the first, as in a browser.
+    for (String html : new String[] {
+            "<a href=\"http://u\"><table><caption><a href=\"http://v\">c"
+            + "</a></caption></table></a>",
+            "<a href=\"http://u\"><table><tr><th><a href=\"http://v\">h"
+            + "</a></th></tr></table></a>",
+            "<a href=\"http://u\">x<a href=\"http://v\">y</a>z</a>",
+         }) {
+      assertEquals(parseAsBrowser(html), parseAsBrowser(p.sanitize(html)), html);
+    }
+  }
+
+  /** The tree a browser builds from html, one node per line. */
+  private static String parseAsBrowser(String html) throws Exception {
+    Node fragment = new HtmlDocumentBuilder().parseFragment(
+        new InputSource(new StringReader(html)), "body");
+    StringBuilder sb = new StringBuilder();
+    appendTree(fragment, "", sb);
+    return sb.toString();
+  }
+
+  private static void appendTree(Node node, String indent, StringBuilder sb) {
+    switch (node.getNodeType()) {
+      case Node.ELEMENT_NODE:
+        sb.append(indent).append('<').append(node.getNodeName());
+        NamedNodeMap attrs = node.getAttributes();
+        for (int i = 0, n = attrs.getLength(); i < n; ++i) {
+          Node attr = attrs.item(i);
+          sb.append(' ').append(attr.getNodeName())
+              .append('=').append(attr.getNodeValue());
+        }
+        sb.append(">\n");
+        indent += "  ";
+        break;
+      case Node.TEXT_NODE:
+        sb.append(indent).append('"').append(node.getNodeValue())
+            .append("\"\n");
+        break;
+      default:
+        break;
+    }
+    for (Node child = node.getFirstChild(); child != null;
+         child = child.getNextSibling()) {
+      appendTree(child, indent, sb);
+    }
   }
 
   @Test

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -598,4 +598,74 @@ class TagBalancingHtmlStreamRendererTest {
         "<div><menu><menuitem></menuitem><menuitem></menuitem></menu></div>",
         htmlOutputBuffer.toString());
   }
+
+  /**
+   * A browser clears its list of active formatting elements to a marker on
+   * entering a table cell, so an {@code a} opened inside the cell does not
+   * end an {@code a} open outside the table (#333).  The balancer used to
+   * close back to any open {@code a}, taking the cell, row and table with
+   * it.
+   */
+  @Test
+  void testLinkInsideCellInsideLinkStaysNested() {
+    balancer.openDocument();
+    balancer.openTag("a", j8().listOf("href", "u"));
+    balancer.openTag("table", j8().listOf());
+    balancer.openTag("tr", j8().listOf());
+    balancer.openTag("td", j8().listOf());
+    balancer.openTag("a", j8().listOf("href", "v"));
+    balancer.text("1");
+    balancer.closeTag("a");
+    balancer.closeTag("td");
+    balancer.closeTag("tr");
+    balancer.closeTag("table");
+    balancer.closeTag("a");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<a href=\"u\"><table><tbody><tr><td><a href=\"v\">1</a></td></tr>"
+        + "</tbody></table></a>",
+        htmlOutputBuffer.toString());
+  }
+
+  /** The other elements a browser puts a marker on entering do the same. */
+  @Test
+  void testLinkInsideFormattingMarkerInsideLinkStaysNested() {
+    for (String marker
+         : new String[] { "applet", "marquee", "object", "template" }) {
+      createBalancer();
+      balancer.openDocument();
+      balancer.openTag("a", j8().listOf("href", "u"));
+      balancer.openTag(marker, j8().listOf());
+      balancer.openTag("a", j8().listOf("href", "v"));
+      balancer.text("x");
+      balancer.closeTag("a");
+      balancer.closeTag(marker);
+      balancer.closeTag("a");
+      balancer.closeDocument();
+
+      assertEquals(
+          "<a href=\"u\"><" + marker + "><a href=\"v\">x</a></" + marker
+          + "></a>",
+          htmlOutputBuffer.toString(), marker);
+    }
+  }
+
+  /** With no marker between them, a second {@code a} still ends the first. */
+  @Test
+  void testLinkInsideLinkStillEndsIt() {
+    balancer.openDocument();
+    balancer.openTag("a", j8().listOf("href", "u"));
+    balancer.text("x");
+    balancer.openTag("a", j8().listOf("href", "v"));
+    balancer.text("y");
+    balancer.closeTag("a");
+    balancer.text("z");
+    balancer.closeTag("a");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<a href=\"u\">x</a><a href=\"v\">y</a>z",
+        htmlOutputBuffer.toString());
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #333.

The tag balancer ended any open `a` when another `a` opened, wherever the two stood, and closed everything between them on the way. For a link inside a table cell inside a link that meant the inner table's cell, row and table, so the inner table's later rows landed in the outer table, which is the reordering the issue shows.

- Browsers clear the list of active formatting elements to a marker on entering a `td`, `th`, `caption` or `template`, or an `applet`, `marquee` or `object`, and the adoption agency algorithm only reaches an `a` after the last marker. A link inside those therefore nests within one outside, and the balancer now looks for an open `a` only above the nearest such element, using the element set its scope tables already list.
- A second link with nothing of the kind between still ends the first, as in a browser.
- Output stays a tree browsers reproduce unchanged: `<a>` around a table with a link in a cell is what a browser builds from the same input.

## Test plan

- Balancer tests for a link in a cell, in each of the other marker elements, and straight inside a link.
- An end-to-end test in `HtmlSanitizerTest` with the input from #333, asserting the output and, through the validator.nu parser already in test scope, that the browser tree of the output equals the browser tree of the input; the same differential check covers `caption`, `th`, and the unmarked case.
- `./mvnw clean verify` passes on JDK 11, 17, 21 and 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYF1WjZmwbGNrph7RDw2BS
