### PR TITLE
fix: Report Policy-Filtered Literal Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ String sanitizedHtml = myPolicyFactory.sanitize(
 was then dropped for having none left, such as a link whose only `href` was
 rejected.  Two default methods carry more detail for listeners that override
 them: `discardedAttribute` receives each rejected attribute's value, and
-`discardedText` receives content the renderer could not emit from a kept
-`script` or `style` element.
+`discardedText` receives tag-like content the policy removed from a kept
+literal-content element, and content the renderer could not emit from one.
 
 **Note**: If a string sanitizes with no change notifications, it is not the case
 that the input string is necessarily safe to use. Only use the output of the sanitizer.
@@ -194,7 +194,7 @@ that the input string is necessarily safe to use. Only use the output of the san
 The sanitizer ensures that the output is in a sub-set of HTML that commonly
 used HTML parsers will agree on the meaning of, but the absence of
 notifications does not mean that the input is in such a sub-set,
-only that it does not contain elements or attributes that were removed.
+only that it does not contain structural content that was removed.
 
 See ["Why sanitize when you can validate"](https://github.com/OWASP/java-html-sanitizer/blob/main/docs/html-validation.md) for more on this topic.
 

--- a/change_log.md
+++ b/change_log.md
@@ -55,8 +55,14 @@ Most recent at top.
       because it could not be emitted safely, such as a `-->` with no comment
       open.  Such drops were invisible to the listener.  The report comes
       from `HtmlStreamRenderer`, which `PolicyFactory.sanitize` uses; a
-      sanitizer built with `PolicyFactory.apply` on another receiver reports
-      tags and attributes only.  Issue #155.
+      sanitizer built with `PolicyFactory.apply` on another receiver cannot
+      report this renderer-side loss.  Issue #155.
+    * `HtmlChangeListener.discardedText` now also reports tag-like ranges the
+      policy removes from the text of a kept `script`, `style`, `iframe` or
+      other literal-content element.  Such ranges arrive from the lexer as
+      text rather than tag events, so an injection attempt like
+      `<style><img onerror=alert(1)></style>` was removed silently instead of
+      reaching an intrusion-detection listener.  Issue #468.
     * `HtmlPolicyBuilder.allowOnlyRelativeUrls()` now provides an explicit
       relative-only URL policy.  It allows URLs with neither a protocol nor
       an authority, but rejects absolute URLs and protocol-relative URLs such

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -50,7 +50,8 @@ import static org.owasp.shim.Java8Shim.j8;
 class ElementAndAttributePolicyBasedSanitizerPolicy
     implements HtmlSanitizer.Policy,
                TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy,
-               HtmlChangeReporter.AttributelessSkipPolicy {
+               HtmlChangeReporter.AttributelessSkipPolicy,
+               HtmlChangeReporter.DroppedTextSource {
   final Map<String, ElementAndAttributePolicies> elAndAttrPolicies;
   final Set<String> allowedTextContainers;
   /**
@@ -90,6 +91,12 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    */
   private boolean inKeptCdataElement;
   /**
+   * The adjusted name of the outermost kept literal-content element, or null
+   * outside one.  This accompanies {@link #inKeptCdataElement} so a listener
+   * can identify the element whose text the policy filtered.
+   */
+  private @Nullable String keptCdataElementName;
+  /**
    * Alternating input names and adjusted names of elements opened by the
    * caller.
    */
@@ -102,6 +109,11 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   private final BitSet skipTextBeforeOpen = new BitSet();
   /** The same for {@link #inKeptCdataElement}. */
   private final BitSet inKeptCdataBeforeOpen = new BitSet();
+  /** The same for {@link #keptCdataElementName}; entries may be null. */
+  private final List<String> keptCdataNameBeforeOpen = new ArrayList<>();
+
+  /** Told about filtered literal content; null while nobody is listening. */
+  private @Nullable HtmlStreamRenderer.DroppedTextListener droppedTextListener;
 
   ElementAndAttributePolicyBasedSanitizerPolicy(
       HtmlStreamEventReceiver out,
@@ -137,10 +149,13 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   public void openDocument() {
     skipText = false;
     inKeptCdataElement = false;
+    keptCdataElementName = null;
+    droppedTextListener = null;
     skippedLastTagAsAttributeless = false;
     openElementStack.clear();
     skipTextBeforeOpen.clear();
     inKeptCdataBeforeOpen.clear();
+    keptCdataNameBeforeOpen.clear();
     out.openDocument();
   }
 
@@ -154,9 +169,16 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     openElementStack.clear();
     skipTextBeforeOpen.clear();
     inKeptCdataBeforeOpen.clear();
+    keptCdataNameBeforeOpen.clear();
     skipText = true;
     inKeptCdataElement = false;
+    keptCdataElementName = null;
     out.closeDocument();
+  }
+
+  public void reportDroppedTextTo(
+      @Nullable HtmlStreamRenderer.DroppedTextListener listener) {
+    this.droppedTextListener = listener;
   }
 
   public void text(String textChunk) {
@@ -166,7 +188,11 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       // says why none may.
       if (inKeptCdataElement
           && textChunk != null && textChunk.indexOf('<') >= 0) {
-        out.text(stripTags(textChunk));
+        String elementName = keptCdataElementName;
+        if (elementName == null) {
+          throw new IllegalStateException("Missing literal-content element");
+        }
+        out.text(stripTags(textChunk, elementName));
       } else {
         out.text(textChunk);
       }
@@ -199,8 +225,9 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    * needs its {@code </} to start here, so a {@code <} that ends the chunk
    * or is followed by {@code /} goes.  Text arrives in chunks whose
    * boundaries fall anywhere, so each chunk has to be safe on its own.
+   * Each exact range removed is also sent to {@link #droppedTextListener}.
    */
-  private static String stripTags(String text) {
+  private String stripTags(String text, String elementName) {
     int len = text.length();
     // Find every tag, and pair each start tag with the end tag that matches
     // it, counting nested tags of the same name, the way brackets pair.  One
@@ -247,10 +274,13 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
           pos = tag[TAG_END];
           break;
         case END_TAG:
+          reportDroppedText(elementName, text, tag[TAG_START], tag[TAG_END]);
           pos = tag[TAG_END];
           break;
         default:
-          pos = tag[MATCH_END] >= 0 ? tag[MATCH_END] : tag[TAG_END];
+          int dropEnd = tag[MATCH_END] >= 0 ? tag[MATCH_END] : tag[TAG_END];
+          reportDroppedText(elementName, text, tag[TAG_START], dropEnd);
+          pos = dropEnd;
           break;
       }
     }
@@ -260,9 +290,19 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       char ch = text.charAt(c);
       if (ch != '<' || (c + 1 < len && text.charAt(c + 1) != '/')) {
         result.append(ch);
+      } else {
+        reportDroppedText(elementName, text, c, c + 1);
       }
     }
     return result.toString();
+  }
+
+  /** Reports one exact range removed from a literal-content text chunk. */
+  private void reportDroppedText(
+      String elementName, String text, int start, int end) {
+    if (droppedTextListener != null) {
+      droppedTextListener.droppedText(elementName, text.substring(start, end));
+    }
   }
 
   /** Indices into the records {@link #stripTags} keeps for each tag. */
@@ -382,6 +422,9 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
         openElementStack.subList(i, n).clear();
         skipText = skipTextBeforeOpen.get(i / 2);
         inKeptCdataElement = inKeptCdataBeforeOpen.get(i / 2);
+        keptCdataElementName = keptCdataNameBeforeOpen.get(i / 2);
+        keptCdataNameBeforeOpen.subList(
+            i / 2, keptCdataNameBeforeOpen.size()).clear();
         break;
       }
     }
@@ -397,9 +440,12 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       // text was disallowed in that.
       skipText = !allowedTextContainers.contains(adjustedElementName)
           || disallowedTextContainers.contains(policies.elementName);
-      inKeptCdataElement = inKeptCdataElement
-          || (isLiteralContentElement(adjustedElementName)
-              && allowedTextContainers.contains(adjustedElementName));
+      boolean enteringKeptCdata = isLiteralContentElement(adjustedElementName)
+          && allowedTextContainers.contains(adjustedElementName);
+      if (!inKeptCdataElement && enteringKeptCdata) {
+        keptCdataElementName = adjustedElementName;
+      }
+      inKeptCdataElement = inKeptCdataElement || enteringKeptCdata;
     }
     out.openTag(adjustedElementName, attrs);
   }
