### PR TITLE
fix: Close Two More Ways Past the Literal-Text Filter and Back It in the Renderer

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,17 @@
 
 Most recent at top.
   * Next release
+    * Two more ways past the filter on kept `style`, `script` and `iframe`
+      text are closed.  A `<` that opened no tag carried everything up to
+      the next `>` through as text, and that `>` could belong to an end tag
+      inside the span, so `<</noscript>` and `< </noscript>` kept the
+      breakout that a bare `</noscript>` lost; the original CVE-2025-66021
+      fix had the same hole.  And a `<` left dangling at the end of a chunk
+      could be completed by the next chunk, or by the sanitizer's own end
+      tag, into a live tag.  The scan now resumes right after a `<` that
+      opens no tag, a dangling `<` goes unless whitespace follows it, and
+      `HtmlStreamRenderer` refuses literal content holding an end tag of
+      `noscript`, `noframes` or `noembed` whatever policy produced it.
     * Text kept inside a `style`, `script` or `iframe` element, or any other
       element whose content the renderer emits unescaped, now has every tag
       removed, end tags included, instead of only the tags of elements the
@@ -12,7 +23,7 @@ Most recent at top.
       came out unchanged under a policy allowing `noscript`, `style` with
       text and `img`.  A browser with scripting on reads `noscript` as raw
       text up to that inner `</noscript>` and then runs the handler; the
-      same holds for `noframes` and `noembed` with scripting off.  The
+      same holds for `noframes` and `noembed` with or without scripting.  The
       filter also keeps the text after a start tag with no matching end tag,
       which it used to discard to the end of the chunk, and keeps a `<` that
       opens no tag.

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -194,11 +194,20 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    * when this chunk has one, so that {@code <script>alert(1)</script>}
    * inside a style block goes entirely; a start tag with no matching end
    * tag goes alone and the text after it stays.  A {@code <} that opens no
