### PR TITLE
Rework the literal-text tag filter for fidelity and footprint

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,49 @@
 
 Most recent at top.
   * Next release
+    * Ordinary script and style text survives the filter on kept
+      literal-content elements.  A tag now needs a well-formed name -- an
+      ASCII letter and then letters, digits, `-`, `_`, `:` or `.` -- so
+      `if (a < b) { x(); } if (c > d) { y(); }` and
+      `for(i=0;i<n;i++){a[i]=b>c;}` keep the text between the brackets that
+      used to be read as a tag and removed.  Anything a browser would read as
+      a tag only where it parses markup stays, which the text of a kept
+      literal-content element never reaches; a name that a character the
+      renderer elides would otherwise hide, as in `</noscript` NUL `>`, is
+      still recognised and removed.  Issue #470.
+    * The filter keeps no record per tag, so a chunk of literal text full of
+      tags no longer costs a multiple of its own size in heap: input that used
+      to sanitize in 160 MB and needed 256 MB after the filter was reworked
+      now needs less than it ever did.  A start tag is paired with its end tag
+      from a bounded note of the start tags not yet matched, names are
+      compared where they lie instead of being copied and split with a regular
+      expression, and the ranges removed are recorded only while a listener is
+      attached.  Issue #473.
+    * Removing a tag from literal text no longer leaves what is on either side
+      of it able to open a tag.  `<style><b<svg> onmouseover=1>` emitted
+      `<b onmouseover=1>`, turning text that followed a tag into a tag with a
+      live handler, and `<style></<b>noscript>` emitted `</noscript>`, which
+      the renderer then refused but which reached a receiver handed to
+      `PolicyFactory.apply` as written.  The `<` of anything a removal, or the
+      element's own end tag, would finish into a tag now goes, while a `<` that
+      opens no tag, as in `<3` or `< b`, stays.
+    * Removing a tag from literal text no longer joins the text on either side
+      of it into a `<!--` or `-->` that the input did not hold, and a start
+      tag dropped together with its content no longer takes an enclosed `-->`
+      with it.  Either one left the element's comment delimiters unbalanced,
+      which cost the whole content: `<style>a{}-<b>->b{}</style>` and
+      `<script><!-- if (a > 0) { <b> } --> </b> f();</script>` came out empty.
+      Issue #475.
+    * The filter now runs exactly where the receiver writes text as it stands.
+      Inside `svg` and `math` a browser parses the content of every element as
+      markup, and `HtmlStreamRenderer` escapes it there, so the tags in the
+      text of a `style` or `script` element in foreign content are kept and
+      escaped rather than stripped.  A receiver handed to
+      `PolicyFactory.apply` does not rename `xmp`, `listing` and `plaintext`
+      to `pre` as the renderer does, and so used to receive the text of those
+      elements with its tags intact, a `</noscript>` among them; the text of
+      every element the lexer reads as raw text is now filtered for any
+      receiver but the library's own renderer.  Issue #474.
     * The filter on text kept inside `style`, `script`, `iframe` and other
       literal-content elements now examines a possible tag prefix before
       looking for its closing `>`.  A long run of `<` characters before one

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -27,11 +27,9 @@
 
 package org.owasp.html;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Deque;
-import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -99,6 +97,21 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    */
   private @Nullable String keptCdataElementName;
   /**
+   * True while a kept {@code svg} or {@code math} element is open, so that a
+   * browser parses the content of every element inside it as markup.
+   * Maintained like {@link #skipText}, and in step with the renderer's own
+   * count of the same elements, since the renderer sees the tags this policy
+   * emits.  {@link #isLiteralContentElement} says why it matters.
+   */
+  private boolean inForeignContent;
+  /**
+   * The last few characters emitted for the kept literal-content element that
+   * is open.  Text arrives in chunks, and {@link #stripTags} needs them to see
+   * a comment delimiter that removing a tag would otherwise splice together
+   * across a chunk boundary.
+   */
+  private String literalTextTail = "";
+  /**
    * Alternating input names and adjusted names of elements opened by the
    * caller.
    */
@@ -111,8 +124,16 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   private final BitSet skipTextBeforeOpen = new BitSet();
   /** The same for {@link #inKeptCdataElement}. */
   private final BitSet inKeptCdataBeforeOpen = new BitSet();
+  /** The same for {@link #inForeignContent}. */
+  private final BitSet inForeignContentBeforeOpen = new BitSet();
   /** The same for {@link #keptCdataElementName}; entries may be null. */
   private final List<String> keptCdataNameBeforeOpen = new ArrayList<>();
+  /**
+   * True if {@link #out} is the library's own renderer, possibly behind
+   * {@link HtmlStreamEventReceiverWrapper} decorators, so that what it escapes
+   * is known.  See {@link #isLiteralContentElement}.
+   */
+  private final boolean outIsLibraryRenderer;
 
   /** Told about filtered literal content; null while nobody is listening. */
   private @Nullable HtmlStreamRenderer.DroppedTextListener droppedTextListener;
@@ -131,6 +152,11 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     this.elAndAttrPolicies = j8().mapCopyOf(elAndAttrPolicies);
     this.allowedTextContainers = j8().setCopyOf(allowedTextContainers);
     this.disallowedTextContainers = j8().setCopyOf(disallowedTextContainers);