@@ -421,6 +467,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     int depth = openElementStack.size() / 2;
     skipTextBeforeOpen.set(depth, skipText);
     inKeptCdataBeforeOpen.set(depth, inKeptCdataElement);
+    keptCdataNameBeforeOpen.add(keptCdataElementName);
     openElementStack.add(elementName);
     openElementStack.add(adjustedElementName);
   }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeListener.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeListener.java
@@ -30,7 +30,7 @@ package org.owasp.html;
 import javax.annotation.Nullable;
 
 /**
- * Receives events when an HTML tag, or attribute is discarded.
+ * Receives events when an HTML tag, attribute, or text is discarded.
  * This can be hooked into an intrusion detection system to alert code when
  * suspicious HTML passes through the sanitizer.
  * <p>
@@ -83,23 +83,29 @@ public interface HtmlChangeListener<T> {
   }
 
   /**
-   * Called when the content of an element the policy kept could not be
-   * rendered and was dropped, leaving the element empty.  A {@code script}
-   * or {@code style} element cannot hold content that a browser would read
-   * as ending the element early or as opening a comment it never closes,
-   * such as a {@code -->} with no {@code <!--} before it, so the renderer
-   * drops the whole content rather than emit it.
+   * Called when text is discarded from an element the policy kept.  The
+   * policy removes tag-shaped ranges from literal content such as
+   * {@code <style>x<div>y</div></style>}, because a browser would receive
+   * those ranges as markup without their passing through element and
+   * attribute policies.  The renderer may instead drop all the remaining
+   * content when a browser would read it differently, such as a {@code -->}
+   * with no {@code <!--} before it.
    * <p>
    * Text inside a discarded element is not reported here; the
-   * {@link #discardedTag} report covers it.  These reports come from
-   * {@link HtmlStreamRenderer}, which
-   * {@link PolicyFactory#sanitize(String, HtmlChangeListener, Object)}
-   * always uses, seen through any {@link HtmlStreamEventReceiverWrapper}
-   * around it; a sanitizer built on some other receiver does not send them.
+   * {@link #discardedTag} report covers it.  Policy drops are reported with
+   * any output receiver.  Renderer drops are reported only with an
+   * {@link HtmlStreamRenderer}, seen through any
+   * {@link HtmlStreamEventReceiverWrapper} around it;
+   * {@link PolicyFactory#sanitize(String, HtmlChangeListener, Object)} always
+   * uses one.
+   * <p>
+   * One input text chunk may result in multiple calls.  Callers must not rely
+   * on the boundaries between calls.  Treat the text as untrusted; it may
+   * contain attacker-controlled markup.
    * <p>
    * The default implementation does nothing.
    *
-   * @param elementName the element whose content was dropped.
+   * @param elementName the name under which the policy kept the element.
    * @param text the content that was dropped.
    */
   public default void discardedText(

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -36,7 +36,8 @@ import org.owasp.html.TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy;
 
 /**
  * Sits between the HTML parser, the policy, and the renderer so that it
- * can report dropped elements and attributes to an {@link HtmlChangeListener}.
+ * can report dropped elements, attributes and text to an
+ * {@link HtmlChangeListener}.
  *
  * <pre>
  * HtmlChangeReporter&lt;T&gt; hcr = new HtmlChangeReporter&lt;T&gt;(
@@ -47,7 +48,7 @@ import org.owasp.html.TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy;
  *
  * The renderer receives events from the policy unchanged, but the reporter
  * notices differences between the events from the lexer and those from the
- * policy.
+ * policy, and receives notice of text the policy or renderer drops.
  *
  * @param <T> The type of context value passed to the
  */
@@ -99,6 +100,16 @@ public final class HtmlChangeReporter<T> {
     boolean skippedLastTagAsAttributeless();
   }
 
+  /**
+   * Implemented by a policy that can report text it drops after keeping the
+   * element that contained it.
+   */
+  interface DroppedTextSource {
+    /** Sends dropped text to {@code listener}, or to nobody when null. */
+    void reportDroppedTextTo(
+        @Nullable HtmlStreamRenderer.DroppedTextListener listener);
+  }
+
   private static final class InputChannel<T>
       implements HtmlSanitizer.Policy,
                  TagBalancingHtmlStreamEventReceiver.NestingLimitListener,
@@ -108,6 +119,8 @@ public final class HtmlChangeReporter<T> {
     final OutputChannel output;
     final T context;
     final HtmlChangeListener<? super T> listener;
+    /** Alternating element names and text, gathered before user callbacks. */
+    final List<String> pendingDroppedText = new ArrayList<>();
 
     InputChannel(
         OutputChannel output, HtmlChangeListener<? super T> listener,
@@ -143,11 +156,16 @@ public final class HtmlChangeReporter<T> {
      * the balancer does for the nesting limit.
      */
     public void droppedText(String elementName, String text) {
-      listener.discardedText(context, elementName, text);
+      pendingDroppedText.add(elementName);
+      pendingDroppedText.add(text);
     }
 
     public void openDocument() {
+      pendingDroppedText.clear();
       policy.openDocument();
+      if (policy instanceof DroppedTextSource) {
+        ((DroppedTextSource) policy).reportDroppedTextTo(this);
+      }
       // The renderer decides on its own to drop literal content it cannot
       // emit, so it has to tell us; any other receiver keeps that to itself.
       // Bound once the renderer has opened the document, which forgets any
@@ -160,7 +178,11 @@ public final class HtmlChangeReporter<T> {
       // Closing may flush and drop pending literal content, so listen until
       // the renderer is done.
       policy.closeDocument();
+      if (policy instanceof DroppedTextSource) {
+        ((DroppedTextSource) policy).reportDroppedTextTo(null);
+      }
       output.listenForDroppedText(null);
+      dispatchDroppedText();
     }
 
     public void openTag(String elementName, List<String> attrs) {
@@ -218,10 +240,24 @@ public final class HtmlChangeReporter<T> {
 
     public void closeTag(String elementName) {
       policy.closeTag(elementName);
+      dispatchDroppedText();
     }
 
     public void text(String textChunk) {
       policy.text(textChunk);
+      dispatchDroppedText();
+    }
+
+    /** Dispatches outside the policy call that decided to drop the text. */
+    private void dispatchDroppedText() {
+      if (!pendingDroppedText.isEmpty()) {
+        String[] dropped = pendingDroppedText.toArray(
+            new String[pendingDroppedText.size()]);
+        pendingDroppedText.clear();
+        for (int i = 0; i < dropped.length; i += 2) {
+          listener.discardedText(context, dropped[i], dropped[i + 1]);
+        }
+      }
     }
 
     private static final String[] ZERO_STRINGS = new String[0];

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -857,7 +857,7 @@ public class HtmlPolicyBuilder {
    * @param out receives calls to open only tags allowed by
    *      previous calls to this object.
    *      Typically a {@link HtmlStreamRenderer}.
-   * @param listener is notified of dropped tags and attributes so that
+   * @param listener is notified of dropped tags, attributes and text so that
    *      intrusion detection systems can be alerted to questionable HTML.
    *      If {@code null} then no notifications are sent.
    * @param context if {@code (listener != null)} then the context value passed

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -137,11 +137,8 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   }
 
   /**
-   * Told when the content of a literal-content element such as
-   * {@code script} or {@code style} is dropped because it cannot be emitted
-   * without a browser reading it differently.  The bad HTML handler hears
-   * of it too, as a message; this carries the content itself, so that
-   * {@link HtmlChangeReporter} can report the loss to its listener.
+   * Carries literal content discarded by the policy or renderer to
+   * {@link HtmlChangeReporter}, which reports the loss to its listener.
    */
   interface DroppedTextListener {
     /**

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/PolicyFactory.java
@@ -94,18 +94,19 @@ public final class PolicyFactory
 
   /**
    * Produces a sanitizer that emits tokens to {@code out} and that notifies
-   * any {@code listener} of any dropped tags and attributes.
-   * Content that {@code out} cannot render, such as a {@code -->} inside a
-   * kept {@code script} element, is reported through
-   * {@link HtmlChangeListener#discardedText} only when {@code out} is an
-   * {@link HtmlStreamRenderer}, possibly behind
+   * any {@code listener} of any dropped tags, attributes and text.
+   * Text the policy removes from a kept literal-content element is reported
+   * through {@link HtmlChangeListener#discardedText} with any {@code out}.
+   * Content that {@code out} itself cannot render, such as a {@code -->}
+   * inside a kept {@code script} element, is reported only when {@code out}
+   * is an {@link HtmlStreamRenderer}, possibly behind
    * {@link HtmlStreamEventReceiverWrapper} decorators, since that is where
-   * the decision to drop it is made;
+   * the second decision to drop it is made;
    * {@link #sanitize(String, HtmlChangeListener, Object)} always uses one.
    * @param out a renderer that receives approved tokens only.
-   * @param listener if non-null, receives notifications of tags and attributes
-   *     that were rejected by the policy.  This may tie into intrusion
-   *     detection systems.
+   * @param listener if non-null, receives notifications of tags, attributes
+   *     and text that were rejected.  This may tie into intrusion detection
+   *     systems.
    * @param context if {@code (listener != null)} then the context value passed
    *     with notifications.  This can be used to let the listener know from
    *     which connection or request the questionable HTML was received.
@@ -130,12 +131,12 @@ public final class PolicyFactory
   /**
    * A convenience function that sanitizes a string of HTML and reports
    * the names of rejected elements and attributes to listener, along with
-   * the rejected attributes' values and any content the renderer could not
-   * emit.
+   * the rejected attributes' values and any content the policy or renderer
+   * could not emit.
    * @param html the string of HTML to sanitize.
-   * @param listener if non-null, receives notifications of tags and attributes
-   *     that were rejected by the policy.  This may tie into intrusion
-   *     detection systems.
+   * @param listener if non-null, receives notifications of tags, attributes
+   *     and text that were rejected.  This may tie into intrusion detection
+   *     systems.
    * @param context if {@code (listener != null)} then the context value passed
    *     with notifications.  This can be used to let the listener know from
    *     which connection or request the questionable HTML was received.

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
@@ -335,6 +335,113 @@ class HtmlChangeReporterTest {
   }
 
   /**
+   * A tag in kept literal content reaches the policy as text, so the policy's
+   * removal of it must use the text channel rather than the tag channel.
+   * Issue #468.
+   */
+  @Test
+  void testTagRemovedFromKeptLiteralContentIsReportedAsText() {
+    Result result = sanitizeVerbose(
+        scriptAndStyleWithText(),
+        "<style>.x{}<div id=\"evil\">XSS?</div>y{}</style>");
+
+    assertEquals("<style>.x{}y{}</style>", result.html);
+    assertEquals("style{<div id=\"evil\">XSS?</div>} ", result.log);
+  }
+
+  /** Each report contains only the exact input range the policy removed. */
+  @Test
+  void testPolicyReportsSeparateLiteralTextDropsExactly() {
+    Result result = sanitizeVerbose(
+        scriptAndStyleWithText(),
+        "<style>a<div>x</div>b</noscript>c</style>");
+
+    assertEquals("<style>abc</style>", result.html);
+    assertEquals(
+        "style{<div>x</div>} style{</noscript>} ", result.log);
+  }
+
+  /** Policy and renderer drops are both reported, without overlap. */
+  @Test
+  void testPolicyAndRendererTextDropsAreBothReported() {
+    Result result = sanitizeVerbose(
+        scriptAndStyleWithText(),
+        "<style>a<div>x</div>-->b</style>");
+
+    assertEquals("<style></style>", result.html);
+    assertEquals("style{<div>x</div>} style{a-->b} ", result.log);
+  }
+
+  /** A postprocessor rewrite is not a policy rejection and is not reported. */
+  @Test
+  void testPostprocessorTextRewriteIsNotReported() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("style")
+        .allowTextIn("style")
+        .withPostprocessor(r -> new HtmlStreamEventReceiverWrapper(r) {
+          @Override
+          public void text(String text) {
+            underlying.text(text.replace("red", "blue"));
+          }
+        })
+        .toFactory();
+    Result result = sanitizeVerbose(
+        policy, "<style>.x{color:red}</style>");
+
+    assertEquals("<style>.x{color:blue}</style>", result.html);
+    assertEquals("", result.log);
+  }
+
+  /**
+   * The reported container is the literal name emitted by an element policy.
+   */
+  @Test
+  void testPolicyDropUsesAdjustedLiteralElementName() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements((elementName, attrs) -> "style", "div")
+        .allowTextIn("style")
+        .toFactory();
+    Result result = sanitizeVerbose(
+        policy, "<div>a&lt;img onerror=alert(1)&gt;b</div>");
+
+    assertEquals("<style>ab</style>", result.html);
+    assertEquals("style{<img onerror=alert(1)>} ", result.log);
+  }
+
+  /** Policy-side drops do not depend on HtmlStreamRenderer's callback. */
+  @Test
+  void testPolicyDroppedTextReachesListenerWithAForeignReceiver() {
+    final List<String> dropped = new ArrayList<>();
+    HtmlChangeListener<Object> listener =
+        textAndTagCollector(dropped, new ArrayList<String>());
+    StringBuilder out = new StringBuilder();
+    final HtmlStreamRenderer renderer =
+        HtmlStreamRenderer.create(out, Handler.DO_NOTHING);
+    HtmlStreamEventReceiver foreign = new HtmlStreamEventReceiver() {
+      public void openDocument() { renderer.openDocument(); }
+
+      public void closeDocument() { renderer.closeDocument(); }
+
+      public void openTag(String elementName, List<String> attrs) {
+        renderer.openTag(elementName, attrs);
+      }
+
+      public void closeTag(String elementName) {
+        renderer.closeTag(elementName);
+      }
+
+      public void text(String text) { renderer.text(text); }
+    };
+
+    HtmlSanitizer.sanitize(
+        "<style>a<div>x</div>b</style>",
+        scriptAndStyleWithText().apply(foreign, listener, null));
+
+    assertEquals("<style>ab</style>", out.toString());
+    assertEquals(Arrays.asList("style:<div>x</div>"), dropped);
+  }
+
+  /**
    * The convenience method renders with HtmlStreamRenderer, so dropped
    * content reaches the listener, as it does through the library's own
    * receiver wrapper around one.  A sanitizer built on some other receiver


### PR DESCRIPTION
## Summary

Fixes #468.

`ElementAndAttributePolicyBasedSanitizerPolicy` removes tag-like ranges from
the text of kept literal-content elements before the renderer sees them. Those
ranges arrived from the lexer as text rather than tag events, so an
`HtmlChangeListener` previously received no notification.

- Connect the policy filter to the same package-private dropped-text channel
  used by `HtmlStreamRenderer`.
- Report each exact range removed, under the adjusted name of the kept literal
  element, after the policy call has completed.
- Keep policy-originated reports available with any output receiver while
  retaining the renderer requirement for renderer-originated drops.
- Avoid comparing reporter input and output text, which would incorrectly
  classify legitimate postprocessor rewrites as policy rejections.
- Update the listener, factory, builder, README, and change-log documentation
  for partial policy drops.

No public signature changes.

## Test plan

- Regression coverage for the issue payload and multiple exact removal ranges.
- Reporting coverage for the current literal-text backstop, including a
  preceding or dangling `<` removed to prevent an assembled end tag.
- Combined policy and renderer drops are reported without overlap.
- Element-policy renaming reports the adjusted literal element name.
- Policy drops reach listeners through a foreign output receiver.
- Postprocessor text rewrites do not produce false reports.
- `./mvnw clean verify` passes on JDK 11: 531 library tests and 7 example tests,
  including the fuzzers, AntiSamy suite, packaged-JAR verification, and JPMS
  consumer check.
