### PR TITLE
Fix review follow-ups for literal text and link balancing

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,25 @@
 
 Most recent at top.
   * Next release
+    * The filter on text kept inside `style`, `script`, `iframe` and other
+      literal-content elements now examines a possible tag prefix before
+      looking for its closing `>`.  A long run of `<` characters before one
+      `>` made it repeatedly scan and copy the same suffix, taking quadratic
+      time.  Removing a tag now also removes every immediately preceding `<`,
+      rather than letting `<<<b>img` turn into `<img`.  Issue #476.
+    * Nested-link balancing now uses the elements that survived policy when
+      looking for the nearest formatting marker.  If a `td`, `th`, `caption`,
+      `template`, `applet`, `marquee` or `object` was dropped or renamed to a
+      non-marker, it no longer protects an outer link from a later link in the
+      output, so the sanitized HTML parses back to the structure the sanitizer
+      emitted.
+      Issue #476.
+    * `HtmlChangeListener.discardedAttribute` now reports the rejected value
+      when it precedes a surviving attribute with the same name.  The output
+      comparison used to account for the first input name regardless of which
+      copy the attribute policy rejected, so the listener could receive the
+      safe surviving URL instead of the rejected `javascript:` URL.  Issue
+      #476.
     * Two more ways past the filter on kept `style`, `script` and `iframe`
       text are closed.  A `<` that opened no tag carried everything up to
       the next `>` through as text, and that `>` could belong to an end tag

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -50,8 +50,10 @@ import static org.owasp.shim.Java8Shim.j8;
 class ElementAndAttributePolicyBasedSanitizerPolicy
     implements HtmlSanitizer.Policy,
                TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy,
+               TagBalancingHtmlStreamEventReceiver.OpenTagOutputPolicy,
                HtmlChangeReporter.AttributelessSkipPolicy,