+    HtmlStreamEventReceiver sink = out;
+    while (sink instanceof HtmlStreamEventReceiverWrapper) {
+      sink = ((HtmlStreamEventReceiverWrapper) sink).underlying;
+    }
+    this.outIsLibraryRenderer = sink instanceof HtmlStreamRenderer;
   }
 
   /**
@@ -157,6 +183,8 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     skipText = false;
     inKeptCdataElement = false;
     keptCdataElementName = null;
+    inForeignContent = false;
+    literalTextTail = "";
     droppedTextListener = null;
     discardedAttributeListener = null;
     outputElementNameForLastOpenTag = null;
@@ -164,6 +192,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     openElementStack.clear();
     skipTextBeforeOpen.clear();
     inKeptCdataBeforeOpen.clear();
+    inForeignContentBeforeOpen.clear();
     keptCdataNameBeforeOpen.clear();
     out.openDocument();
   }
@@ -178,10 +207,12 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     openElementStack.clear();
     skipTextBeforeOpen.clear();
     inKeptCdataBeforeOpen.clear();
+    inForeignContentBeforeOpen.clear();
     keptCdataNameBeforeOpen.clear();
     skipText = true;
     inKeptCdataElement = false;
     keptCdataElementName = null;
+    inForeignContent = false;
     outputElementNameForLastOpenTag = null;
     out.closeDocument();
   }
@@ -205,19 +236,21 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       // The renderer emits the text of a kept literal-content element as it
       // is, so a tag in it would reach the browser as written.  stripTags
       // says why none may.
-      if (inKeptCdataElement
-          && textChunk != null && textChunk.indexOf('<') >= 0) {
+      if (inKeptCdataElement && textChunk != null) {
         String elementName = keptCdataElementName;
         if (elementName == null) {
           throw new IllegalStateException("Missing literal-content element");
         }
-        out.text(stripTags(textChunk, elementName));
+        String filtered = textChunk.indexOf('<') < 0
+            ? textChunk : stripTags(textChunk, elementName);
+        rememberLiteralTextTail(filtered);
+        out.text(filtered);
       } else {
         out.text(textChunk);
       }
     }
   }
-  
+
   /**
    * Removes every tag from a chunk of the text of a kept literal-content
    * element such as {@code style}, {@code script} or {@code iframe}.
@@ -235,16 +268,35 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    * an allowed element's start tag used to be copied through with its
    * attributes unvetted, which put an event handler after the breakout.
    * <p>
+   * A tag is {@code <}, optional whitespace, an optional {@code /}, and a
+   * well-formed name: an ASCII letter and then letters, digits, {@code -},
+   * {@code _}, {@code :} or {@code .} up to whitespace, a {@code /} or the
+   * {@code >}.  A {@code <} that opens no tag is text and stays, and the scan
+   * resumes right after it rather than at the next {@code >}, which may
+   * belong to a tag inside the span, as in {@code < </noscript>}.  Anything a
+   * browser would only read as a tag in a markup context, such as the
+   * {@code < b) { x(); } if (c >} in ordinary script text, therefore stays:
+   * the text reaches a browser inside an element whose content it reads
+   * literally, and the cases where it might not are closed elsewhere -- an
+   * end tag that would break out of a raw-text element has a well-formed
+   * name and goes, the renderer refuses content holding one anyway, text in a
+   * literal element under a {@code select} is dropped by the tag balancer
+   * (CVE-2021-42575), and in foreign content, where a browser parses
+   * everything as markup, the renderer escapes the text instead of emitting
+   * it as written.
+   * <p>
    * A start tag goes together with everything up to its matching end tag
    * when this chunk has one, so that {@code <script>alert(1)</script>}
    * inside a style block goes entirely; a start tag with no matching end
-   * tag goes alone and the text after it stays.  A {@code <} that opens no
-   * tag is text and stays, and the scan resumes right after it rather than
-   * at the next {@code >}, which may belong to a tag inside the span, as in
-   * {@code < </noscript>}.  A {@code <} left at the end of the output when
-   * a tag is dropped goes with the tag, since it would otherwise meet
-   * whatever follows the tag, as {@code <<b>/noscript>} would otherwise
-   * yield {@code </noscript>}.
+   * tag goes alone and the text after it stays.  A {@code <} left at the end
+   * of the output when a tag is dropped goes with the tag, since it would
+   * otherwise meet whatever follows the tag, as {@code <<b>/noscript>} would
+   * otherwise yield {@code </noscript>}.  Removing a tag also must not splice
+   * a {@code <!--} or {@code -->} together out of the text on either side,
+   * nor take one away, since the renderer refuses the whole content of an
+   * element whose comments are unbalanced: a space goes in where a join would
+   * make one, and a start tag that would take one along with its content is
+   * dropped on its own instead.
    * <p>
    * Text arrives in chunks whose boundaries fall anywhere, so each chunk has
    * to be safe on its own.  A {@code <} with no {@code >} after it in the
@@ -257,70 +309,57 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    */
   private String stripTags(String text, String elementName) {
     int len = text.length();
-    // Find every tag, and pair each start tag with the end tag that matches
-    // it, counting nested tags of the same name, the way brackets pair.  One
-    // pass, so that a chunk full of unmatched start tags stays linear.
-    List<int[]> tags = new ArrayList<>();
-    Map<String, Deque<Integer>> unmatchedStarts = new HashMap<>();
+    StringBuilder result = new StringBuilder(len);
+    int[] starts = unmatchedStarts;
+    if (starts == null) {
+      starts = unmatchedStarts = new int[MAX_UNMATCHED_STARTS * START_FIELDS];
+    }
+    // How much of starts holds unmatched start tags, innermost last.
+    int nStarts = 0;
+    // Where the last comment delimiter in result ends, or 0 for none, so that
+    // a start tag that would take one with its content can be spotted.
+    int lastDelimiterEnd = 0;
+    // Text before this has been appended to result or dropped.
+    int pos = 0;
+    // Where the text appended since the last removal began, in the chunk and
+    // in result, so that a '<' the removal leaves at the end of result can be
+    // reported under the range it came from.  Nothing before it can end in
+    // one, since every removal takes the one it would have left.
+    int runInputStart = 0, runResultStart = 0;
+    // Where dropTagStartsLeftAtTheEnd last left off.
+    int tagStartsCheckedTo = 0;
     int i = 0;
     while (i < len) {
       int tagStart = text.indexOf('<', i);
       if (tagStart < 0) { break; }
-      int nameStart = skipTrimSpace(text, tagStart + 1);
-      if (nameStart == len) { break; }
-      boolean isEndTag = text.charAt(nameStart) == '/';
-      if (isEndTag) {
-        nameStart = skipTrimSpace(text, nameStart + 1);
-        if (nameStart == len) { break; }
-      }
-      if (!Character.isLetter(text.charAt(nameStart))) {
-        // Not a tag: "<!-- -->", "</>", "<3" and the like.  The '<' is text,
-        // and the scan resumes right after it.  In particular, do not search
-        // for a '>' until the prefix is known to open a tag: repeatedly
-        // searching the same suffix makes a long run of '<' quadratic.
+      int p = skipBeforeTagName(text, tagStart + 1, len);
+      boolean isEndTag = p < len && text.charAt(p) == '/';
+      if (isEndTag) { p = skipBeforeTagName(text, p + 1, len); }
+      int nameEnd = tagNameEnd(text, p, len);
+      if (nameEnd < 0) {
+        // Not a tag: "<!-- -->", "</>", "<3", "< b) {" and the like.  The '<'
+        // is text, and the scan resumes right after it: a '>' later in the
+        // chunk may end a tag that starts inside the span, as in
+        // "< </noscript>".  The name is read before any '>' is looked for, so
+        // that a chunk where no '<' opens a tag costs one pass over it and
+        // not one pass for each '<'.
         i = tagStart + 1;
         continue;
       }
-      int tagEnd = text.indexOf('>', nameStart + 1);
+      int tagEnd = nameEnd < len && text.charAt(nameEnd) == '>'
+          ? nameEnd : text.indexOf('>', nameEnd);
       if (tagEnd < 0) { break; }  // No '<' from here on starts a tag.
-      int bodyEnd = tagEnd;
-      while (bodyEnd > nameStart && text.charAt(bodyEnd - 1) <= ' ') {
-        --bodyEnd;
-      }
-      int nameEnd = nameStart + 1;
-      while (nameEnd < bodyEnd
-          && !isRegexWhitespace(text.charAt(nameEnd))) {
-        ++nameEnd;
-      }
-      String tagName = HtmlLexer.canonicalElementName(
-          text.substring(nameStart, nameEnd));
-      int kind = isEndTag ? END_TAG : START_TAG;
-      int[] tag = { tagStart, tagEnd + 1, -1, kind };
-      if (kind == START_TAG) {
-        Deque<Integer> starts = unmatchedStarts.get(tagName);
-        if (starts == null) {
-          starts = new ArrayDeque<>();
-          unmatchedStarts.put(tagName, starts);
-        }
-        starts.push(tags.size());
-      } else if (kind == END_TAG) {
-        Deque<Integer> starts = unmatchedStarts.get(tagName);
-        if (starts != null && !starts.isEmpty()) {
-          tags.get(starts.pop())[MATCH_END] = tagEnd + 1;
+      // The text before the tag survives.
+      if (pos < tagStart) {
+        int delimiterEnd = lastCommentDelimiterEnd(text, pos, tagStart);
+        runInputStart = pos;
+        runResultStart = result.length();
+        result.append(text, pos, tagStart);
+        if (delimiterEnd >= 0) {
+          lastDelimiterEnd = result.length() - (tagStart - delimiterEnd);
         }
       }
-      tags.add(tag);
-      i = tagEnd + 1;
-    }
-
-    StringBuilder result = new StringBuilder(len);
-    int pos = 0;
-    for (int[] tag : tags) {
-      if (tag[TAG_START] < pos) { continue; }  // Inside dropped content.
-      result.append(text, pos, tag[TAG_START]);
-      int dropStart = tag[TAG_START];
-      pos = tag[KIND] == END_TAG || tag[MATCH_END] < 0
-          ? tag[TAG_END] : tag[MATCH_END];
+      int dropStart = tagStart;
       // Any '<'s that the dropped tag followed would meet what follows the
       // tag.  Take the whole adjacent run, lest "<<<b>img" become "<img".
       int last = result.length() - 1;
@@ -329,7 +368,32 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
         dropStart -= 1;
         --last;
       }
-      reportDroppedText(elementName, text, dropStart, pos);
+      // Before the output is noted for an end tag to come back to, so that
+      // what it comes back to is output this has already been over.
+      tagStartsCheckedTo = dropTagStartsLeftAtTheEnd(
+          result, tagStartsCheckedTo, runInputStart, runResultStart);
+      int matched = isEndTag
+          ? indexOfUnmatchedStart(text, starts, nStarts, p, nameEnd)
+          : -1;
+      if (matched >= 0
+          && lastDelimiterEnd <= starts[matched + START_RESULT_LEN]) {
+        // The start tag's content goes with it, and so do the start tags
+        // inside, which the text that went took with it.
+        result.setLength(starts[matched + START_RESULT_LEN]);
+        dropStart = starts[matched + START_TAG_START];
+        nStarts = matched;
+        tagStartsCheckedTo = Math.min(tagStartsCheckedTo, result.length());
+      } else if (!isEndTag && nStarts < starts.length) {
+        starts[nStarts + START_TAG_START] = dropStart;
+        starts[nStarts + START_NAME_START] = p;
+        starts[nStarts + START_NAME_END] = nameEnd;
+        starts[nStarts + START_RESULT_LEN] = result.length();
+        nStarts += START_FIELDS;
+      }
+      pos = tagEnd + 1;
+      i = pos;
+      recordDroppedRange(dropStart, pos);
+      appendSpaceIfJoinWouldMakeCommentDelimiter(result, text, pos);
     }
     // The rest holds no tag.  A '<' in it stays if a '>' follows it in this
     // chunk, since it opened no tag and nothing after it can change that,
@@ -337,70 +401,361 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     // state.  Otherwise it is left dangling, and a later chunk could
     // complete it, so it goes.
     int lastGt = text.lastIndexOf('>');
+    if (pos < len) {
+      runInputStart = pos;
+      runResultStart = result.length();
+    }
     for (int c = pos; c < len; ++c) {
       char ch = text.charAt(c);
       if (ch != '<' || c < lastGt
           || (c + 1 < len && Strings.isHtmlSpace(text.charAt(c + 1)))) {
         result.append(ch);
       } else {
-        reportDroppedText(elementName, text, c, c + 1);
+        recordDroppedRange(c, c + 1);
+        appendSpaceIfJoinWouldMakeCommentDelimiter(result, text, c + 1);
+        runInputStart = c + 1;
+        runResultStart = result.length();
       }
     }
+    // What the element's own end tag, or a later chunk, would finish into a
+    // tag goes too.
+    dropTagStartsLeftAtTheEnd(
+        result, tagStartsCheckedTo, runInputStart, runResultStart);
+    reportDroppedRanges(elementName, text);
     return result.toString();
   }
 
-  /** Reports one exact range removed from a literal-content text chunk. */
-  private void reportDroppedText(
-      String elementName, String text, int start, int end) {
-    if (droppedTextListener != null) {
-      droppedTextListener.droppedText(elementName, text.substring(start, end));
+  /**
+   * Scratch for {@link #stripTags}, reused across chunks: the start tags it
+   * has not matched an end tag to, as {@link #START_FIELDS} ints each.
+   */
+  private int[] unmatchedStarts;
+
+  /**
+   * How many unmatched start tags one chunk pairs end tags with.  Pairing only
+   * keeps a dropped element's content with it, which buys no safety, since
+   * whatever survives is tag-free text either way, so the bookkeeping is
+   * bounded rather than growing with a count of tags an attacker chooses: the
+   * filter's memory stays proportional to its output.  Literal text nested
+   * deeper than this drops each tag on its own.
+   */
+  private static final int MAX_UNMATCHED_STARTS = 64;
+
+  /** The fields {@link #stripTags} keeps for an unmatched start tag. */
+  private static final int
+      START_TAG_START = 0, START_NAME_START = 1, START_NAME_END = 2,
+      START_RESULT_LEN = 3, START_FIELDS = 4;
+
+  /**
+   * Where in {@code starts} the innermost unmatched start tag whose name is
+   * {@code text.substring(nameStart, nameEnd)} sits, or -1 if there is none.
+   * Names are compared where they lie, so that pairing allocates nothing, and
+   * case-insensitively, as a browser matches an end tag to a start tag.
+   */
+  private static int indexOfUnmatchedStart(
+      String text, int[] starts, int nStarts, int nameStart, int nameEnd) {
+    int nameLen = nameEnd - nameStart;
+    for (int k = nStarts - START_FIELDS; k >= 0; k -= START_FIELDS) {
+      int start = starts[k + START_NAME_START];
+      if (starts[k + START_NAME_END] - start == nameLen
+          && Strings.regionMatchesIgnoreCase(
+                 text, start, text, nameStart, nameLen)) {
+        return k;
+      }
     }
+    return -1;
   }
 
-  /** Indices into the records {@link #stripTags} keeps for each tag. */
-  private static final int TAG_START = 0, TAG_END = 1, MATCH_END = 2, KIND = 3;
-  /** The kinds of record. */
-  private static final int START_TAG = 0, END_TAG = 1;
-
-  /** Skips characters that {@link String#trim} treats as whitespace. */
-  private static int skipTrimSpace(String s, int start) {
+  /**
+   * Skips what can lie between a tag's {@code <}, or its {@code /}, and its
+   * name: HTML whitespace, which a browser tolerates in an end tag, and
+   * anything the renderer elides, which would otherwise hide a name behind a
+   * character that is not there in the output.
+   */
+  private static int skipBeforeTagName(String text, int start, int limit) {
     int i = start;
-    while (i < s.length() && s.charAt(i) <= ' ') { ++i; }
+    while (i < limit) {
+      char ch = text.charAt(i);
+      if (!Strings.isHtmlSpace(ch) && !Encoding.isPossiblyElidedCodeunit(ch)) {
+        break;
+      }
+      ++i;
+    }
     return i;
   }
 
-  /** The Java 8 regular-expression meaning of {@code \\s}. */
-  private static boolean isRegexWhitespace(char ch) {
-    switch (ch) {
-      case ' ':
-      case '\t':
-      case '\n':
-      case '\u000b':
-      case '\f':
-      case '\r':
-        return true;
-      default:
-        return false;
+  /**
+   * Where the tag name starting at {@code nameStart} ends, or -1 if what is
+   * there is not one.  A name is an ASCII letter and then letters, digits,
+   * {@code -}, {@code _}, {@code :} or {@code .}, and it ends at HTML
+   * whitespace, a {@code /} or a {@code >}; running into any other character
+   * the output keeps, or into the end of the chunk, makes it no name.
+   * {@link #stripTags} says why that is the right line to draw.
+   * <p>
+   * A character the renderer elides ends the name instead, since eliding it
+   * joins the name to what follows: an end tag spelt {@code </noscript}, a
+   * NUL, {@code >} is {@code </noscript>} by the time it is emitted.
+   */
+  private static int tagNameEnd(String text, int nameStart, int limit) {
+    if (nameStart >= limit) { return -1; }
+    if (!isTagNameStart(text.charAt(nameStart))) { return -1; }
+    for (int p = nameStart + 1; p < limit; ++p) {
+      char ch = text.charAt(p);
+      if (isTagNameChar(ch)) { continue; }
+      return Strings.isHtmlSpace(ch) || ch == '/' || ch == '>'
+          || Encoding.isPossiblyElidedCodeunit(ch) ? p : -1;
+    }
+    return -1;  // The chunk ends inside the name, so no '>' follows it.
+  }
+
+  /** True if a tag name can start with {@code ch}. */
+  private static boolean isTagNameStart(char ch) {
+    return ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z');
+  }
+
+  /** True if a tag name can go on with {@code ch}. */
+  private static boolean isTagNameChar(char ch) {
+    return isTagNameStart(ch) || ('0' <= ch && ch <= '9')
+        || ch == '-' || ch == '_' || ch == ':' || ch == '.';
+  }
+
+  /**
+   * Removes the {@code <} of anything that a removal, or the end of the chunk,
+   * leaves able to open a tag.  Whatever comes next in the output -- the text
+   * that followed a removed tag, the next chunk, or the {@code >} of the
+   * element's own end tag -- would otherwise finish a {@code <b} or
+   * {@code </b} that the text itself did not hold, and a browser that reads
+   * markup here would act on it: {@code <b<svg> onmouseover=1>} must not become
+   * {@code <b onmouseover=1>}, nor {@code </<b>noscript>} become
+   * {@code </noscript>}.
+   * <p>
+   * Only the run of name characters, {@code <} and {@code /} that ends the
+   * output can hold one, and in it only a {@code <} that a name follows, or
+   * that the output ends before the name: a {@code <} before anything else
+   * opens no tag however the text goes on, so {@code <3} and {@code < b} stay.
+   * The run is read from the right, since what a {@code <} opens depends on
+   * what survives after it, as the second {@code <} of {@code <<b} shows.
+   * What follows one never changes once it has been read, so each is read
+   * once.
+   *
+   * @param from where the last look left off, so that what it kept is not
+   *     looked at again.
+   * @return where this look left off.
+   */
+  private int dropTagStartsLeftAtTheEnd(
+      StringBuilder result, int from, int runInputStart, int runResultStart) {
+    int limit = Math.max(from, runResultStart);
+    int regionStart = result.length();
+    while (regionStart > limit
+           && isTagRunChar(result.charAt(regionStart - 1))) {
+      --regionStart;
+    }
+    // What survives is written to the right of a cursor as the run is read, so
+    // that the run is rewritten once rather than closed up around each '<'.
+    int w = result.length();
+    char after = NOTHING, afterThat = NOTHING;
+    for (int r = result.length() - 1; r >= regionStart; --r) {
+      char ch = result.charAt(r);
+      if (ch == '<' && startsTagName(after, afterThat)) {
+        int lessThan = runInputStart + (r - runResultStart);
+        recordDroppedRange(lessThan, lessThan + 1);
+      } else {
+        result.setCharAt(--w, ch);
+        afterThat = after;
+        after = ch;
+      }
+    }
+    result.delete(regionStart, w);
+    return result.length();
+  }
+
+  /**
+   * Stands for the end of the output in {@link #startsTagName}.  No character
+   * of a run that can end in an unfinished tag is this one.
+   */
+  private static final char NOTHING = '\0';
+
+  /** True if {@code ch} can be part of a tag that the output ends inside. */
+  private static boolean isTagRunChar(char ch) {
+    return ch == '<' || ch == '/' || isTagNameChar(ch);
+  }
+
+  /**
+   * True if a tag name follows a {@code <}, where {@code after} and
+   * {@code afterThat} are the first two characters that survive after it and
+   * {@link #NOTHING} says the output ends there, which what comes next may
+   * continue into a name.
+   */
+  private static boolean startsTagName(char after, char afterThat) {
+    if (after == NOTHING) { return true; }
+    if (after == '/') {
+      return afterThat == NOTHING || isTagNameStart(afterThat);
+    }
+    return isTagNameStart(after);
+  }
+
+  /**
+   * Where the last {@code <!--} or {@code -->} in
+   * {@code text.substring(start, end)} ends, or -1 if it holds neither.
+   */
+  private static int lastCommentDelimiterEnd(String text, int start, int end) {
+    for (int i = end - 1; i > start; --i) {
+      if (text.charAt(i) == '-' && text.charAt(i - 1) == '-') {
+        if (i + 1 < end && text.charAt(i + 1) == '>') { return i + 2; }
+        if (i - 3 >= start
+            && text.charAt(i - 2) == '!' && text.charAt(i - 3) == '<') {
+          return i + 1;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Appends a space to {@code result} if the text from {@code pos} on would
+   * otherwise join what a removed range left before it into a {@code <!--} or
+   * {@code -->}.  The renderer refuses the whole content of a literal element
+   * whose comment delimiters do not balance, so removing a tag must not make
+   * one.  What comes before may be in an earlier chunk and what follows may be
+   * in a later one, and an unseen character is taken to be the worst one.
+   */
+  private void appendSpaceIfJoinWouldMakeCommentDelimiter(
+      StringBuilder result, String text, int pos) {
+    int len = text.length();
+    char r0 = pos < len ? text.charAt(pos) : UNSEEN;
+    char r1 = pos + 1 < len ? text.charAt(pos + 1) : UNSEEN;
+    boolean joins
+        // "-->" split by the join, as "--" + ">" or as "-" + "->".
+        = (endsWith(result, "--") && (r0 == '>' || r0 == UNSEEN))
+        || (endsWith(result, "-")
+            && (r0 == '-' || r0 == UNSEEN) && (r1 == '>' || r1 == UNSEEN))
+        // "<!--" the same way.  The third split, after the '<', cannot happen:
+        // a '<' left before a removed range goes with it.
+        || (endsWith(result, "<!")
+            && (r0 == '-' || r0 == UNSEEN) && (r1 == '-' || r1 == UNSEEN))
+        || (endsWith(result, "<!-") && (r0 == '-' || r0 == UNSEEN));
+    if (joins) {
+      result.append(' ');
+    }
+  }
+
+  /** Stands for a character in another chunk, which may be any character. */
+  private static final char UNSEEN = '\uFFFF';
+
+  /**
+   * True if the text emitted for this literal-content element so far ends with
+   * {@code suffix}, looking into {@link #literalTextTail} for what an earlier
+   * chunk emitted.
+   */
+  private boolean endsWith(StringBuilder result, String suffix) {
+    int resultLen = result.length();
+    for (int k = 0, n = suffix.length(); k < n; ++k) {
+      char want = suffix.charAt(n - 1 - k);
+      char got;
+      if (k < resultLen) {
+        got = result.charAt(resultLen - 1 - k);
+      } else {
+        int t = literalTextTail.length() - (k - resultLen) - 1;
+        if (t < 0) { return false; }
+        got = literalTextTail.charAt(t);
+      }
+      if (got != want) { return false; }
+    }
+    return true;
+  }
+
+  /** Keeps the end of a chunk for {@link #endsWith} to look back into. */
+  private void rememberLiteralTextTail(String emitted) {
+    int n = emitted.length();
+    if (n >= LITERAL_TEXT_TAIL_LENGTH) {
+      literalTextTail = emitted.substring(n - LITERAL_TEXT_TAIL_LENGTH);
+    } else if (n != 0) {
+      String tail = literalTextTail + emitted;
+      int tailLen = tail.length();
+      literalTextTail = tailLen <= LITERAL_TEXT_TAIL_LENGTH
+          ? tail : tail.substring(tailLen - LITERAL_TEXT_TAIL_LENGTH);
+    }
+  }
+
+  /** The longest part of a comment delimiter that can precede a join. */
+  private static final int LITERAL_TEXT_TAIL_LENGTH = 3;
+
+  /**
+   * Pairs of offsets into the chunk {@link #stripTags} is filtering that it
+   * has removed, held until the chunk is done because removing a start tag's
+   * content subsumes the ranges recorded inside it.  Empty while nobody is
+   * listening, so that a chunk full of tags costs nothing but its output.
+   */
+  private int[] droppedRanges = NO_RANGES;
+  /** How much of {@link #droppedRanges} holds ranges. */
+  private int nDroppedRanges;
+
+  private static final int[] NO_RANGES = new int[0];
+
+  /** Records one range removed from a literal-content text chunk. */
+  private void recordDroppedRange(int start, int end) {
+    if (droppedTextListener == null) { return; }
+    int n = nDroppedRanges;
+    // A range that covers ones already recorded replaces them: the text they
+    // held went with it.
+    while (n >= 2 && droppedRanges[n - 2] >= start && droppedRanges[n - 1] <= end) {
+      n -= 2;
+    }
+    if (n + 2 > droppedRanges.length) {
+      droppedRanges = Arrays.copyOf(
+          droppedRanges, Math.max(16, droppedRanges.length * 2));
+    }
+    droppedRanges[n] = start;
+    droppedRanges[n + 1] = end;
+    nDroppedRanges = n + 2;
+  }
+
+  /** Reports the ranges removed from one chunk, in the order they lay. */
+  private void reportDroppedRanges(String elementName, String text) {
+    int n = nDroppedRanges;
+    nDroppedRanges = 0;
+    // A '<' that a removal left able to open a tag is found after the text
+    // that follows it has been looked at, so the ranges can be a little out of
+    // order.  Insertion sort, since they almost always are in it.
+    for (int k = 2; k < n; k += 2) {
+      int start = droppedRanges[k], end = droppedRanges[k + 1];
+      int j = k;
+      while (j > 0 && droppedRanges[j - 2] > start) {
+        droppedRanges[j] = droppedRanges[j - 2];
+        droppedRanges[j + 1] = droppedRanges[j - 1];
+        j -= 2;
+      }
+      droppedRanges[j] = start;
+      droppedRanges[j + 1] = end;
+    }
+    for (int k = 0; k < n; k += 2) {
+      droppedTextListener.droppedText(
+          elementName,
+          text.substring(droppedRanges[k], droppedRanges[k + 1]));
     }
   }
 
   /**
-   * True if the renderer emits the element's text as it is, without
-   * escaping, so that a tag in that text would reach the browser as written.
-   * Judged by the name the renderer emits: it renames {@code xmp},
-   * {@code listing} and {@code plaintext} to {@code pre} and escapes their
-   * text.
+   * True if the text of an element kept as {@code adjustedElementName} reaches
+   * a browser as written, so that a tag in it would be a tag to the browser
+   * and {@link #stripTags} has to run over it.
+   * <p>
+   * {@link HtmlStreamRenderer} escapes the text of the elements it renames --
+   * {@code xmp}, {@code listing} and {@code plaintext} become {@code pre} --
+   * and escapes the content of every element inside {@code svg} or
+   * {@code math}, which a browser parses as markup.  Where the output is one
+   * of those renderers the filter follows it exactly, so that nothing is
+   * stripped from text the renderer escapes anyway.  Any other
+   * {@link HtmlStreamEventReceiver} may write the text as it stands, under the
+   * name the policy gives it, so for those every element whose content the
+   * lexer read as raw text is filtered, wherever it sits.
    */
-  private static boolean isLiteralContentElement(String elementName) {
-    switch (HtmlTextEscapingMode.getModeForTag(
-                HtmlStreamRenderer.safeName(elementName))) {
-      case CDATA:
-      case CDATA_SOMETIMES:
-      case PLAIN_TEXT:
-        return true;
-      default:
-        return false;
-    }
+  private boolean isLiteralContentElement(String adjustedElementName) {
+    return outIsLibraryRenderer
+        ? HtmlStreamRenderer.emitsContentLiterally(
+              HtmlStreamRenderer.safeName(adjustedElementName),
+              inForeignContent)
+        : HtmlStreamRenderer.emitsContentLiterally(adjustedElementName, false);
   }
 
   public void openTag(String elementName, List<String> attrs) {
@@ -489,6 +844,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
         openElementStack.subList(i, n).clear();
         skipText = skipTextBeforeOpen.get(i / 2);
         inKeptCdataElement = inKeptCdataBeforeOpen.get(i / 2);
+        inForeignContent = inForeignContentBeforeOpen.get(i / 2);
         keptCdataElementName = keptCdataNameBeforeOpen.get(i / 2);
         keptCdataNameBeforeOpen.subList(
             i / 2, keptCdataNameBeforeOpen.size()).clear();
@@ -512,8 +868,15 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
           && allowedTextContainers.contains(adjustedElementName);
       if (!inKeptCdataElement && enteringKeptCdata) {
         keptCdataElementName = adjustedElementName;
+        literalTextTail = "";
       }
       inKeptCdataElement = inKeptCdataElement || enteringKeptCdata;
+      // Judged before this element is in foreign content itself: a browser
+      // parses the content of an svg or math element as markup, but the
+      // element's own tag sits in whatever contains it.
+      inForeignContent = inForeignContent
+          || HtmlStreamRenderer.FOREIGN_CONTENT_ROOT_ELEMENT_NAMES.contains(
+                 adjustedElementName);
     }
     out.openTag(adjustedElementName, attrs);
   }
@@ -535,6 +898,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     int depth = openElementStack.size() / 2;
     skipTextBeforeOpen.set(depth, skipText);
     inKeptCdataBeforeOpen.set(depth, inKeptCdataElement);
+    inForeignContentBeforeOpen.set(depth, inForeignContent);
     keptCdataNameBeforeOpen.add(keptCdataElementName);
     openElementStack.add(elementName);
     openElementStack.add(adjustedElementName);

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Encoding.java
@@ -417,6 +417,21 @@ public final class Encoding {
   }
 
   /**
+   * True if {@link #stripBannedCodeunits} may elide {@code ch}, so that the
+   * text on either side of it is joined up in the output.  A policy that reads
+   * text has to judge the text that will be emitted, not text that a later
+   * elision would join differently, so this answers true for a surrogate,
+   * which is elided when it is alone and may be when it is paired.
+   */
+  @TCB
+  static boolean isPossiblyElidedCodeunit(char ch) {
+    if (ch < 0x20) { return IS_BANNED_ASCII[ch]; }
+    return (0x7f <= ch && ch <= 0x9f)
+        || (0xd800 <= ch && ch <= 0xdfff)
+        || isNoncharacter(ch);
+  }
+
+  /**
    * Bit {@code c} is set when the BMP character U+c has a compatibility
    * decomposition (NFKD) that contains a printable, non-alphanumeric ASCII
    * character, so that a downstream normalization could turn it into an HTML

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -291,9 +291,13 @@ public final class HtmlChangeReporter<T> {
     private static final String[] ZERO_STRINGS = new String[0];
   }
 
+  /**
+   * Forwards to the renderer, and is one of the library's own decorators so
+   * that the policy can see the renderer behind it and know what it escapes.
+   */
   private static final class OutputChannel
-      implements HtmlStreamEventReceiver, DiscardedAttributeListener {
-    private final HtmlStreamEventReceiver renderer;
+      extends HtmlStreamEventReceiverWrapper
+      implements DiscardedAttributeListener {
     /**
      * The name of the tag the policy has opened in response to the tag being
      * opened, or null while it has opened none.
@@ -315,7 +319,7 @@ public final class HtmlChangeReporter<T> {
     final BitSet emittedAttrs = new BitSet();
 
     OutputChannel(HtmlStreamEventReceiver renderer) {
-      this.renderer = renderer;
+      super(renderer);
     }
 
     /** Starts accounting for the attributes on one input start tag. */
@@ -368,7 +372,7 @@ public final class HtmlChangeReporter<T> {
      */
     void listenForDroppedText(
         @Nullable HtmlStreamRenderer.DroppedTextListener listener) {
-      HtmlStreamEventReceiver r = renderer;
+      HtmlStreamEventReceiver r = underlying;
       while (r instanceof HtmlStreamEventReceiverWrapper) {
         r = ((HtmlStreamEventReceiverWrapper) r).underlying;
       }
@@ -377,14 +381,7 @@ public final class HtmlChangeReporter<T> {
       }
     }
 
-    public void openDocument() {
-      renderer.openDocument();
-    }
-
-    public void closeDocument() {
-      renderer.closeDocument();
-    }
-
+    @Override
     public void openTag(String elementName, List<String> attrs) {
       openedElementName = elementName;
       for (int i = 0, n = attrs.size(); i < n; i += 2) {
@@ -392,7 +389,7 @@ public final class HtmlChangeReporter<T> {
         // stay behind to be reported.
         markFirstEmitted(attrs.get(i));
       }
-      renderer.openTag(elementName, attrs);
+      underlying.openTag(elementName, attrs);
     }
 
     /** Accounts for the first eligible input copy of an emitted name. */
@@ -404,14 +401,6 @@ public final class HtmlChangeReporter<T> {
           return;
         }
       }
-    }
-
-    public void closeTag(String elementName) {
-      renderer.closeTag(elementName);
-    }
-
-    public void text(String text) {
-      renderer.text(text);
     }
   }
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -210,46 +210,30 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
       return;
     }
 
-    if (foreignContentRootElementNames.contains(elementName)) {
+    if (FOREIGN_CONTENT_ROOT_ELEMENT_NAMES.contains(elementName)) {
       foreignContentDepth += 1;
     }
 
+    boolean inForeignContent = foreignContentDepth != 0;
     HtmlTextEscapingMode tentativeEscapingMode =
         HtmlTextEscapingMode.getModeForTag(elementName);
-    decodeTextBeforeEscaping = false;
-    if (foreignContentDepth == 0) {
+    // The lexer delivers the content of a raw-text element without decoding
+    // character references, but browsers parse that content as markup inside
+    // foreign content, so decode it there before re-encoding.
+    decodeTextBeforeEscaping
+        = inForeignContent && emitsContentLiterally(elementName, false);
+    if (!inForeignContent
+        || tentativeEscapingMode == HtmlTextEscapingMode.PCDATA
+        || tentativeEscapingMode == HtmlTextEscapingMode.VOID) {
       escapingMode = tentativeEscapingMode;
     } else {
-      switch (tentativeEscapingMode) {
-        case PCDATA:
-        case VOID:
-          escapingMode = tentativeEscapingMode;
-          break;
-        case CDATA:
-        case CDATA_SOMETIMES:
-        case PLAIN_TEXT:
-          // The lexer delivers the content of these elements as raw text
-          // without decoding character references, but browsers parse it as
-          // markup inside foreign content, so decode before re-encoding.
-          decodeTextBeforeEscaping = true;
-          escapingMode = HtmlTextEscapingMode.RCDATA;
-          break;
-        default: // escape special characters but do not allow tags
-          escapingMode = HtmlTextEscapingMode.RCDATA;
-          break;
-      }
+      // Escape special characters but do not allow tags.
+      escapingMode = HtmlTextEscapingMode.RCDATA;
     }
 
-
-    switch (escapingMode) {
-      case CDATA_SOMETIMES:
-      case CDATA:
-      case PLAIN_TEXT:
-        lastTagOpened = elementName;
-        pendingUnescaped = new StringBuilder();
-        break;
-      default:
-        break;
+    if (emitsContentLiterally(elementName, inForeignContent)) {
+      lastTagOpened = elementName;
+      pendingUnescaped = new StringBuilder();
     }
 
     output.append('<').append(elementName);
@@ -312,7 +296,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     }
 
     if (foreignContentDepth != 0
-        && foreignContentRootElementNames.contains(elementName)) {
+        && FOREIGN_CONTENT_ROOT_ELEMENT_NAMES.contains(elementName)) {
       foreignContentDepth -= 1;
     }
     decodeTextBeforeEscaping = false;
@@ -480,6 +464,31 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   }
 
   /**
+   * True if the content of an element named {@code canonElementName}, written
+   * where {@code inForeignContent} says, is emitted as it is instead of being
+   * escaped, so that a tag in that content would reach the browser as
+   * written.
+   * <p>
+   * This is the one place that decides it.  The renderer asks under the name
+   * it emits, which {@link #safeName} may have substituted, and
+   * {@link ElementAndAttributePolicyBasedSanitizerPolicy}, whose filter has to
+   * run exactly where nothing escapes a tag for it, asks the same question
+   * about the receiver it writes to.
+   */
+  static boolean emitsContentLiterally(
+      String canonElementName, boolean inForeignContent) {
+    if (inForeignContent) { return false; }
+    switch (HtmlTextEscapingMode.getModeForTag(canonElementName)) {
+      case CDATA:
+      case CDATA_SOMETIMES:
+      case PLAIN_TEXT:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
    * Canonicalizes the element name and possibly substitutes an alternative
    * that has more consistent semantics.
    */
@@ -570,6 +579,10 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
     return ch < 63 && 0 != (TAG_ENDS & (1L << ch));
   }
 
-  private static final Set<String> foreignContentRootElementNames =
+  /**
+   * The elements that root foreign content, inside which a browser parses the
+   * content of every element as markup, so that nothing there is literal.
+   */
+  static final Set<String> FOREIGN_CONTENT_ROOT_ELEMENT_NAMES =
       j8().setOf("svg", "math");
 }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -63,7 +63,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   private HtmlTextEscapingMode escapingMode = HtmlTextEscapingMode.PCDATA;
   private boolean open;
   /**
-   * The count of {@link #foreignContentRootElementNames} opened and not
+   * The count of {@link #FOREIGN_CONTENT_ROOT_ELEMENT_NAMES} opened and not
    * subsequently closed.
    */
   private int foreignContentDepth = 0;

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
@@ -1133,6 +1134,47 @@ class HtmlSanitizerTest {
   }
 
   /**
+   * The worst case for the sweep that keeps a removal from leaving a tag
+   * behind: a long run of what could be the start of one, ended by a tag that
+   * goes.  Every {@code <} of the run goes with it, and the run is rewritten
+   * once rather than closed up around each, which would be quadratic: this
+   * text takes well under a second, where closing up each takes half a minute.
+   */
+  @Test
+  void testLongRunOfUnfinishedTagsInLiteralTextIsLinear() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("style", "svg").allowTextIn("style").toFactory();
+    int n = 1_500_000;
+    final String html =
+        "<style>" + stringRepeatedTimes("<b", n) + "<svg></style>";
+
+    String out = assertTimeoutPreemptively(
+        Duration.ofSeconds(20), () -> p.sanitize(html));
+    assertEquals("<style>" + stringRepeatedTimes("b", n) + "</style>", out);
+  }
+
+  /**
+   * The other worst case for the scan: literal text where no {@code <} opens a
+   * tag and the only {@code >} is at the end, so that every {@code <} is
+   * looked at and none of them resolves until the last character.  The scan
+   * remembers the {@code >} it found rather than looking for the same one
+   * again from each {@code <}, which would be quadratic: this text takes
+   * under a second, where looking again takes minutes.
+   */
+  @Test
+  void testLiteralTextFullOfBracketsThatOpenNoTagIsLinear() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("style").allowTextIn("style").toFactory();
+    final String html =
+        "<style>" + stringRepeatedTimes("a<b'", 1_000_000) + ">" + "</style>";
+
+    String out = assertTimeoutPreemptively(
+        Duration.ofSeconds(20), () -> p.sanitize(html));
+    // None of it is a tag, so none of it goes.
+    assertEquals(html, out);
+  }
+
+  /**
    * The filter no longer discards the rest of a chunk after a start tag with
    * no matching end tag, and keeps a {@code <} that opens no tag, so script
    * and style text with a bare comparison survives.
@@ -1147,14 +1189,15 @@ class HtmlSanitizerTest {
     assertEquals(
         "<script>if (a < b) x();</script>",
         policy.sanitize("<script>if (a < b) x();</script>"));
-    // A '<' dangling before a letter at the end of a chunk goes; #470
-    // tracks the fidelity cost.
+    // A '<' dangling before a letter at the end of a chunk goes: a later
+    // chunk could complete it into a tag.
     assertEquals(
         "<script>if (ab) x();</script>",
         policy.sanitize("<script>if (a<b) x();</script>"));
-    // A tag with no matching end tag goes alone; the text after it stays.
+    // "<b'; var t = 'c>" is a tag only where a browser would read "b';" as a
+    // tag name, which is nowhere this text can reach one, so it stays (#470).
     assertEquals(
-        "<script>var s = 'ad';</script>",
+        "<script>var s = 'a<b'; var t = 'c>d';</script>",
         policy.sanitize("<script>var s = 'a<b'; var t = 'c>d';</script>"));
     assertEquals(
         "<style>a{}c{}</style>",
@@ -1171,6 +1214,426 @@ class HtmlSanitizerTest {
     assertEquals(
         "<style>a{}<3>{}</style>",
         policy.sanitize("<style>a{}<3>{}</style>"));
+  }
+
+  /**
+   * Issue #470.  Ordinary script and style text tripped the filter, which
+   * took {@code <} plus anything up to the next {@code >} for a tag, so a
+   * comparison or a loop condition lost the text between.  A tag now needs a
+   * well-formed name.
+   */
+  @Test
+  void testIssue470ComparisonOperatorsInScriptTextSurvive() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("script", "style")
+        .allowTextIn("script", "style")
+        .toFactory();
+
+    for (String js : new String[] {
+            "if (a < b) { x(); } if (c > d) { y(); }",
+            "for(i=0;i<n;i++){a[i]=b>c;}",
+            "a = b << 2 >> 1;",
+            "if (x<y) { g(); } // z>w",
+            "if (a<b){c();}else{d>e;}",
+         }) {
+      assertEquals("<script>" + js + "</script>",
+                   policy.sanitize("<script>" + js + "</script>"), js);
+    }
+    // CSS keeps its own comparisons, and a media query's parentheses.
+    assertEquals(
+        "<style>@media (max-width:10px){a{}}</style>",
+        policy.sanitize("<style>@media (max-width:10px){a{}}</style>"));
+    // What is left: a name followed by whitespace is a tag wherever a browser
+    // reads markup, so "<b ||" goes with everything up to the next '>', as
+    // the "< script>" that test #6 pins does.  The filter cannot tell them
+    // apart, and an end tag hiding there would break out.
+    assertEquals(
+        "<script>if (ad) f();</script>",
+        policy.sanitize("<script>if (a<b || c>d) f();</script>"));
+  }
+
+  /**
+   * Issue #470.  Relaxing what counts as a tag gives up nothing: a browser
+   * reads a weird name as a tag only in a markup context, and the text of a
+   * kept literal-content element never reaches one.  Anything that could end
+   * such an element for a browser has a well-formed name and still goes,
+   * including a name that only becomes one once the renderer elides a
+   * character it cannot emit.
+   */
+  @Test
+  void testIssue470OnlyAWellFormedNameMakesATag() {
+    PolicyFactory policy = noscriptStyleImg();
+
+    // Names a browser could act on, in every shape an element name takes.
+    for (String tag : new String[] {
+            "<img src=x onerror=alert(1)>", "<my-widget onmouseover=alert(1)>",
+            "<svg:a onmouseover=alert(1)>", "<b2 onmouseover=alert(1)>",
+            "<b_c onmouseover=alert(1)>", "<b.c onmouseover=alert(1)>",
+            "< img src=x onerror=alert(1)>", "<img/src=x onerror=alert(1)>",
+         }) {
+      assertEquals(
+          "<style>a{}b{}</style>",
+          policy.sanitize("<style>a{}" + tag + "b{}</style>"), tag);
+    }
+    // A name that is not one stays, and is inert: a browser reads the text of
+    // a style element literally, and an end tag whose name is not an element's
+    // own name does not end it.
+    for (String notATag : new String[] {
+            "<b) onmouseover=alert(1)>", "<n;i++){a[i]=b>", "<b'x'>",
+            "</b) onmouseover=alert(1)>", "</3>",
+         }) {
+      assertEquals(
+          "<style>a{}" + notATag + "b{}</style>",
+          policy.sanitize("<style>a{}" + notATag + "b{}</style>"), notATag);
+    }
+    // The renderer elides a NUL, a DEL and a C1 control, which would
+    // otherwise join a name to what follows it, so they end a name instead.
+    for (String elided : new String[] { "\u0000", "\u007f", "\u0085" }) {
+      assertEquals(
+          "<noscript><style></style></noscript>",
+          policy.sanitize(
+              "<noscript><style></noscript" + elided + ">"
+              + "<img src=x onerror=alert(1)></style></noscript>"),
+          "U+" + Integer.toHexString(elided.charAt(0)));
+      assertEquals(
+          "<style>a{}b{}</style>",
+          policy.sanitize(
+              "<style>a{}<img" + elided + " src=x onerror=alert(1)>b{}"
+              + "</style>"));
+    }
+  }
+
+  /**
+   * Issue #473.  The filter kept a record per tag, so a chunk of literal text
+   * full of tags cost a multiple of its own size in heap, and text that used
+   * to sanitize in 160 MB needed 256 MB.  It now keeps only its output and a
+   * bounded note of the start tags it has not matched, so the cost per tag is
+   * what the lexer already spends on the same text.
+   */
+  @Test
+  void testIssue473LiteralTextFilterKeepsNoRecordPerTag() {
+    java.lang.management.ThreadMXBean threads
+        = java.lang.management.ManagementFactory.getThreadMXBean();
+    assumeTrue(threads instanceof com.sun.management.ThreadMXBean,
+               "needs a JVM that counts allocation per thread");
+    com.sun.management.ThreadMXBean counter
+        = (com.sun.management.ThreadMXBean) threads;
+
+    int n = 200_000;
+    String html = "<style>" + stringRepeatedTimes("<b>x", n) + "</style>";
+    // The same text, filtered and not: one policy keeps the text of a style
+    // element and filters it, the other drops it, so the difference in what
+    // they allocate is the filter's own, without the lexer's share of it.
+    PolicyFactory filtering = new HtmlPolicyBuilder()
+        .allowElements("style").allowTextIn("style").toFactory();
+    PolicyFactory notFiltering = new HtmlPolicyBuilder()
+        .allowElements("style").toFactory();
+    filtering.sanitize(html);
+    notFiltering.sanitize(html);  // Load the classes both use.
+
+    long id = Thread.currentThread().getId();
+    long before = counter.getThreadAllocatedBytes(id);
+    filtering.sanitize(html);
+    long between = counter.getThreadAllocatedBytes(id);
+    notFiltering.sanitize(html);
+    long after = counter.getThreadAllocatedBytes(id);
+
+    long perTag = ((between - before) - (after - between)) / n;
+    // Around 5 bytes a tag, for the output and the string it becomes; a
+    // record per tag cost more than 700.
+    assertTrue(perTag < 64, perTag + " bytes allocated per tag");
+  }
+
+  /**
+   * Issue #473.  Pairing a start tag with its end tag keeps a dropped
+   * element's content with it, which is fidelity rather than safety, so the
+   * filter bounds what it remembers.  Literal text nested deeper than that
+   * loses each tag on its own, and still no tag survives.
+   */
+  @Test
+  void testIssue473LiteralTextNestedPastThePairingBoundIsStillTagFree() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("style").allowTextIn("style").toFactory();
+    for (int depth : new int[] { 8, 64, 65, 100, 1000 }) {
+      String html = "<style>" + stringRepeatedTimes("<b>x", depth)
+          + stringRepeatedTimes("</b>", depth) + "</style>";
+      String out = policy.sanitize(html);
+      String body = out.substring(
+          out.indexOf("<style>") + 7, out.lastIndexOf("</style>"));
+      assertFalse(body.contains("<"), depth + ": " + out);
+      assertFalse(body.contains(">"), depth + ": " + out);
+    }
+  }
+
+  /**
+   * Issue #475.  Removing a tag joins the text on either side of it, which
+   * could make a {@code <!--} or a {@code -->} that the input did not have.
+   * The renderer refuses the whole content of a literal element whose comment
+   * delimiters do not balance, so the element came out empty.  A space goes in
+   * where the join would make one.
+   */
+  @Test
+  void testIssue475RemovingATagDoesNotSpliceACommentDelimiter() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("style", "script", "b")
+        .allowTextIn("style", "script")
+        .toFactory();
+
+    assertEquals(
+        "<style>a{}- ->b{}</style>",
+        policy.sanitize("<style>a{}-<b>->b{}</style>"));
+    assertEquals(
+        "<style>a{}-- >b{}</style>",
+        policy.sanitize("<style>a{}--<b>>b{}</style>"));
+    assertEquals(
+        "<style>a<! --x</style>",
+        policy.sanitize("<style>a<!<b>--x</style>"));
+    assertEquals(
+        "<style>a<!- -x</style>",
+        policy.sanitize("<style>a<!-<b>-x</style>"));
+    // The text on either side of the join can be in different chunks, which
+    // the lexer splits at server-side script tags, so the last of a chunk is
+    // remembered, and a join at the end of one assumes the worst.
+    assertEquals(
+        "<style>a{}- ->b{}</style>",
+        policy.sanitize("<style>a{}-<%%><b>->b{}</style>"));
+    assertEquals(
+        "<style>a{}- ->b{}</style>",
+        policy.sanitize("<style>a{}-<b><%%>->b{}</style>"));
+    // A delimiter the input itself holds is not the filter's to fix: the
+    // renderer still refuses the content, and says so.
+    assertEquals(
+        "<style></style>",
+        policy.sanitize("<style>a{}--><b>b{}</style>"));
+  }
+
+  /**
+   * Issue #475, the other way round: a start tag dropped together with its
+   * content can take a {@code -->} with it and leave an earlier {@code <!--}
+   * unclosed, which costs the whole content again.  Such a pair is dropped
+   * tag by tag instead, so what the comment holds stays.
+   */
+  @Test
+  void testIssue475ADroppedPairDoesNotTakeACommentDelimiter() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("style", "script", "b")
+        .allowTextIn("style", "script")
+        .toFactory();
+
+    assertEquals(
+        "<script><!-- if (a > 0) {  } -->  f();</script>",
+        policy.sanitize(
+            "<script><!-- if (a > 0) { <b> } --> </b> f();</script>"));
+    assertEquals(
+        "<style><!-- a --> b </style>",
+        policy.sanitize("<style><!-- a<b> --> b </b></style>"));
+    // A pair whose content holds no delimiter still goes whole.
+    assertEquals(
+        "<style>a{}c{}</style>",
+        policy.sanitize("<style>a{}<b>x - y</b>c{}</style>"));
+  }
+
+  /**
+   * Removing a tag must not splice what is on either side of it into another
+   * tag, nor leave the element's own end tag to finish one.  A browser reads
+   * the text of a kept literal-content element literally, so none of this is
+   * reachable, but the filter must not hand one a tag the text did not hold:
+   * {@code <b<svg>} is a tag a browser acts on and the text after it is text,
+   * while {@code <b} followed by that text is a tag with a live handler.
+   */
+  @Test
+  void testRemovingATagDoesNotSpliceAnotherTag() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("noscript", "style", "script", "svg", "b", "img", "p")
+        .allowTextIn("style", "script")
+        .allowAttributes("src").onElements("img")
+        .allowUrlProtocols("https")
+        .toFactory();
+
+    // The "<b" the removed tag followed goes, so the text after it cannot
+    // become its attributes.
+    assertEquals(
+        "<style>b onmouseover=alert(1)>x</style>",
+        policy.sanitize("<style><b<svg> onmouseover=alert(1)>x</style>"));
+    // Every '<' of the run goes: dropping one leaves the next before a name.
+    assertEquals(
+        "<style>bb onmouseover=alert(1)>x</style>",
+        policy.sanitize("<style><b<b<svg> onmouseover=alert(1)>x</style>"));
+    // A "</" before the removed tag would have met the name after it, which
+    // is the breakout the filter exists to stop.
+    assertEquals(
+        "<style>/noscript></style>",
+        policy.sanitize("<style></<b>noscript></style>"));
+    assertEquals(
+        "<noscript><style>/noscript></style></noscript>",
+        policy.sanitize(
+            "<noscript><style></<b>noscript>"
+            + "<img src=x onerror=alert(1)></style></noscript>"));
+    // At the end of the text it is the element's own end tag that would
+    // finish the tag, whether or not a '>' came earlier.
+    assertEquals(
+        "<style>a{}b</style>",
+        policy.sanitize("<style>a{}<b<svg></style>"));
+    assertEquals(
+        "<script>x> x<3/style</script>",
+        policy.sanitize("<script>x><p> x<3</style<B></script>"));
+    // A start tag the text kept has a place to come back to that the sweep
+    // has already been over, so its end tag cannot cut the text short.
+    assertEquals(
+        "<noscript><style>--bnoscript></style></noscript>",
+        policy.sanitize(
+            "<noscript><style>--<b<b/></><style></ b>noscript></noscript>"));
+    // What opens no tag stays: "3" is no name, and no browser state starts a
+    // tag at '<' and whitespace.
+    assertEquals(
+        "<style>a{}<3{}</style>",
+        policy.sanitize("<style>a{}<3<svg>{}</style>"));
+    assertEquals(
+        "<style>a{}< b{}</style>",
+        policy.sanitize("<style>a{}< b<svg>{}</style>"));
+    // And ordinary text is untouched.
+    assertEquals(
+        "<style>a{}c{}</style>",
+        policy.sanitize("<style>a{}<b>c{}</style>"));
+    assertEquals(
+        "<script>var s = 'a<b'; var t = 'c>d';</script>",
+        policy.sanitize("<script>var s = 'a<b'; var t = 'c>d';</script>"));
+  }
+
+  /**
+   * Issue #474.  Inside {@code svg} or {@code math} a browser parses the
+   * content of every element as markup, so the renderer escapes the text of a
+   * style or script element there instead of emitting it as written.  The
+   * filter used to strip the tags from that text as well, which was safe but
+   * lost them for no reason.
+   */
+  @Test
+  void testIssue474LiteralTextInForeignContentIsEscapedNotStripped() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("svg", "math", "style", "script", "b")
+        .allowTextIn("style", "script", "svg", "math")
+        .toFactory();
+
+    assertEquals(
+        "<svg><style>a{}&lt;b&gt;x&lt;/b&gt;c{}</style></svg>",
+        policy.sanitize("<svg><style>a{}<b>x</b>c{}</style></svg>"));
+    assertEquals(
+        "<math><script>a&lt;b&gt;c</script></math>",
+        policy.sanitize("<math><script>a<b>c</script></math>"));
+    // Escaped, so a breakout cannot ride along on it either.
+    assertEquals(
+        "<svg><style>&lt;/noscript&gt;&lt;img src&#61;x onerror&#61;alert(1)&gt;"
+        + "</style></svg>",
+        policy.sanitize(
+            "<svg><style></noscript><img src=x onerror=alert(1)></style>"
+            + "</svg>"));
+    // Outside the svg the same element's text is emitted as written, so the
+    // filter runs over it: the tags go and the end tag with them.
+    assertEquals(
+        "<svg></svg><style>a{}c{}</style>",
+        policy.sanitize("<svg></svg><style>a{}<b>x</b>c{}</style>"));
+    assertEquals(
+        "<svg><b></b></svg><style>a{}c{}</style>",
+        policy.sanitize("<svg><b></b></svg><style>a{}<b>x</b>c{}</style>"));
+  }
+
+  /**
+   * Issue #474.  The filter judged the element by the name the library's own
+   * renderer emits, which renames {@code xmp}, {@code listing} and
+   * {@code plaintext} to {@code pre} and escapes their text.  A receiver
+   * handed to {@link PolicyFactory#apply} does not rename, so it used to
+   * receive the text of those elements with its tags intact, a
+   * {@code </noscript>} among them, and the renderer-side check cannot run
+   * for it either.  With any other receiver every element whose content the
+   * lexer read as raw text is filtered.
+   */
+  @Test
+  void testIssue474ACustomReceiverGetsRawTextWithoutTags() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("noscript", "xmp", "listing", "plaintext", "style",
+                       "img")
+        .allowTextIn("xmp", "listing", "plaintext", "style")
+        .allowAttributes("src").onElements("img")
+        .toFactory();
+
+    for (String rawText : new String[] { "xmp", "listing", "plaintext" }) {
+      String html = "<noscript><" + rawText + "></noscript>"
+          + "<img src=x onerror=alert(1)></" + rawText + "></noscript>";
+      final List<String> text = new ArrayList<>();
+      HtmlSanitizer.sanitize(html, policy.apply(collectText(text)));
+      assertEquals(Arrays.asList(""), text, rawText);
+
+      // Through the library's renderer, which renames the element and escapes
+      // its text, the tags are still there to see.  A plaintext element runs
+      // to the end of the input, so its own end tag is part of its text.
+      assertEquals(
+          "<noscript><pre>&lt;/noscript&gt;&lt;img src&#61;x"
+          + " onerror&#61;alert(1)&gt;"
+          + ("plaintext".equals(rawText)
+             ? "&lt;/plaintext&gt;&lt;/noscript&gt;" : "")
+          + "</pre></noscript>",
+          policy.sanitize(html), rawText);
+    }
+    // A receiver the library cannot see through gets no tags in the text of a
+    // style element inside an svg either, where the renderer would escape
+    // them, since it may write what it is given as it stands.
+    PolicyFactory svgPolicy = new HtmlPolicyBuilder()
+        .allowElements("svg", "style", "b").allowTextIn("style", "svg")
+        .toFactory();
+    final List<String> text = new ArrayList<>();
+    HtmlSanitizer.sanitize(
+        "<svg><style>a{}<b>x</b>c{}</style></svg>",
+        svgPolicy.apply(collectText(text)));
+    assertEquals(Arrays.asList("a{}c{}"), text);
+  }
+
+  /** A receiver that records the text events it is given. */
+  private static HtmlStreamEventReceiver collectText(final List<String> text) {
+    return new HtmlStreamEventReceiver() {
+      public void openDocument() { /* Not under test. */ }
+
+      public void closeDocument() { /* Not under test. */ }
+
+      public void openTag(String elementName, List<String> attrs) {
+        // Not under test.
+      }
+
+      public void closeTag(String elementName) { /* Not under test. */ }
+
+      public void text(String t) { text.add(t); }
+    };
+  }
+
+  /**
+   * Listening for what a policy drops must not change what it keeps.  The
+   * filter follows what the receiver escapes, and a reporter sits between the
+   * policy and the renderer, so the renderer has to stay visible behind it.
+   */
+  @Test
+  void testTheLiteralTextFilterDoesNotDependOnAListener() {
+    PolicyFactory policy = new HtmlPolicyBuilder()
+        .allowElements("svg", "style", "xmp", "b")
+        .allowTextIn("style", "xmp", "svg")
+        .toFactory();
+    HtmlChangeListener<Object> ignore = new HtmlChangeListener<Object>() {
+      public void discardedTag(Object context, String elementName) {
+        // Not under test.
+      }
+
+      public void discardedAttributes(
+          Object context, String tagName, String... attributeNames) {
+        // Not under test.
+      }
+    };
+
+    for (String html : new String[] {
+            "<svg><style>a{}<b>x</b>c{}</style></svg>",
+            "<style>a{}<b>x</b>c{}</style>",
+            "<xmp>a<b>x</b>c</xmp>",
+         }) {
+      assertEquals(
+          policy.sanitize(html), policy.sanitize(html, ignore, null), html);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #470, closes #473, closes #474, closes #475.

## Summary

The four follow-ups from the review of #465 all live in the same ~120 lines, so
the filter on the text of a kept literal-content element is rewritten once, as a
single pass that keeps no record per tag. Built on #477, which had just landed.

**#470 — a tag needs a well-formed name.** The filter took `<`, optional
whitespace, a letter and everything to the next `>` for a tag, so ordinary
script and style text lost the text between its brackets. A name is now an ASCII
letter and then letters, digits, `-`, `_`, `:` or `.`, ending at whitespace, `/`
or `>`; running into anything else the output keeps makes it no name:

| input | before | now |
|---|---|---|
| `if (a < b) { x(); } if (c > d) { y(); }` | `if (a  d) { y(); }` | unchanged |
| `for(i=0;i<n;i++){a[i]=b>c;}` | `for(i=0;ic;}` | unchanged |
| `var s = 'a<b'; var t = 'c>d';` | `var s = 'ad';` | unchanged |

Fixture #6 still strips `< script>`, and a name the renderer's elision would
otherwise assemble (`</noscript` NUL `>`, DEL, a C1 control) is still removed —
`Encoding` gains `isPossiblyElidedCodeunit` for that, since a policy has to
judge the text that will be emitted.

I checked the relaxation against Chrome 152 rather than the spec alone: a weird
name **is** a live element with a live handler where a browser parses markup
(`<b)` → `localName "b)"`, `onmouseover` a function, fires), so the question is
whether such text can reach a markup context. It cannot: an end tag that would
break a raw-text element open has a well-formed name and still goes, the
renderer refuses content holding one anyway (#472), text in a literal element
under a `select` is dropped by the balancer (CVE-2021-42575), and in foreign
content the renderer escapes. Chrome also confirms `</b)>` does not end a
raw-text `noscript`, while `</noscript/>`, `</noscript >` and `</NOSCRIPT>` do
— all of which the filter removes.

**#473 — the filter's memory is its output.** No `int[]` per tag, no `ArrayList`,
no `ArrayDeque`, no boxed `Integer`, and `tagNameOf`'s `String.split("\\s")` is
gone. Pairing reads a bounded note of the start tags not yet matched and
compares names where they lie; removed ranges are recorded only while a listener
is attached. Fixtures #2 and #3 pin start-tag-plus-content removal, so the
pairing stays — bounded, because it buys fidelity rather than safety.

- `<style>` + 3M × `<b>x` + `</style>` (12 MB): `OutOfMemoryError` at `-Xmx160m`
  before, sanitizes at `-Xmx96m` now.
- Allocation for 200k tags: 836 bytes/tag before, 111 now — of which 104 is what
  the lexer spends on the same text either way, so the filter's own share went
  from ~730 bytes/tag to ~7. The new test measures that difference.

**#475 — a removal must not splice something new.** Joining the text on either
side of a removed tag could make a `<!--` or `-->`, and a dropped pair could
take a `-->` with it; either left the element's comments unbalanced, which costs
its whole content:

| input | before | now |
|---|---|---|
| `<style>a{}-<b>->b{}</style>` | `<style></style>` | `<style>a{}- ->b{}</style>` |
| `<style>a{}--<b>>b{}</style>` | `<style></style>` | `<style>a{}-- >b{}</style>` |
| `<script><!-- if (a > 0) { <b> } --> </b> f();</script>` | `<script></script>` | content kept |

A space goes in only where the join would make a delimiter, so no existing
expectation moves; the element's text is remembered across chunk boundaries,
because the lexer splits literal text at `<%...%>` and the join can straddle
chunks (`<style>a{}-<%%><b>->b{}</style>` was empty too). A pair that would take
a delimiter with it is dropped tag by tag instead.

**#474 — one predicate for where text is emitted as written.** `HtmlStreamRenderer`
now has the only copy of that decision and the policy asks it, with the
foreign-content depth the policy tracks alongside its other per-element gates:

- `<svg><style>a{}<b>x</b>c{}</style></svg>` keeps its tags again, escaped by the
  renderer as RCDATA, instead of having them stripped for nothing.
- A receiver handed to `PolicyFactory.apply` does not rename `xmp`, `listing` and
  `plaintext` to `pre`, so it used to receive their text with a `</noscript>`
  intact, and the renderer-side check does not run for it. With any receiver but
  the library's own renderer, every element whose content the lexer read as raw
  text is filtered.

`HtmlChangeReporter.OutputChannel` becomes one of the library's own decorators so
the renderer stays visible behind it; otherwise attaching a listener would change
what the filter strips, which a new test pins.

## Two more holes the fuzzing turned up

Both are on `main` today and are fixed here, with the splice tests beside the
#475 ones:

- `<style><b<svg> onmouseover=alert(1)>x</style>` emitted
  `<b onmouseover=alert(1)>x` inside the style body: the input's tag was
  `<b<svg>` and what followed it was text, so removing the tag turned that text
  into a live handler. A sweep now takes the `<` of anything a removal, or the
  element's own end tag, would finish into a tag, while `<3` and `< b` stay.
- `<style></<b>noscript></style>` handed a receiver `</noscript>` verbatim — a
  real breakout for a custom receiver, caught only by the renderer's backstop on
  the `sanitize` path. It now emits `/noscript>`.

## Test plan

- 18 new or reworked tests in `HtmlSanitizerTest`; 8 of them fail against
  `main`'s library code, one per issue and then some, and the listener test fails
  without the reporter change. 551 tests pass in all.
- Three linearity tests guard the scan's worst cases, each of which I measured
  quadratic first: 1M `<` that open no tag with one `>` at the end (101 s → 92
  ms), a 1.5M-long run of unfinished tags ended by a removable one (12 s → 80
  ms), and the existing 200k unmatched tags.
- Local fuzzing beyond the suite: 2.4M hostile literal-text cases, delivered
  whole and one character at a time, with an oracle for an end tag a browser
  acts on and for a start tag a browser acts on. `main` leaves ~3,900 tag shapes
  per 200k cases, including the `</noscript>` above; this leaves none. Output
  idempotence also improves (14.2% → 10.1% of cases differ on a second pass; the
  remainder is #465's dangling-`<` rule, unchanged here).
- `./mvnw clean verify` passes on JDK 11, 17, 21 and 25, fuzzers, AntiSamy suite
  and JPMS consumer check included.

## Fidelity left on the table

`if (a<b || c>d) f();` still loses ` b || c`: a name followed by whitespace is a
tag wherever a browser reads markup, exactly like the `< script>` that fixture #6
pins, and the filter cannot tell them apart. A test records that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4kNbd4REPF5ozRjnCu6tW