-   * tag, because no {@code >} follows it in the chunk, is text and stays,
-   * except where a later chunk could complete it into an end tag: an end tag
-   * needs its {@code </} to start here, so a {@code <} that ends the chunk
-   * or is followed by {@code /} goes.  Text arrives in chunks whose
-   * boundaries fall anywhere, so each chunk has to be safe on its own.
+   * tag is text and stays, and the scan resumes right after it rather than
+   * at the next {@code >}, which may belong to a tag inside the span, as in
+   * {@code < </noscript>}.  A {@code <} left at the end of the output when
+   * a tag is dropped goes with the tag, since it would otherwise meet
+   * whatever follows the tag, as {@code <<b>/noscript>} would otherwise
+   * yield {@code </noscript>}.
+   * <p>
+   * Text arrives in chunks whose boundaries fall anywhere, so each chunk has
+   * to be safe on its own.  A {@code <} with no {@code >} after it in the
+   * chunk therefore goes, unless HTML whitespace follows it: a later chunk
+   * could otherwise complete it into an end tag, or into a start tag that
+   * the element's own end tag then closes for a browser already reading
+   * markup, whereas no browser state starts a tag at {@code <} followed by
+   * whitespace.
    */
   private static String stripTags(String text) {
     int len = text.length();
@@ -216,7 +225,14 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       String trimmed = text.substring(tagStart + 1, tagEnd).trim();
       boolean isEndTag = trimmed.startsWith("/");
       String tagName = tagNameOf(trimmed, isEndTag);
-      int kind = tagName == null ? NOT_A_TAG : isEndTag ? END_TAG : START_TAG;
+      if (tagName == null) {
+        // Not a tag: "<!-- -->", "</>", "<3" and the like.  The '<' is text,
+        // and the scan resumes right after it: the '>' found above may end
+        // a tag that starts inside the span, as in "< </noscript>".
+        i = tagStart + 1;
+        continue;
+      }
+      int kind = isEndTag ? END_TAG : START_TAG;
       int[] tag = { tagStart, tagEnd + 1, -1, kind };
       if (kind == START_TAG) {
         Deque<Integer> starts = unmatchedStarts.get(tagName);
@@ -240,25 +256,24 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     for (int[] tag : tags) {
       if (tag[TAG_START] < pos) { continue; }  // Inside dropped content.
       result.append(text, pos, tag[TAG_START]);
-      switch (tag[KIND]) {
-        case NOT_A_TAG:
-          // "<!-- -->", "</>", "<3" and the like are text.
-          result.append(text, tag[TAG_START], tag[TAG_END]);
-          pos = tag[TAG_END];
-          break;
-        case END_TAG:
-          pos = tag[TAG_END];
-          break;
-        default:
-          pos = tag[MATCH_END] >= 0 ? tag[MATCH_END] : tag[TAG_END];
-          break;
+      pos = tag[KIND] == END_TAG || tag[MATCH_END] < 0
+          ? tag[TAG_END] : tag[MATCH_END];
+      // A '<' that the dropped tag followed would meet what follows the tag.
+      int last = result.length() - 1;
+      if (last >= 0 && result.charAt(last) == '<') {
+        result.setLength(last);
       }
     }
-    // The rest holds no tag.  Each '<' in it is text, unless a later chunk
-    // could complete it into an end tag.
+    // The rest holds no tag.  A '<' in it stays if a '>' follows it in this
+    // chunk, since it opened no tag and nothing after it can change that,
+    // or if HTML whitespace follows it, which starts no tag in any browser
+    // state.  Otherwise it is left dangling, and a later chunk could
+    // complete it, so it goes.
+    int lastGt = text.lastIndexOf('>');
     for (int c = pos; c < len; ++c) {
       char ch = text.charAt(c);
-      if (ch != '<' || (c + 1 < len && text.charAt(c + 1) != '/')) {
+      if (ch != '<' || c < lastGt
+          || (c + 1 < len && Strings.isHtmlSpace(text.charAt(c + 1)))) {
         result.append(ch);
       }
     }
@@ -268,7 +283,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   /** Indices into the records {@link #stripTags} keeps for each tag. */
   private static final int TAG_START = 0, TAG_END = 1, MATCH_END = 2, KIND = 3;
   /** The kinds of record. */
-  private static final int NOT_A_TAG = 0, START_TAG = 1, END_TAG = 2;
+  private static final int START_TAG = 0, END_TAG = 1;
 
   /**
    * The canonical name of the tag whose trimmed content between the angle
@@ -304,9 +319,6 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   }
 
   public void openTag(String elementName, List<String> attrs) {
-    // StylingPolicy repeats some of this code because it is more complicated
-    // to refactor it into multiple method bodies, so if you change this,
-    // check the override of it in that class.
     ElementAndAttributePolicies policies = elAndAttrPolicies.get(elementName);
     String adjustedElementName = applyPolicies(elementName, attrs, policies);
     skippedLastTagAsAttributeless = false;

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -410,6 +410,15 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
             int start = i + 1;
             if (start + 1 < n && sb.charAt(start) == '/') {
               ++start;
+              // The end tag of an element that a browser reads as raw text
+              // while the sanitizer treats it as a container would end that
+              // element for the browser, wherever this content sits, and
+              // hand it whatever follows as markup (CVE-2025-66021).  The
+              // policy strips such tags; this catches what reaches the
+              // renderer by any other route.
+              for (String container : CONTAINERS_RAW_TEXT_TO_BROWSERS) {
+                if (isTagNameAt(sb, start, container)) { return i; }
+              }
             } else if (innerStart < 0) {
               break;
             }
@@ -541,6 +550,24 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
       | (1L << ' ')
       | (1L << '/')
       | (1L << '>');
+
+  /**
+   * Elements the sanitizer treats as ordinary containers but that browsers
+   * read as raw text: {@code noscript} with scripting on, and
+   * {@code noframes} and {@code noembed} always.
+   */
+  private static final String[] CONTAINERS_RAW_TEXT_TO_BROWSERS = {
+    "noscript", "noframes", "noembed",
+  };
+
+  /** True if {@code name} sits at {@code start} in {@code sb} as a tag name. */
+  private static boolean isTagNameAt(
+      StringBuilder sb, int start, String name) {
+    int end = start + name.length();
+    return end <= sb.length()
+        && Strings.regionMatchesIgnoreCase(sb, start, name, 0, name.length())
+        && (end == sb.length() || isTagEnd(sb.charAt(end)));
+  }
 
   private static boolean isTagEnd(char ch) {
     return ch < 63 && 0 != (TAG_ENDS & (1L << ch));

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -34,6 +34,8 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import java.io.StringReader;
+import java.util.Collections;
+import java.util.regex.Pattern;
 
 import nu.validator.htmlparser.dom.HtmlDocumentBuilder;
 import org.junit.jupiter.api.Test;
@@ -923,6 +925,170 @@ class HtmlSanitizerTest {
   }
 
   /**
+   * Test #12:
+   * A {@code <} that opens no tag used to carry everything up to the next
+   * {@code >} through as text, and that {@code >} could belong to an end tag
+   * inside the span, so {@code <</noscript>} and {@code < </noscript>} kept
+   * the breakout that a bare {@code </noscript>} lost.  The original fix had
+   * the same hole.  The scan now resumes right after such a {@code <}.
+   */
+  @Test
+  void testCVE202566021_12EndTagBehindAStrayBracket() {
+    PolicyFactory policy = noscriptStyleImg();
+
+    assertEquals(
+        "<noscript><style></style></noscript>",
+        policy.sanitize(
+            "<noscript><style><</noscript>"
+            + "<<img src=x onerror=alert(1)></style></noscript>"));
+    assertEquals(
+        "<noscript><style>< </style></noscript>",
+        policy.sanitize(
+            "<noscript><style>< </noscript>"
+            + "<img src=x onerror=alert(1)></style></noscript>"));
+    assertEquals(
+        "<noscript><style><3</style></noscript>",
+        policy.sanitize(
+            "<noscript><style><3</noscript>"
+            + "<img src=x onerror=alert(1)></style></noscript>"));
+    assertEquals(
+        "<noscript><style><??></style></noscript>",
+        policy.sanitize(
+            "<noscript><style><?</noscript>"
+            + "<img src=x onerror=alert(1)>?></style></noscript>"));
+    assertEquals(
+        "<noscript><style><!----></style></noscript>",
+        policy.sanitize(
+            "<noscript><style><!--</noscript>"
+            + "<img src=x onerror=alert(1)>--></style></noscript>"));
+    // The dropped tag takes a '<' just before it along: "<" + "/noscript>"
+    // would otherwise be an end tag again.
+    assertEquals(
+        "<noscript><style>/noscript></style></noscript>",
+        policy.sanitize(
+            "<noscript><style><<b>/noscript></style></noscript>"));
+  }
+
+  /**
+   * Test #13:
+   * Once a breakout has put a browser in a markup state, a start tag left
+   * without its {@code >} inside the literal text is completed by the
+   * {@code >} of the sanitizer's own end tag.  A dangling {@code <} goes
+   * unless HTML whitespace follows it, which starts no tag in any browser
+   * state.
+   */
+  @Test
+  void testCVE202566021_13DanglingBracketBeforeTheEndTag() {
+    PolicyFactory policy = noscriptStyleImg();
+
+    assertEquals(
+        "<noscript><style>< img src=y onerror=alert(1)</style></noscript>",
+        policy.sanitize(
+            "<noscript><style>< </noscript>"
+            + "<img src=y onerror=alert(1)</style></noscript>"));
+    assertEquals(
+        "<style>a { } b < c</style>",
+        policy.sanitize("<style>a { } b < c</style>"));
+  }
+
+  /**
+   * Test #14:
+   * The lexer hands the content of a literal element over in more than one
+   * chunk when a server-side script tag {@code <%...%>} sits in it, so the
+   * pieces of an end tag or a start tag can arrive in different chunks, and
+   * each chunk has to drop its own dangling {@code <}.
+   */
+  @Test
+  void testCVE202566021_14ChunksSplitByServerCode() {
+    assertEquals(
+        "<noscript><style>/noscript>img src=x onerror=alert(1)>"
+        + "</style></noscript>",
+        noscriptStyleImg().sanitize(
+            "<noscript><style><<<%%>/noscript><<<%%>"
+            + "img src=x onerror=alert(1)></style></noscript>"));
+  }
+
+  /**
+   * Test #15:
+   * Text re-chunked by a preprocessor into fixed-size blocks, which can
+   * split a tag anywhere, still leaves nothing in the literal text that a
+   * browser could read as an end tag or as a start tag.
+   */
+  @Test
+  void testCVE202566021_15FixedSizeRechunking() {
+    for (final int size : new int[] { 1, 2, 3, 5, 7, 16 }) {
+      PolicyFactory policy = new HtmlPolicyBuilder()
+          .allowElements("noscript", "style", "img")
+          .allowTextIn("style")
+          .allowAttributes("src").onElements("img")
+          .withPreprocessor(r -> new HtmlStreamEventReceiverWrapper(r) {
+            @Override
+            public void text(String text) {
+              for (int i = 0, n = text.length(); i < n; i += size) {
+                underlying.text(text.substring(i, Math.min(n, i + size)));
+              }
+            }
+          })
+          .toFactory();
+      for (String html : new String[] {
+              "<noscript><style><</noscript>"
+              + "<<img src=x onerror=alert(1)></style></noscript>",
+              "<noscript><style>< </noscript>"
+              + "<img src=y onerror=alert(1)</style></noscript>",
+           }) {
+        String out = policy.sanitize(html);
+        String styleText = out.substring(
+            out.indexOf("<style>") + 7, out.indexOf("</style>"));
+        assertFalse(styleText.contains("</"), size + ": " + out);
+        assertFalse(
+            Pattern.compile("<[a-zA-Z]").matcher(styleText).find(),
+            size + ": " + out);
+      }
+    }
+  }
+
+  /**
+   * Test #16:
+   * The renderer itself refuses literal content holding the end tag of an
+   * element that a browser reads as raw text, so a policy that never runs
+   * the filter, such as one built by hand on {@code PolicyFactory.apply},
+   * is covered too.
+   */
+  @Test
+  void testCVE202566021_16RendererRefusesContainerEndTags() {
+    for (String name
+         : new String[] { "noscript", "NOSCRIPT", "noframes", "noembed" }) {
+      StringBuilder sb = new StringBuilder();
+      HtmlStreamRenderer r = HtmlStreamRenderer.create(sb, Handler.DO_NOTHING);
+      r.openDocument();
+      r.openTag("style", Collections.<String>emptyList());
+      r.text("a{} </" + name + "><img src=x onerror=alert(1)> b{}");
+      r.closeTag("style");
+      r.closeDocument();
+      assertEquals("<style></style>", sb.toString(), name);
+    }
+    // Names that only start alike are left alone.
+    StringBuilder sb = new StringBuilder();
+    HtmlStreamRenderer r = HtmlStreamRenderer.create(sb, Handler.DO_NOTHING);
+    r.openDocument();
+    r.openTag("style", Collections.<String>emptyList());
+    r.text("a{} </noscripts> </no b{}");
+    r.closeTag("style");
+    r.closeDocument();
+    assertEquals("<style>a{} </noscripts> </no b{}</style>", sb.toString());
+  }
+
+  /** Allows noscript, style with its text, and img with src. */
+  private static PolicyFactory noscriptStyleImg() {
+    return new HtmlPolicyBuilder()
+        .allowElements("noscript", "style", "img")
+        .allowTextIn("style")
+        .allowAttributes("src").onElements("img")
+        .allowUrlProtocols("https")
+        .toFactory();
+  }
+
+  /**
    * A chunk of literal text full of start tags with no end tags is the
    * worst case for pairing tags, since every one is searched for a match.
    * Pairing is done in one pass, so this takes a fraction of a second; a
@@ -933,16 +1099,12 @@ class HtmlSanitizerTest {
     PolicyFactory p = new HtmlPolicyBuilder()
         .allowElements("style").allowTextIn("style").toFactory();
     int n = 200_000;
-    StringBuilder html = new StringBuilder("<style>");
-    StringBuilder expected = new StringBuilder("<style>");
-    for (int i = 0; i < n; ++i) {
-      html.append("<b>x");
-      expected.append('x');
-    }
-    html.append("</style>");
-    expected.append("</style>");
+    final String html = "<style>" + stringRepeatedTimes("<b>x", n) + "</style>";
+    String expected = "<style>" + stringRepeatedTimes("x", n) + "</style>";
 
-    assertEquals(expected.toString(), p.sanitize(html.toString()));
+    String out = assertTimeoutPreemptively(
+        Duration.ofSeconds(20), () -> p.sanitize(html));
+    assertEquals(expected, out);
   }
 
   /**
@@ -960,8 +1122,10 @@ class HtmlSanitizerTest {
     assertEquals(
         "<script>if (a < b) x();</script>",
         policy.sanitize("<script>if (a < b) x();</script>"));
+    // A '<' dangling before a letter at the end of a chunk goes; #470
+    // tracks the fidelity cost.
     assertEquals(
-        "<script>if (a<b) x();</script>",
+        "<script>if (ab) x();</script>",
         policy.sanitize("<script>if (a<b) x();</script>"));
     // A tag with no matching end tag goes alone; the text after it stays.
     assertEquals(
@@ -974,10 +1138,14 @@ class HtmlSanitizerTest {
     assertEquals(
         "<style>a{}c{}</style>",
         policy.sanitize("<style>a{}<b>x<b>y</b>z</b>c{}</style>"));
-    // Not tags: a comment, an empty end tag, a bare bracket.
+    // Not tags: a comment and an empty end tag stay; a bare bracket with no
+    // '>' after it in the chunk is dangling and goes.
     assertEquals(
-        "<style>a{}<!-- x --></>c<3{}</style>",
+        "<style>a{}<!-- x --></>c3{}</style>",
         policy.sanitize("<style>a{}<!-- x --></>c<3{}</style>"));
+    assertEquals(
+        "<style>a{}<3>{}</style>",
+        policy.sanitize("<style>a{}<3>{}</style>"));
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #465 from its review, which found two working bypasses of the filter on kept `style`, `script` and `iframe` text. Both are live on `main` now; one was also present in the original CVE-2025-66021 fix.

- A `<` that opened no tag carried everything up to the next `>` through as text, and that `>` could belong to an end tag inside the span. `< </noscript>` and `<</noscript>` therefore kept the `</noscript>` that a bare one lost, and with it the breakout into markup. The scan now resumes right after such a `<`, and a `<` left just before a dropped tag goes with the tag, since `<<b>/noscript>` would otherwise yield `</noscript>`.
- A `<` left dangling at the end of a chunk could be completed by the next chunk, which a server-side script tag inside the element or a preprocessor can produce, or by the sanitizer's own end tag once a browser is reading markup. Such a `<` now goes unless HTML whitespace follows it, which starts no tag in any browser state; a `<` with a `>` after it in the chunk opened no tag and stays, so comments in script text survive.
- `HtmlStreamRenderer`'s check on buffered literal content also refuses an end tag of `noscript`, `noframes` or `noembed`, the elements the sanitizer treats as containers while browsers read them as raw text, so a policy that never runs the filter, such as one built by hand on `PolicyFactory.apply`, is covered too.
- Smaller items from the same review: the linearity test gets the preemptive timeout its sibling uses, the change log's claim that `noframes` and `noembed` matter only with scripting off is corrected, and a stale comment pointing at a `StylingPolicy` override that does not exist goes.

Two fidelity expectations from #465 change: a `<` dangling before a letter or digit at the end of a chunk goes, as it did before #465. #470 tracks the fidelity of this filter separately.

## Test plan

- New tests in `HtmlSanitizerTest`: the `<<`, `< `, `<3`, `<?` and `<!--` spellings of the breakout, the dangling start tag completed by the sanitizer's end tag, the chunk split by `<%%>`, re-chunking through a preprocessor at six block sizes, and the renderer refusing each container end tag while leaving look-alike names alone.
- All existing tests pass with the two expectation changes above.
- `./mvnw clean verify` passes on JDK 11, 17, 21 and 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYF1WjZmwbGNrph7RDw2BS