-               HtmlChangeReporter.DroppedTextSource {
+               HtmlChangeReporter.DroppedTextSource,
+               HtmlChangeReporter.DiscardedAttributeSource {
   final Map<String, ElementAndAttributePolicies> elAndAttrPolicies;
   final Set<String> allowedTextContainers;
   /**
@@ -114,6 +116,11 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
   /** Told about filtered literal content; null while nobody is listening. */
   private @Nullable HtmlStreamRenderer.DroppedTextListener droppedTextListener;
+  /** Told exactly which input attributes an attribute policy rejects. */
+  private @Nullable HtmlChangeReporter.DiscardedAttributeListener
+      discardedAttributeListener;
+  /** The output name, if any, produced by the most recent open-tag call. */
+  private transient @Nullable String outputElementNameForLastOpenTag;
 
   ElementAndAttributePolicyBasedSanitizerPolicy(
       HtmlStreamEventReceiver out,
@@ -151,6 +158,8 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     inKeptCdataElement = false;
     keptCdataElementName = null;
     droppedTextListener = null;
+    discardedAttributeListener = null;
+    outputElementNameForLastOpenTag = null;
     skippedLastTagAsAttributeless = false;
     openElementStack.clear();
     skipTextBeforeOpen.clear();
@@ -173,12 +182,22 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     skipText = true;
     inKeptCdataElement = false;
     keptCdataElementName = null;
+    outputElementNameForLastOpenTag = null;
     out.closeDocument();
   }
 
   public void reportDroppedTextTo(
       @Nullable HtmlStreamRenderer.DroppedTextListener listener) {
     this.droppedTextListener = listener;
+  }
+
+  public void reportDiscardedAttributesTo(
+      @Nullable HtmlChangeReporter.DiscardedAttributeListener listener) {
+    this.discardedAttributeListener = listener;
+  }
+
+  public @Nullable String outputElementNameForLastOpenTag() {
+    return outputElementNameForLastOpenTag;
   }
 
   public void text(String textChunk) {
@@ -247,18 +266,34 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     while (i < len) {
       int tagStart = text.indexOf('<', i);
       if (tagStart < 0) { break; }
-      int tagEnd = text.indexOf('>', tagStart + 1);
-      if (tagEnd < 0) { break; }  // No '<' from here on starts a tag.
-      String trimmed = text.substring(tagStart + 1, tagEnd).trim();
-      boolean isEndTag = trimmed.startsWith("/");
-      String tagName = tagNameOf(trimmed, isEndTag);
-      if (tagName == null) {
+      int nameStart = skipTrimSpace(text, tagStart + 1);
+      if (nameStart == len) { break; }
+      boolean isEndTag = text.charAt(nameStart) == '/';
+      if (isEndTag) {
+        nameStart = skipTrimSpace(text, nameStart + 1);
+        if (nameStart == len) { break; }
+      }
+      if (!Character.isLetter(text.charAt(nameStart))) {
         // Not a tag: "<!-- -->", "</>", "<3" and the like.  The '<' is text,
-        // and the scan resumes right after it: the '>' found above may end
-        // a tag that starts inside the span, as in "< </noscript>".
+        // and the scan resumes right after it.  In particular, do not search
+        // for a '>' until the prefix is known to open a tag: repeatedly
+        // searching the same suffix makes a long run of '<' quadratic.
         i = tagStart + 1;
         continue;
       }
+      int tagEnd = text.indexOf('>', nameStart + 1);
+      if (tagEnd < 0) { break; }  // No '<' from here on starts a tag.
+      int bodyEnd = tagEnd;
+      while (bodyEnd > nameStart && text.charAt(bodyEnd - 1) <= ' ') {
+        --bodyEnd;
+      }
+      int nameEnd = nameStart + 1;
+      while (nameEnd < bodyEnd
+          && !isRegexWhitespace(text.charAt(nameEnd))) {
+        ++nameEnd;
+      }
+      String tagName = HtmlLexer.canonicalElementName(
+          text.substring(nameStart, nameEnd));
       int kind = isEndTag ? END_TAG : START_TAG;
       int[] tag = { tagStart, tagEnd + 1, -1, kind };
       if (kind == START_TAG) {
@@ -286,11 +321,13 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       int dropStart = tag[TAG_START];
       pos = tag[KIND] == END_TAG || tag[MATCH_END] < 0
           ? tag[TAG_END] : tag[MATCH_END];
-      // A '<' that the dropped tag followed would meet what follows the tag.
+      // Any '<'s that the dropped tag followed would meet what follows the
+      // tag.  Take the whole adjacent run, lest "<<<b>img" become "<img".
       int last = result.length() - 1;
-      if (last >= 0 && result.charAt(last) == '<') {
+      while (last >= 0 && result.charAt(last) == '<') {
         result.setLength(last);
         dropStart -= 1;
+        --last;
       }
       reportDroppedText(elementName, text, dropStart, pos);
     }
@@ -325,18 +362,26 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   /** The kinds of record. */
   private static final int START_TAG = 0, END_TAG = 1;
 
-  /**
-   * The canonical name of the tag whose trimmed content between the angle
-   * brackets is {@code trimmed}, or null if it is not a tag.  A tag name
-   * starts with a letter; whitespace between {@code <} or {@code </} and the
-   * name is tolerated, which is stricter than a browser.
-   */
-  private static @Nullable String tagNameOf(String trimmed, boolean isEndTag) {
-    String body = isEndTag ? trimmed.substring(1).trim() : trimmed;
-    if (body.isEmpty() || !Character.isLetter(body.charAt(0))) {
-      return null;
+  /** Skips characters that {@link String#trim} treats as whitespace. */
+  private static int skipTrimSpace(String s, int start) {
+    int i = start;
+    while (i < s.length() && s.charAt(i) <= ' ') { ++i; }
+    return i;
+  }
+
+  /** The Java 8 regular-expression meaning of {@code \\s}. */
+  private static boolean isRegexWhitespace(char ch) {
+    switch (ch) {
+      case ' ':
+      case '\t':
+      case '\n':
+      case '\u000b':
+      case '\f':
+      case '\r':
+        return true;
+      default:
+        return false;
     }
-    return HtmlLexer.canonicalElementName(body.split("\\s")[0]);
   }
 
   /**
@@ -359,6 +404,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   }
 
   public void openTag(String elementName, List<String> attrs) {
+    outputElementNameForLastOpenTag = null;
     ElementAndAttributePolicies policies = elAndAttrPolicies.get(elementName);
     String adjustedElementName = applyPolicies(elementName, attrs, policies);
     skippedLastTagAsAttributeless = false;
@@ -377,7 +423,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     return skippedLastTagAsAttributeless;
   }
 
-  static final @Nullable String applyPolicies(
+  private @Nullable String applyPolicies(
       String elementName, List<String> attrs,
       ElementAndAttributePolicies policies) {
     String adjustedElementName;
@@ -389,12 +435,14 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
             = policies.attrPolicies.get(name);
         if (attrPolicy == null) {
           attrsIt.remove();
-          attrsIt.next();
+          String value = attrsIt.next();
+          reportDiscardedAttribute(name, value);
           attrsIt.remove();
         } else {
           String value = attrsIt.next();
           String adjustedValue = attrPolicy.apply(elementName, name, value);
           if (adjustedValue == null) {
+            reportDiscardedAttribute(name, value);
             attrsIt.remove();
             attrsIt.previous();
             attrsIt.remove();
@@ -417,6 +465,13 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       adjustedElementName = null;
     }
     return adjustedElementName;
+  }
+
+  /** Reports an attribute-policy rejection without invoking user code. */
+  private void reportDiscardedAttribute(String name, String value) {
+    if (discardedAttributeListener != null) {
+      discardedAttributeListener.discardedAttribute(name, value);
+    }
   }
 
   public void closeTag(String elementName) {
@@ -445,6 +500,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   void writeOpenTag(
       ElementAndAttributePolicies policies, String adjustedElementName,
       List<String> attrs) {
+    outputElementNameForLastOpenTag = adjustedElementName;
     if (!HtmlTextEscapingMode.isVoidElement(adjustedElementName)) {
       push(policies.elementName, adjustedElementName);
       // A kept element is the container for the text inside it.  It is judged

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -28,11 +28,13 @@
 package org.owasp.html;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 
 import javax.annotation.Nullable;
 
 import org.owasp.html.TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy;
+import org.owasp.html.TagBalancingHtmlStreamEventReceiver.OpenTagOutputPolicy;
 
 /**
  * Sits between the HTML parser, the policy, and the renderer so that it
@@ -110,10 +112,23 @@ public final class HtmlChangeReporter<T> {
         @Nullable HtmlStreamRenderer.DroppedTextListener listener);
   }
 
+  /** Receives exact input attributes rejected by an attribute policy. */
+  interface DiscardedAttributeListener {
+    void discardedAttribute(String name, String value);
+  }
+
+  /** Implemented by a policy that can identify attribute-policy rejections. */
+  interface DiscardedAttributeSource {
+    /** Sends rejections to {@code listener}, or to nobody when null. */
+    void reportDiscardedAttributesTo(
+        @Nullable DiscardedAttributeListener listener);
+  }
+
   private static final class InputChannel<T>
       implements HtmlSanitizer.Policy,
                  TagBalancingHtmlStreamEventReceiver.NestingLimitListener,
                  TextSuppressionPolicy,
+                 OpenTagOutputPolicy,
                  HtmlStreamRenderer.DroppedTextListener {
     HtmlStreamEventReceiver policy;
     final OutputChannel output;
@@ -121,6 +136,8 @@ public final class HtmlChangeReporter<T> {
     final HtmlChangeListener<? super T> listener;
     /** Alternating element names and text, gathered before user callbacks. */
     final List<String> pendingDroppedText = new ArrayList<>();
+    /** Output name produced in response to the most recent input start tag. */
+    private @Nullable String outputElementNameForLastOpenTag;
 
     InputChannel(
         OutputChannel output, HtmlChangeListener<? super T> listener,
@@ -160,11 +177,20 @@ public final class HtmlChangeReporter<T> {
       pendingDroppedText.add(text);
     }
 
+    public @Nullable String outputElementNameForLastOpenTag() {
+      return outputElementNameForLastOpenTag;
+    }
+
     public void openDocument() {
       pendingDroppedText.clear();
+      outputElementNameForLastOpenTag = null;
       policy.openDocument();
       if (policy instanceof DroppedTextSource) {
         ((DroppedTextSource) policy).reportDroppedTextTo(this);
+      }
+      if (policy instanceof DiscardedAttributeSource) {
+        ((DiscardedAttributeSource) policy)
+            .reportDiscardedAttributesTo(output);
       }
       // The renderer decides on its own to drop literal content it cannot
       // emit, so it has to tell us; any other receiver keeps that to itself.
@@ -181,16 +207,19 @@ public final class HtmlChangeReporter<T> {
       if (policy instanceof DroppedTextSource) {
         ((DroppedTextSource) policy).reportDroppedTextTo(null);
       }
+      if (policy instanceof DiscardedAttributeSource) {
+        ((DiscardedAttributeSource) policy)
+            .reportDiscardedAttributesTo(null);
+      }
       output.listenForDroppedText(null);
       dispatchDroppedText();
     }
 
     public void openTag(String elementName, List<String> attrs) {
       output.openedElementName = null;
-      output.expectedAttrs.clear();
       // Copied before the policy runs: it removes rejected attributes from
       // attrs in place, and their values are wanted for the report.
-      output.expectedAttrs.addAll(attrs);
+      output.expectAttributes(attrs);
       policy.openTag(elementName, attrs);
       {
         // Gather the notification details to avoid any problems with the
@@ -201,6 +230,7 @@ public final class HtmlChangeReporter<T> {
         // name is not compared with the input name: an ElementPolicy may
         // rename the element, and a renamed element was kept, not dropped.
         boolean discarded = output.openedElementName == null;
+        outputElementNameForLastOpenTag = output.openedElementName;
         output.openedElementName = null;
         // Attributes go unreported with a tag the policy rejected: the tag
         // report covers them.  Not so when the policy allowed the element and
@@ -210,13 +240,11 @@ public final class HtmlChangeReporter<T> {
             || (policy instanceof AttributelessSkipPolicy
                 && ((AttributelessSkipPolicy) policy)
                     .skippedLastTagAsAttributeless());
-        int nDiscarded = attrsRejectedOnTheirOwn
-            ? output.expectedAttrs.size() / 2
-            : 0;
-        String[] discardedAttrs = nDiscarded != 0
-            ? output.expectedAttrs.toArray(new String[nDiscarded * 2])
+        String[] discardedAttrs = attrsRejectedOnTheirOwn
+            ? output.discardedAttributes()
             : ZERO_STRINGS;
-        output.expectedAttrs.clear();
+        int nDiscarded = discardedAttrs.length / 2;
+        output.clearExpectedAttributes();
         // Dispatch notifications to the listener, under the input name,
         // which is the one the listener can relate to what came in.
         if (discarded) {
@@ -263,7 +291,8 @@ public final class HtmlChangeReporter<T> {
     private static final String[] ZERO_STRINGS = new String[0];
   }
 
-  private static final class OutputChannel implements HtmlStreamEventReceiver {
+  private static final class OutputChannel
+      implements HtmlStreamEventReceiver, DiscardedAttributeListener {
     private final HtmlStreamEventReceiver renderer;
     /**
      * The name of the tag the policy has opened in response to the tag being
@@ -271,18 +300,64 @@ public final class HtmlChangeReporter<T> {
      */
     String openedElementName;
     /**
-     * The attributes on the tag being opened, as name and value pairs, that
-     * have not turned up in the output yet.  A list rather than a map: a
+     * The attributes on the tag being opened, as original name and value
+     * pairs.  A list rather than a map: a
      * name repeated on one tag is two attributes, and HTML forbids that, so
      * the sanitizer keeps the first and drops the rest.  Collapsing the copies
      * here would leave the surviving one accounting for all of them, and the
      * drops would go unreported.  The values ride along so that the drops can
      * be reported with them.
      */
-    List<String> expectedAttrs = new ArrayList<>();
+    final List<String> expectedAttrs = new ArrayList<>();
+    /** Input pairs an attribute policy explicitly rejected. */
+    final BitSet rejectedAttrs = new BitSet();
+    /** Input pairs accounted for by attributes the policy emitted. */
+    final BitSet emittedAttrs = new BitSet();
 
     OutputChannel(HtmlStreamEventReceiver renderer) {
       this.renderer = renderer;
+    }
+
+    /** Starts accounting for the attributes on one input start tag. */
+    void expectAttributes(List<String> attrs) {
+      expectedAttrs.clear();
+      expectedAttrs.addAll(attrs);
+      rejectedAttrs.clear();
+      emittedAttrs.clear();
+    }
+
+    public void discardedAttribute(String name, String value) {
+      for (int i = 0, n = expectedAttrs.size() / 2; i < n; ++i) {
+        int pair = i * 2;
+        if (!rejectedAttrs.get(i) && !emittedAttrs.get(i)
+            && name.equals(expectedAttrs.get(pair))
+            && value.equals(expectedAttrs.get(pair + 1))) {
+          rejectedAttrs.set(i);
+          return;
+        }
+      }
+    }
+
+    /** Returns original pairs not accounted for by emitted attributes. */
+    String[] discardedAttributes() {
+      int n = expectedAttrs.size() / 2;
+      int nDiscarded = n - emittedAttrs.cardinality();
+      if (nDiscarded == 0) { return InputChannel.ZERO_STRINGS; }
+      String[] discarded = new String[nDiscarded * 2];
+      int out = 0;
+      for (int i = 0; i < n; ++i) {
+        if (!emittedAttrs.get(i)) {
+          discarded[out++] = expectedAttrs.get(i * 2);
+          discarded[out++] = expectedAttrs.get(i * 2 + 1);
+        }
+      }
+      return discarded;
+    }
+
+    void clearExpectedAttributes() {
+      expectedAttrs.clear();
+      rejectedAttrs.clear();
+      emittedAttrs.clear();
     }
 
     /**
@@ -315,16 +390,17 @@ public final class HtmlChangeReporter<T> {
       for (int i = 0, n = attrs.size(); i < n; i += 2) {
         // Accounts for one copy of the name, so repeats the policy dropped
         // stay behind to be reported.
-        removeFirstNamed(expectedAttrs, attrs.get(i));
+        markFirstEmitted(attrs.get(i));
       }
       renderer.openTag(elementName, attrs);
     }
 
-    /** Removes the first pair in pairs whose name is name, if there is one. */
-    private static void removeFirstNamed(List<String> pairs, String name) {
-      for (int i = 0, n = pairs.size(); i < n; i += 2) {
-        if (name.equals(pairs.get(i))) {
-          pairs.subList(i, i + 2).clear();
+    /** Accounts for the first eligible input copy of an emitted name. */
+    private void markFirstEmitted(String name) {
+      for (int i = 0, n = expectedAttrs.size() / 2; i < n; ++i) {
+        if (!rejectedAttrs.get(i) && !emittedAttrs.get(i)
+            && name.equals(expectedAttrs.get(i * 2))) {
+          emittedAttrs.set(i);
           return;
         }
       }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.owasp.html.HtmlElementTables.HtmlElementNames;
 
 /**
@@ -47,12 +49,19 @@ public class TagBalancingHtmlStreamEventReceiver
   private final HtmlStreamEventReceiver underlying;
   private int nestingLimit = Integer.MAX_VALUE;
   private final IntVector openElements = new IntVector();
+  /**
+   * The element each entry in {@link #openElements} became after policy
+   * application, or {@link #NO_OUTPUT_ELEMENT} when the policy dropped it.
+   * When the receiver below cannot report that, the input name is used.
+   */
+  private final IntVector outputElements = new IntVector();
   private final IntVector toResumeInReverse = new IntVector();
   private static final HtmlElementTables METADATA = HtmlElementTables.get();
   private static final int UNRECOGNIZED_TAG =
       METADATA.indexForName(HtmlElementNames.CUSTOM_ELEMENT_NAME);
   private static final int A_TAG = METADATA.indexForName("a");
   private static final int BODY_TAG = METADATA.indexForName("body");
+  private static final int NO_OUTPUT_ELEMENT = -1;
   /**
    * Elements on entering which a browser puts a marker on its list of
    * active formatting elements, so that an {@code a} opened inside one of
@@ -103,6 +112,20 @@ public class TagBalancingHtmlStreamEventReceiver
      *     is suppressed rather than emitted where the element was.
      */
     boolean suppressesTextWhenDropped(String canonElementName);
+  }
+
+  /**
+   * Implemented by a policy that can identify the element, if any, emitted
+   * by its most recent {@link HtmlStreamEventReceiver#openTag} call.  The
+   * balancer uses the output name when applying the formatting-marker rule
+   * for nested links: a marker the policy dropped cannot affect how a browser
+   * parses the sanitized output.
+   */
+  interface OpenTagOutputPolicy {
+    /**
+     * @return the canonical emitted name, or null if no element was emitted.
+     */
+    @Nullable String outputElementNameForLastOpenTag();
   }
 
   /**
@@ -166,6 +189,7 @@ public class TagBalancingHtmlStreamEventReceiver
       underlying.closeTag(elname);
     }
     openElements.clear();
+    outputElements.clear();
     toResumeInReverse.clear();
     underlying.closeDocument();
   }
@@ -194,6 +218,7 @@ public class TagBalancingHtmlStreamEventReceiver
       underlying.openTag(METADATA.canonNameForIndex(elIndex), attrs);
       if (!HtmlTextEscapingMode.isVoidElement(canonElementName)) {
         openElements.add(elIndex);
+        outputElements.add(outputElementIndexForLastOpenTag(elIndex));
       }
     } else {
       if (contentIsSkippable(canonElementName)) { ++droppedSkippableDepth; }
@@ -209,12 +234,32 @@ public class TagBalancingHtmlStreamEventReceiver
    * cell leaves one outside the table alone.
    */
   private boolean hasOpenLinkInFormattingScope() {
-    for (int i = openElements.size(); --i >= 0;) {
-      int openElementIndex = openElements.get(i);
+    for (int i = outputElements.size(); --i >= 0;) {
+      int openElementIndex = outputElements.get(i);
       if (openElementIndex == A_TAG) { return true; }
-      if (FORMATTING_MARKERS.get(openElementIndex)) { return false; }
+      if (openElementIndex != NO_OUTPUT_ELEMENT
+          && FORMATTING_MARKERS.get(openElementIndex)) {
+        return false;
+      }
     }
     return false;
+  }
+
+  /**
+   * The output counterpart of an input element just sent downstream.
+   * Receivers other than the library policy cannot provide this feedback, so
+   * preserve the traditional input-based balancing for them.
+   */
+  private int outputElementIndexForLastOpenTag(int inputElementIndex) {
+    if (underlying instanceof OpenTagOutputPolicy) {
+      String outputElementName = ((OpenTagOutputPolicy) underlying)
+          .outputElementNameForLastOpenTag();
+      return outputElementName != null
+          ? METADATA.indexForName(
+              HtmlLexer.canonicalElementName(outputElementName))
+          : NO_OUTPUT_ELEMENT;
+    }
+    return inputElementIndex;
   }
 
   private void prepareForContent(int elIndex) {
@@ -242,6 +287,8 @@ public class TagBalancingHtmlStreamEventReceiver
           attrs.clear();
           underlying.openTag(impliedElName, attrs);
           openElements.add(impliedElIndex);
+          outputElements.add(
+              outputElementIndexForLastOpenTag(impliedElIndex));
           top = impliedElIndex;
           ++nOpen;
         }
@@ -261,6 +308,7 @@ public class TagBalancingHtmlStreamEventReceiver
           underlying.closeTag(METADATA.canonNameForIndex(top));
         }
         openElements.remove(--nOpen);
+        outputElements.remove(nOpen);
         if (METADATA.resumable(top) && top != elIndex) {
           toResumeInReverse.add(top);
         }
@@ -278,12 +326,15 @@ public class TagBalancingHtmlStreamEventReceiver
           || canContain(toResume, openElements.get(nOpen - 1), nOpen))
           && canContain(elIndex, toResume, nOpen)) {
         toResumeInReverse.removeLast();
+        int outputElementIndex = NO_OUTPUT_ELEMENT;
         if (openElements.size() < nestingLimit) {
           underlying.openTag(
               METADATA.canonNameForIndex(toResume),
               new ArrayList<>());
+          outputElementIndex = outputElementIndexForLastOpenTag(toResume);
         }
         openElements.add(toResume);
+        outputElements.add(outputElementIndex);
       } else {
         break;
       }
@@ -407,6 +458,7 @@ public class TagBalancingHtmlStreamEventReceiver
     // Close all the elements that cannot contain the element to open.
     while (--last > index) {
       int unclosed = openElements.remove(last);
+      outputElements.remove(last);
       if (last + 1 < nestingLimit) {
         underlying.closeTag(METADATA.canonNameForIndex(unclosed));
       }
@@ -418,6 +470,7 @@ public class TagBalancingHtmlStreamEventReceiver
       underlying.closeTag(METADATA.canonNameForIndex(elIndex));
     }
     openElements.remove(index);
+    outputElements.remove(index);
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
@@ -183,6 +183,20 @@ class HtmlChangeReporterTest {
     assertEquals("", result.log);
   }
 
+  /** Reporter indirection preserves output-aware nested-link balancing. */
+  @Test
+  void testDroppedFormattingMarkerDoesNotProtectLinksWithAReporter() {
+    Result result = sanitize(
+        Sanitizers.LINKS,
+        "<a href=u><marquee><a href=v>x</a></marquee>y</a>");
+
+    assertEquals(
+        "<a href=\"u\" rel=\"nofollow\"></a>"
+        + "<a href=\"v\" rel=\"nofollow\">x</a>y",
+        result.html);
+    assertEquals("<marquee> ", result.log);
+  }
+
   /**
    * Renames {@code span} to {@code div}.  {@code div} is allowed as well so
    * that text inside the renamed element is kept: the policy decides whether
@@ -269,6 +283,21 @@ class HtmlChangeReporterTest {
         result.html);
     assertEquals(
         "<a href href> a.href=\"/one\" a.href=\"/two\" ", result.log);
+  }
+
+  /** A rejected first copy must not borrow a surviving duplicate's value. */
+  @Test
+  void testRejectedDuplicateReportsTheRejectedValue() {
+    Result result = sanitizeVerbose(
+        Sanitizers.LINKS,
+        "<a href=\"javascript:alert(1)\" "
+        + "href=\"https://safe.example/\">link</a>");
+
+    assertEquals(
+        "<a href=\"https://safe.example/\" rel=\"nofollow\">link</a>",
+        result.html);
+    assertEquals(
+        "<a href> a.href=\"javascript:alert(1)\" ", result.log);
   }
 
   /** The value reported is the input value after character references. */
@@ -370,6 +399,16 @@ class HtmlChangeReporterTest {
 
     assertEquals("<style>ab</style>", result.html);
     assertEquals("style{<</noscript>} style{<} ", result.log);
+  }
+
+  /** Every adjacent bracket removed with a tag belongs to the same report. */
+  @Test
+  void testPolicyReportsAllAdjacentBracketsRemovedWithATag() {
+    Result result = sanitizeVerbose(
+        scriptAndStyleWithText(), "<style><<<b>payload</style>");
+
+    assertEquals("<style>payload</style>", result.html);
+    assertEquals("style{<<<b>} ", result.log);
   }
 
   /** Policy and renderer drops are both reported, without overlap. */

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1107,6 +1107,31 @@ class HtmlSanitizerTest {
     assertEquals(expected, out);
   }
 
+  /** Invalid tag openings must not repeatedly rescan the same long suffix. */
+  @Test
+  void testLongRunOfStrayBracketsInLiteralTextIsLinear() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("style").allowTextIn("style").toFactory();
+    int n = 1_000_000;
+    String brackets = stringRepeatedTimes("<", n);
+    final String html = "<style>" + brackets + "></style>";
+
+    String out = assertTimeoutPreemptively(
+        Duration.ofSeconds(20), () -> p.sanitize(html));
+    assertEquals(html, out);
+  }
+
+  /** Removing a tag must not turn preceding brackets into a new start tag. */
+  @Test
+  void testTagRemovalTakesAllAdjacentOpeningBrackets() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("style").allowTextIn("style").toFactory();
+
+    assertEquals(
+        "<style>img src=x onerror=alert(1)></style>",
+        p.sanitize("<style><<<b>img src=x onerror=alert(1)></style>"));
+  }
+
   /**
    * The filter no longer discards the rest of a chunk after a start tag with
    * no matching end tag, and keeps a {@code <} that opens no tag, so script
@@ -1225,6 +1250,70 @@ class HtmlSanitizerTest {
       assertEquals(
           parseAsBrowser(html), parseAsBrowser(p.sanitize(html)), html);
     }
+  }
+
+  /** A formatting marker matters only when the policy keeps it in output. */
+  @Test
+  void testDroppedFormattingMarkersDoNotProtectNestedLinks()
+      throws Exception {
+    String expected = "<a href=\"u\" rel=\"nofollow\"></a>"
+        + "<a href=\"v\" rel=\"nofollow\">x</a>y";
+    for (String marker : new String[] {
+            "applet", "caption", "marquee", "object", "td", "template", "th",
+         }) {
+      String input = "<a href=u><" + marker + "><a href=v>x</a></"
+          + marker + ">y</a>";
+      String out = Sanitizers.LINKS.sanitize(input);
+
+      assertEquals(expected, out, marker);
+      assertEquals(out, Sanitizers.LINKS.sanitize(out), marker);
+      assertEquals(parseAsBrowser(expected), parseAsBrowser(out), marker);
+    }
+  }
+
+  /** A marker that survives policy still permits the browser's nested links. */
+  @Test
+  void testKeptFormattingMarkerStillProtectsNestedLinks() throws Exception {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("a", "marquee")
+        .allowAttributes("href").onElements("a")
+        .toFactory();
+    String input = "<a href=u><marquee><a href=v>x</a></marquee>y</a>";
+    String out = p.sanitize(input);
+
+    assertEquals(
+        "<a href=\"u\"><marquee><a href=\"v\">x</a></marquee>y</a>",
+        out);
+    assertEquals(parseAsBrowser(input), parseAsBrowser(out));
+    assertEquals(out, p.sanitize(out));
+  }
+
+  /** Marker scope follows an element policy's output name, not its input. */
+  @Test
+  void testRenamedElementsDetermineFormattingMarkerScope() {
+    PolicyFactory awayFromMarker = new HtmlPolicyBuilder()
+        .allowElements("a", "div")
+        .allowElements((name, attrs) -> "div", "marquee")
+        .allowAttributes("href").onElements("a")
+        .toFactory();
+    String renamedAway = awayFromMarker.sanitize(
+        "<a href=u><marquee><a href=v>x</a></marquee>y</a>");
+    assertEquals(
+        "<a href=\"u\"><div></div></a><a href=\"v\">x</a>y",
+        renamedAway);
+    assertEquals(renamedAway, awayFromMarker.sanitize(renamedAway));
+
+    PolicyFactory intoMarker = new HtmlPolicyBuilder()
+        .allowElements("a", "marquee")
+        .allowElements((name, attrs) -> "marquee", "div")
+        .allowAttributes("href").onElements("a")
+        .toFactory();
+    String renamedInto = intoMarker.sanitize(
+        "<a href=u><div><a href=v>x</a></div>y</a>");
+    assertEquals(
+        "<a href=\"u\"><marquee><a href=\"v\">x</a></marquee>y</a>",
+        renamedInto);
+    assertEquals(renamedInto, intoMarker.sanitize(renamedInto));
   }
 
   /** The tree a browser builds from html, one node per line. */


### PR DESCRIPTION
Closes #476.

## Summary

This fixes the four confirmed follow-ups from review of #463, #465, #466, #467, and #472:

- The literal-content tag scan now validates a candidate prefix before looking for its closing greater-than sign. A chunk containing one million less-than signs followed by one greater-than sign is handled in one pass instead of repeatedly scanning and copying the same suffix.
- Dropping a literal-text tag consumes the entire adjacent run of preceding less-than signs. The input <style><<<b>img src=x onerror=alert(1)></style> now emits <style>img src=x onerror=alert(1)></style>, rather than synthesizing a tag-shaped <img sequence.
- Nested-link balancing uses the element name that actually survived policy. If one of the seven adoption-agency markers is dropped or renamed away, it cannot protect an outer anchor that remains in output. A marker that survives, or an element renamed into a marker, still preserves the browser-valid nesting.
- HtmlChangeReporter now receives package-private, per-document provenance for attributes rejected by the built policy. For href=javascript: followed by a surviving HTTPS href, the safe output is unchanged and discardedAttribute receives the rejected javascript: value.

No public API changes are introduced; the library and tests still compile to Java 8 bytecode. Reporting remains batch-first, then one value callback per dropped attribute in input order.

## Security and release assessment

The renderer backstop for noscript, noframes, and noembed remains in place. The new hostile tests cover the literal-text splice and CPU cases, all seven formatting markers, policy renaming in both directions, reporter indirection, idempotent sanitization, and validator.nu browser parsing.

The literal-text CPU/splice defects and the policy-layer link round-trip mutation should be fixed before releasing the reviewed literal-text changes. This PR resolves those confirmed blockers. The separately known linear-memory issue #473 remains out of scope and tracked independently.

## Verification

All commands passed from the repository root:

- JAVA_HOME=OpenJDK-11.0.32.1 ./mvnw clean verify
- JAVA_HOME=OpenJDK-17.0.20.1 ./mvnw clean verify
- JAVA_HOME=OpenJDK-21.0.12.1 ./mvnw clean verify
- JAVA_HOME=OpenJDK-25.0.4.1 ./mvnw clean verify

Each run includes the normal fuzzers, AntiSamy suite, Java 8 compilation, and JPMS consumer integration check.