### PR TITLE
fix: Drop a Tag the Input Ends Inside and Read a Bogus End Tag as a Comment

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,14 @@
 
 Most recent at top.
   * Next release
+    * Two tokenizer differences from browsers are gone.  A tag that the
+      input ends inside, such as `x<p ` or `<p class=">y</p>`, is dropped
+      whole, as a browser drops it, instead of being opened with the
+      attributes read so far; the text before it stands.  And `</` followed
+      by anything but a letter is a bogus comment running to the next `>`,
+      so `<p></>z` gives `<p>z</p>` and `</"<p>y</p>` swallows the `<p>`, as
+      in a browser; `</` at the end of input is text.  Literal content such
+      as script and style text is unaffected.  Issue #410.
     * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
       relative-only URL policy.  It allows URLs with neither a protocol nor
       an authority, but rejects absolute URLs and protocol-relative URLs such

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlLexer.java
@@ -490,6 +490,8 @@ final class HtmlInputSplitter extends AbstractTokenStream {
     DIRECTIVE,
     DONE,
     BOGUS_COMMENT,
+    /** After "</" and a character that cannot start a tag name. */
+    END_TAG_BOGUS_COMMENT,
     SERVER_CODE,
     SERVER_CODE_PCT,
     ;
@@ -664,13 +666,25 @@ final class HtmlInputSplitter extends AbstractTokenStream {
                 case SLASH:
                   if (Character.isLetter(ch)) {
                     state = State.TAGNAME;
-                  } else {
+                  } else if (this.inEscapeExemptBlock) {
+                    // Literal content: "</" not followed by a letter is
+                    // text, as it is in a browser's RAWTEXT state.
                     if ('<' == ch) {
                       type = HtmlTokenType.TEXT;
                     } else {
                       ++end;
                     }
                     break charloop;
+                  } else if ('>' == ch) {
+                    // "</>" is a missing-end-tag-name error for which a
+                    // browser emits nothing, so it is an empty comment here.
+                    type = HtmlTokenType.COMMENT;
+                    state = State.DONE;
+                  } else {
+                    // Anything else after "</" is an
+                    // invalid-first-character-of-tag-name error that starts
+                    // a bogus comment running to the next '>'.
+                    state = State.END_TAG_BOGUS_COMMENT;
                   }
                   break;
                 case BANG:
@@ -764,6 +778,12 @@ final class HtmlInputSplitter extends AbstractTokenStream {
                     state = State.DONE;
                   }
                   break;
+                case END_TAG_BOGUS_COMMENT:
+                  if ('>' == ch) {
+                    type = HtmlTokenType.COMMENT;
+                    state = State.DONE;
+                  }
+                  break;
                 case SERVER_CODE:
                   if ('%' == ch) {
                     state = State.SERVER_CODE_PCT;
@@ -790,6 +810,11 @@ final class HtmlInputSplitter extends AbstractTokenStream {
                   break;
                 case BOGUS_COMMENT:
                   type = HtmlTokenType.QMARKMETA;
+                  break;
+                case END_TAG_BOGUS_COMMENT:
+                  // A bogus comment that runs to the end of input is still a
+                  // comment.
+                  type = HtmlTokenType.COMMENT;
                   break;
                 case COMMENT:
                 case COMMENT_DASH:

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -160,17 +160,27 @@ public final class HtmlSanitizer {
           if (htmlContent.charAt(token.start + 1) == '/') {  // A close tag.
             String elementName = HtmlLexer.canonicalElementName(
                 htmlContent.substring(token.start + 2, token.end));
-            receiver.closeTag(elementName);
-            while (lexer.hasNext()
-                   && lexer.next().type != HtmlTokenType.TAGEND) {
+            boolean ended = false;
+            while (lexer.hasNext()) {
               // skip tokens until we see a ">"
+              if (lexer.next().type == HtmlTokenType.TAGEND) {
+                ended = true;
+                break;
+              }
             }
+            if (!ended) {
+              // The input ended inside the tag.  A browser drops the tag
+              // whole, so there is nothing to close.
+              break;
+            }
+            receiver.closeTag(elementName);
             foreignContent.processEndTag(elementName);
           } else {
             attrs.clear();
 
             boolean attrsReadyForName = true;
             boolean selfClosing = false;
+            boolean ended = false;
             tagBody:
             while (lexer.hasNext()) {
               HtmlToken tagBodyToken = lexer.next();
@@ -196,10 +206,16 @@ public final class HtmlSanitizer {
                   // greater-than sign when the tokenizer is in a state where
                   // the solidus sets the self-closing flag.
                   selfClosing = htmlContent.charAt(tagBodyToken.start) == '/';
+                  ended = true;
                   break tagBody;
                 default:
                   // Just drop anything not recognized
               }
+            }
+            if (!ended) {
+              // The input ended inside the tag.  A browser drops the tag
+              // whole, attributes and all; the text before it stands.
+              break;
             }
             if (!attrsReadyForName) {
               attrs.add(attrs.getLast());

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlLexerTest.java
@@ -71,6 +71,35 @@ class HtmlLexerTest {
     assertTokens("</div\n", "TAGBEGIN: </div");
   }
 
+  /**
+   * After {@code </}, only a letter starts an end tag.  A browser drops
+   * {@code </>} outright, turns anything else into a bogus comment that
+   * runs to the next {@code >}, and takes {@code </} at the end of input as
+   * text (#410).  Inside literal content none of that applies.
+   */
+  @Test
+  void testEndTagOpenFollowedByANonLetter() {
+    assertTokens("</>", "COMMENT: </>");
+    assertTokens("</ notatag>x", "COMMENT: </ notatag>", "TEXT: x");
+    assertTokens(
+        "</\"<p>y</p>",
+        "COMMENT: </\"<p>", "TEXT: y", "TAGBEGIN: </p", "TAGEND: >");
+    assertTokens("</<p>y", "COMMENT: </<p>", "TEXT: y");
+    // Unterminated, the bogus comment runs to the end of input.
+    assertTokens("</\"", "COMMENT: </\"");
+    assertTokens("</", "TEXT: </");
+    assertTokens("a</", "TEXT: a</");
+    // Literal content is text whatever follows "</", up to its end tag.
+    assertTokens(
+        "<script></\"</script>",
+        "TAGBEGIN: <script", "TAGEND: >", "UNESCAPED: </\"",
+        "TAGBEGIN: </script", "TAGEND: >");
+    assertTokens(
+        "<style>a</ b</style>",
+        "TAGBEGIN: <style", "TAGEND: >", "UNESCAPED: a</ b",
+        "TAGBEGIN: </style", "TAGEND: >");
+  }
+
   @Test
   void testPartialTagInCData() {
     assertTokens(
@@ -129,7 +158,10 @@ class HtmlLexerTest {
         "ATTRNAME: href",
         "ATTRVALUE: \"/\"",
         "TAGEND: >",
-        "TEXT: first part of the text</> second part");
+        "TEXT: first part of the text",
+        // "</>" is nothing to a browser: an empty comment here.
+        "COMMENT: </>",
+        "TEXT:  second part");
     assertTokens(
         "<p/b/",
         "TAGBEGIN: <p",

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -393,11 +393,14 @@ class HtmlSanitizerTest {
     //
     //      All could be fine if this form typo-that-happens-to-be-legal was
     //      properly implemented in contemporary HTML user-agents. It is not.
-    assertEquals("<p></p>", sanitize("<p/b/"));  // Short-tag discarded.
+    // Short-tag discarded, and since the input ends inside the tag, the tag
+    // goes with it, as in a browser (#410).
+    assertEquals("", sanitize("<p/b/"));
     assertEquals("<p></p>", sanitize("<p<b>"));  // Discard <b attribute
     assertEquals(
-        // This behavior for short tags is not ideal, but it is safe.
-        "<p href=\"/\">first part of the text&lt;/&gt; second part</p>",
+        // This behavior for short tags is not ideal, but it is safe.  The
+        // "</>" is nothing to a browser, and nothing here (#410).
+        "<p href=\"/\">first part of the text second part</p>",
         sanitize("<p<a href=\"/\">first part of the text</> second part"));
   }
 
@@ -763,6 +766,39 @@ class HtmlSanitizerTest {
     assertEquals(expectedPayload, sanitized);
   }
 
+  /**
+   * Two tokenizer differences left over from #189 (#410).  A tag that the
+   * input ends inside is dropped whole, as a browser drops it, rather than
+   * opened with whatever attributes had been read; and {@code </} followed
+   * by anything but a letter is a bogus comment running to the next
+   * {@code >}, or text at the end of input, rather than text up to the next
+   * tag.
+   */
+  @Test
+  void testIssue410EofInTagAndBogusEndTags() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("p", "b")
+        .allowAttributes("class", "x").onElements("p")
+        .toFactory();
+
+    // End of input inside a tag: the tag goes, the text before it stays.
+    assertEquals("x", p.sanitize("x<p "));
+    assertEquals("", p.sanitize("<p class=\">y</p>"));
+    assertEquals(
+        "<p>foo</p> ",
+        p.sanitize("<p>foo</p> <p class=\"test\" \"=\">bar</p> <p>baz</p>"));
+    // An end tag the input ends inside goes too; the balancer closes the
+    // element at the end as it would have anyway.
+    assertEquals("<b>x</b>", p.sanitize("<b>x</b"));
+    assertEquals("<b>x</b>", p.sanitize("<b>x</b class"));
+
+    // "</" and a non-letter.
+    assertEquals("<p>z</p>", p.sanitize("<p></>z"));
+    assertEquals("<p x=\"x\">y</p>", p.sanitize("<p x></\"<p>y</p>"));
+    assertEquals("<b>xy</b>", p.sanitize("<b>x</ b>y"));
+    assertEquals("a&lt;/", p.sanitize("a</"));
+  }
+
   @Test
   void testIssue189StrayQuoteInTag() {
     // A quote that does not directly follow an attribute name and '=' is part
@@ -781,9 +817,10 @@ class HtmlSanitizerTest {
     assertEquals("<p class=\"p-x\">y</p>", sanitize("<p class=\"x\"/=\">y</p>"));
     assertEquals("<p>y</p>", sanitize("<p title/=\">y</p>"));
     // Here the second quote does follow '=', so it begins a value that never
-    // closes; browsers hit EOF inside the tag and drop everything from it on.
+    // closes; browsers hit EOF inside the tag and drop everything from it on,
+    // and so does the sanitizer (#410).
     assertEquals(
-        "<p>foo</p> <p class=\"p-test\"></p>",
+        "<p>foo</p> ",
         sanitize("<p>foo</p> <p class=\"test\" \"=\">bar</p> <p>baz</p>"));
   }
 

--- a/owasp-java-html-sanitizer/src/test/resources/org/owasp/html/htmllexergolden1.txt
+++ b/owasp-java-html-sanitizer/src/test/resources/org/owasp/html/htmllexergolden1.txt
@@ -88,7 +88,9 @@ COMMENT    [<!-- some tokenization corner cases -->]  :  891-930
 TEXT       [\n\n< notatag ]  :  930-942
 TAGBEGIN   [<atag]  :  942-947
 TAGEND     [/>]  :  947-949
-TEXT       [\n\n</ notatag> ]  :  949-963
+TEXT       [\n\n]  :  949-951
+COMMENT    [</ notatag>]  :  951-962
+TEXT       [ ]  :  962-963
 TAGBEGIN   [</redundantlyclosed]  :  963-982
 TAGEND     [/>]  :  982-984
 TEXT       [\n\n]  :  984-986


### PR DESCRIPTION
## Summary

Fixes #410.

Two tokenizer differences from browsers that the differential fuzz run for #409 left standing.

- **A tag the input ends inside is dropped whole.** The sanitizer read a tag's attributes until the lexer ran dry and then opened the tag with whatever it had, so `x<p ` gave `x<p></p>` and `<p class=">y</p>` gave a `p` carrying the rest of the document as a class. A browser hits end of input inside the tag and drops it, which the sanitizer now does too, for start and end tags alike; the text before the tag stands. The lexer still emits the partial `TAGBEGIN`, so its own tests are unchanged; the decision lives in the sanitizer loop, next to the foreign-content tracker, which is not told about a dropped tag.
- **`</` followed by a non-letter is a bogus comment.** The lexer took it as text running to the next `<`, so `<p></>z` showed `</>` as text and `</"<p>y</p>` opened the `p` that a browser never sees. Per the WHATWG end-tag-open state, `</>` emits nothing, any other non-letter starts a bogus comment running to the next `>`, and `</` at the end of input is text. The lexer now produces a `COMMENT` token for the first two, which the sanitizer drops as it drops every comment. Inside literal content such as script and style text, `</` stays text, as in a browser's RAWTEXT state.

Three expectations changed to the browser's reading: the lexer golden file's `</ notatag>`, the short-tag test's `</>` and `<p/b/`, and the #189 test's tag left open at end of input, each with the reason in place.

## Test plan

- New lexer test covering `</>`, `</ notatag>`, `</"<p>`, `</<p>`, an unterminated bogus comment, `</` at end of input, and `</` inside script and style content.
- New sanitizer test covering the issue's table end to end, plus end tags the input ends inside.
- The existing suite passes with the three expectation changes above.
- `./mvnw clean verify` passes on JDK 11, 17, 21 and 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYF1WjZmwbGNrph7RDw2BS
