### PR TITLE
Keep a table open across content a browser would put in front of it (#342)

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -13,9 +13,14 @@ Most recent at top.
       output cannot put anything in front of a tag already written, so the
       table is written twice, once empty and once with the later rows, and
       text pushed out of a table follows it rather than preceding it as in a
-      browser; a browser reads the rest as it reads the input.  A link
-      pushed out of a table is not written again around or inside another
-      link.
+      browser; a browser reads the rest as it reads the input.  Such content
+      is judged by the element that holds the table, which is where a
+      browser puts it: that element closes if it cannot hold the content,
+      and supplies the elements a browser would imply around it, such as the
+      `select` around an `option`.  A link is no longer written again around
+      or inside another link, with or without a table involved, since a
+      browser's parse unnests links and the output would read back as a
+      different tree.
     * What `HtmlStreamRenderer` leaves out now reaches an `HtmlChangeListener`
       as well as the renderer's bad-HTML handler: a start tag whose name is
       not one HTML allows, which an `ElementPolicy` can produce by renaming,

--- a/change_log.md
+++ b/change_log.md
@@ -20,7 +20,12 @@ Most recent at top.
       `select` around an `option`.  A link is no longer written again around
       or inside another link, with or without a table involved, since a
       browser's parse unnests links and the output would read back as a
-      different tree.
+      different tree.  Table-part names in SVG and MathML stay in foreign
+      content, including across stray end tags, while names at HTML integration
+      points still return to the table.  Implied table structure observes the
+      nesting limit.  If an element policy drops the table written again for
+      later rows, or renames it, the synthetic replacement and its row
+      structure are suppressed while allowed cell text survives.
     * What `HtmlStreamRenderer` leaves out now reaches an `HtmlChangeListener`
       as well as the renderer's bad-HTML handler: a start tag whose name is
       not one HTML allows, which an `ElementPolicy` can produce by renaming,

--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,20 @@
 
 Most recent at top.
   * Next release
+    * Content that cannot go inside a table, such as a `div` between its
+      rows, no longer stays open until the end of the document, taking the
+      rows and everything after the table with it (#342).  A browser puts
+      such content in front of the table and keeps the table open, so that
+      the next row pops the content and carries on in the same table.  The
+      tag balancer now keeps the table, and any row group and row, on its
+      stack while closing them in the output, closes the content when a part
+      of the table arrives, and writes the table again for that part.  The
+      output cannot put anything in front of a tag already written, so the
+      table is written twice, once empty and once with the later rows, and
+      text pushed out of a table follows it rather than preceding it as in a
+      browser; a browser reads the rest as it reads the input.  A link
+      pushed out of a table is not written again around or inside another
+      link.
     * What `HtmlStreamRenderer` leaves out now reaches an `HtmlChangeListener`
       as well as the renderer's bad-HTML handler: a start tag whose name is
       not one HTML allows, which an `ElementPolicy` can produce by renaming,

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -49,6 +49,9 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     implements HtmlSanitizer.Policy,
                TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy,
                TagBalancingHtmlStreamEventReceiver.OpenTagOutputPolicy,
+               TagBalancingHtmlStreamEventReceiver.OpenTagSuppressionPolicy,
+               TagBalancingHtmlStreamEventReceiver.ReopenedTablePolicy,
+               TagBalancingHtmlStreamEventReceiver.OutputContextPolicy,
                HtmlChangeReporter.AttributelessSkipPolicy,
                HtmlChangeReporter.DroppedTextSource,
                HtmlChangeReporter.DiscardedAttributeSource {
@@ -105,6 +108,9 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    * emits.  {@link #isLiteralContentElement} says why it matters.
    */
   private boolean inForeignContent;
+  /** Browser tree-construction context for the tags actually emitted. */
+  private HtmlSanitizer.ForeignContentContext outputForeignContent
+      = new HtmlSanitizer.ForeignContentContext();
   /**
    * The last few characters emitted for the kept literal-content element that
    * is open.  Text arrives in chunks, and {@link #stripTags} needs them to see
@@ -187,6 +193,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     inKeptCdataElement = false;
     keptCdataElementName = null;
     inForeignContent = false;
+    outputForeignContent = new HtmlSanitizer.ForeignContentContext();
     literalTextTail = "";
     droppedTextListener = null;
     discardedAttributeListener = null;
@@ -204,6 +211,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     for (int i = openElementStack.size() - 1; i >= 0; i -= 2) {
       String tagNameToClose = openElementStack.get(i);
       if (tagNameToClose != null) {
+        outputForeignContent.processEndTag(tagNameToClose);
         out.closeTag(tagNameToClose);
       }
     }
@@ -232,6 +240,20 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
   public @Nullable String outputElementNameForLastOpenTag() {
     return outputElementNameForLastOpenTag;
+  }
+
+  public boolean isOutputInForeignContent() {
+    return outputForeignContent.isInForeignContent();
+  }
+
+  public @Nullable String outputForeignContentRootName() {
+    return outputForeignContent.outermostForeignElementName();
+  }
+
+  public boolean outputStartTagUsesForeignContentRules(
+      String elementName, List<String> attrs) {
+    return outputForeignContent.startTagUsesForeignContentRules(
+        elementName, attrs);
   }
 
   public void text(String textChunk) {
@@ -762,19 +784,52 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   }
 
   public void openTag(String elementName, List<String> attrs) {
+    openTag(elementName, attrs, OpenTagMode.NORMAL);
+  }
+
+  public void openTagWithoutOutput(String elementName, List<String> attrs) {
+    openTag(elementName, attrs, OpenTagMode.SUPPRESS);
+  }
+
+  public void openReopenedTable(List<String> attrs) {
+    openTag("table", attrs, OpenTagMode.REOPENED_TABLE);
+  }
+
+  private void openTag(
+      String elementName, List<String> attrs, OpenTagMode mode) {
     outputElementNameForLastOpenTag = null;
     ElementAndAttributePolicies policies = elAndAttrPolicies.get(elementName);
     String adjustedElementName = applyPolicies(elementName, attrs, policies);
     skippedLastTagAsAttributeless = false;
     if (adjustedElementName != null) {
       if (!(attrs.isEmpty() && policies.htmlTagSkipType.skipAvailability())) {
-        writeOpenTag(policies, adjustedElementName, attrs);
+        if (mode == OpenTagMode.NORMAL
+            || (mode == OpenTagMode.REOPENED_TABLE
+                && "table".equals(adjustedElementName))) {
+          writeOpenTag(policies, adjustedElementName, attrs);
+        } else if (!HtmlTextEscapingMode.isVoidElement(elementName)) {
+          push(elementName, null);
+          skipText = !allowedTextContainers.contains(elementName)
+              || disallowedTextContainers.contains(elementName)
+              // An emitted HTML breakout can leave the renderer's lexical
+              // SVG/Math nesting open after the browser context has left it.
+              // Text from a suppressed table part cannot be placed safely in
+              // that stale lexical context, so fail closed for that text.
+              || (inForeignContent
+                  && !outputForeignContent.isInForeignContent());
+        }
         return;
       }
       // The element was allowed; it goes only because no attribute survived.
       skippedLastTagAsAttributeless = true;
     }
     deferOpenTag(elementName);
+  }
+
+  private enum OpenTagMode {
+    NORMAL,
+    REOPENED_TABLE,
+    SUPPRESS,
   }
 
   public boolean skippedLastTagAsAttributeless() {
@@ -841,6 +896,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
         for (int j = n - 1; j > i; j -= 2) {
           String tagNameToClose = openElementStack.get(j);
           if (tagNameToClose != null) {
+            outputForeignContent.processEndTag(tagNameToClose);
             out.closeTag(tagNameToClose);
           }
         }
@@ -866,10 +922,15 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     // on the name the policy emitted it under.  The stack follows suit, so
     // that every entry on it is one a close tag can pop.
     if (HtmlTextEscapingMode.isVoidElement(elementName)) {
+      boolean adjustedIsVoid =
+          HtmlTextEscapingMode.isVoidElement(adjustedElementName);
+      outputForeignContent.processStartTag(
+          adjustedElementName, attrs, adjustedIsVoid);
       out.openTag(adjustedElementName, attrs);
-      if (!HtmlTextEscapingMode.isVoidElement(adjustedElementName)) {
+      if (!adjustedIsVoid) {
         // Renamed to an element that needs closing, which nothing upstream
         // will do: closed at once, so it does not swallow what follows.
+        outputForeignContent.processEndTag(adjustedElementName);
         out.closeTag(adjustedElementName);
       }
       return;
@@ -881,6 +942,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       // a dropped element.
       push(elementName, null);
       skipText = skipText || suppressesTextWhenDropped(elementName);
+      outputForeignContent.processStartTag(adjustedElementName, attrs, true);
       out.openTag(adjustedElementName, attrs);
       return;
     }
@@ -907,6 +969,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     inForeignContent = inForeignContent
         || HtmlStreamRenderer.FOREIGN_CONTENT_ROOT_ELEMENT_NAMES.contains(
                adjustedElementName);
+    outputForeignContent.processStartTag(adjustedElementName, attrs, false);
     out.openTag(adjustedElementName, attrs);
   }
 

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -49,9 +49,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     implements HtmlSanitizer.Policy,
                TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy,
                TagBalancingHtmlStreamEventReceiver.OpenTagOutputPolicy,
-               TagBalancingHtmlStreamEventReceiver.OpenTagSuppressionPolicy,
-               TagBalancingHtmlStreamEventReceiver.ReopenedTablePolicy,
-               TagBalancingHtmlStreamEventReceiver.OutputContextPolicy,
+               TagBalancingHtmlStreamEventReceiver.PushedOutTablePolicy,
                HtmlChangeReporter.AttributelessSkipPolicy,
                HtmlChangeReporter.DroppedTextSource,
                HtmlChangeReporter.DiscardedAttributeSource {
@@ -241,6 +239,8 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   public @Nullable String outputElementNameForLastOpenTag() {
     return outputElementNameForLastOpenTag;
   }
+
+  public boolean supportsPushedOutTableOperations() { return true; }
 
   public boolean isOutputInForeignContent() {
     return outputForeignContent.isInForeignContent();

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -33,8 +33,11 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import org.owasp.html.TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy;
 import org.owasp.html.TagBalancingHtmlStreamEventReceiver.OpenTagOutputPolicy;
+import org.owasp.html.TagBalancingHtmlStreamEventReceiver.OpenTagSuppressionPolicy;
+import org.owasp.html.TagBalancingHtmlStreamEventReceiver.OutputContextPolicy;
+import org.owasp.html.TagBalancingHtmlStreamEventReceiver.ReopenedTablePolicy;
+import org.owasp.html.TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy;
 
 /**
  * Sits between the HTML parser, the policy, and the renderer so that it
@@ -127,8 +130,11 @@ public final class HtmlChangeReporter<T> {
   private static final class InputChannel<T>
       implements HtmlSanitizer.Policy,
                  TagBalancingHtmlStreamEventReceiver.NestingLimitListener,
-                 TextSuppressionPolicy,
                  OpenTagOutputPolicy,
+                 OpenTagSuppressionPolicy,
+                 OutputContextPolicy,
+                 ReopenedTablePolicy,
+                 TextSuppressionPolicy,
                  HtmlStreamRenderer.DropListener {
     HtmlStreamEventReceiver policy;
     final OutputChannel output;
@@ -138,6 +144,12 @@ public final class HtmlChangeReporter<T> {
     final List<String> pendingDroppedText = new ArrayList<>();
     /** Output name produced in response to the most recent input start tag. */
     private @Nullable String outputElementNameForLastOpenTag;
+
+    private enum OpenTagMode {
+      NORMAL,
+      REOPENED_TABLE,
+      SUPPRESS,
+    }
 
     InputChannel(
         OutputChannel output, HtmlChangeListener<? super T> listener,
@@ -201,6 +213,24 @@ public final class HtmlChangeReporter<T> {
       return outputElementNameForLastOpenTag;
     }
 
+    public boolean isOutputInForeignContent() {
+      return policy instanceof OutputContextPolicy
+          && ((OutputContextPolicy) policy).isOutputInForeignContent();
+    }
+
+    public @Nullable String outputForeignContentRootName() {
+      return policy instanceof OutputContextPolicy
+          ? ((OutputContextPolicy) policy).outputForeignContentRootName()
+          : null;
+    }
+
+    public boolean outputStartTagUsesForeignContentRules(
+        String elementName, List<String> attrs) {
+      return policy instanceof OutputContextPolicy
+          && ((OutputContextPolicy) policy)
+              .outputStartTagUsesForeignContentRules(elementName, attrs);
+    }
+
     public void openDocument() {
       pendingDroppedText.clear();
       outputElementNameForLastOpenTag = null;
@@ -237,11 +267,40 @@ public final class HtmlChangeReporter<T> {
     }
 
     public void openTag(String elementName, List<String> attrs) {
+      openTag(elementName, attrs, OpenTagMode.NORMAL);
+    }
+
+    public void openTagWithoutOutput(
+        String elementName, List<String> attrs) {
+      openTag(elementName, attrs, OpenTagMode.SUPPRESS);
+    }
+
+    public void openReopenedTable(List<String> attrs) {
+      openTag("table", attrs, OpenTagMode.REOPENED_TABLE);
+    }
+
+    private void openTag(
+        String elementName, List<String> attrs, OpenTagMode mode) {
       output.openedElementName = null;
       // Copied before the policy runs: it removes rejected attributes from
       // attrs in place, and their values are wanted for the report.
       output.expectAttributes(attrs);
-      policy.openTag(elementName, attrs);
+      if (mode == OpenTagMode.REOPENED_TABLE) {
+        if (!(policy instanceof ReopenedTablePolicy)) {
+          throw new IllegalStateException(
+              "Policy cannot safely reopen a table");
+        }
+        ((ReopenedTablePolicy) policy).openReopenedTable(attrs);
+      } else if (mode == OpenTagMode.SUPPRESS) {
+        if (!(policy instanceof OpenTagSuppressionPolicy)) {
+          throw new IllegalStateException(
+              "Policy cannot suppress a table-structure tag");
+        }
+        ((OpenTagSuppressionPolicy) policy)
+            .openTagWithoutOutput(elementName, attrs);
+      } else {
+        policy.openTag(elementName, attrs);
+      }
       {
         // Gather the notification details to avoid any problems with the
         // listener re-entering the stream event receiver.  This shouldn't
@@ -249,8 +308,10 @@ public final class HtmlChangeReporter<T> {
         //
         // The tag survived if the policy opened anything in response and
         // the renderer wrote it.  Its name is not compared with the input
-        // name: an ElementPolicy may rename the element, and a renamed
-        // element was kept, not dropped.
+        // name: an ElementPolicy may rename an ordinary element, and that
+        // renamed element was kept.  A synthetic table reopen is the exception:
+        // its policy result is deliberately suppressed unless it remains a
+        // table, so it is reported as discarded here.
         boolean discarded = output.openedElementName == null;
         outputElementNameForLastOpenTag = output.openedElementName;
         output.openedElementName = null;

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlChangeReporter.java
@@ -34,9 +34,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import org.owasp.html.TagBalancingHtmlStreamEventReceiver.OpenTagOutputPolicy;
-import org.owasp.html.TagBalancingHtmlStreamEventReceiver.OpenTagSuppressionPolicy;
-import org.owasp.html.TagBalancingHtmlStreamEventReceiver.OutputContextPolicy;
-import org.owasp.html.TagBalancingHtmlStreamEventReceiver.ReopenedTablePolicy;
+import org.owasp.html.TagBalancingHtmlStreamEventReceiver.PushedOutTablePolicy;
 import org.owasp.html.TagBalancingHtmlStreamEventReceiver.TextSuppressionPolicy;
 
 /**
@@ -131,9 +129,7 @@ public final class HtmlChangeReporter<T> {
       implements HtmlSanitizer.Policy,
                  TagBalancingHtmlStreamEventReceiver.NestingLimitListener,
                  OpenTagOutputPolicy,
-                 OpenTagSuppressionPolicy,
-                 OutputContextPolicy,
-                 ReopenedTablePolicy,
+                 PushedOutTablePolicy,
                  TextSuppressionPolicy,
                  HtmlStreamRenderer.DropListener {
     HtmlStreamEventReceiver policy;
@@ -213,22 +209,34 @@ public final class HtmlChangeReporter<T> {
       return outputElementNameForLastOpenTag;
     }
 
+    public boolean supportsPushedOutTableOperations() {
+      PushedOutTablePolicy tablePolicy = pushedOutTablePolicy();
+      return tablePolicy != null
+          && tablePolicy.supportsPushedOutTableOperations();
+    }
+
     public boolean isOutputInForeignContent() {
-      return policy instanceof OutputContextPolicy
-          && ((OutputContextPolicy) policy).isOutputInForeignContent();
+      PushedOutTablePolicy tablePolicy = pushedOutTablePolicy();
+      return tablePolicy != null && tablePolicy.isOutputInForeignContent();
     }
 
     public @Nullable String outputForeignContentRootName() {
-      return policy instanceof OutputContextPolicy
-          ? ((OutputContextPolicy) policy).outputForeignContentRootName()
-          : null;
+      PushedOutTablePolicy tablePolicy = pushedOutTablePolicy();
+      return tablePolicy != null
+          ? tablePolicy.outputForeignContentRootName() : null;
     }
 
     public boolean outputStartTagUsesForeignContentRules(
         String elementName, List<String> attrs) {
-      return policy instanceof OutputContextPolicy
-          && ((OutputContextPolicy) policy)
-              .outputStartTagUsesForeignContentRules(elementName, attrs);
+      PushedOutTablePolicy tablePolicy = pushedOutTablePolicy();
+      return tablePolicy != null
+          && tablePolicy.outputStartTagUsesForeignContentRules(
+              elementName, attrs);
+    }
+
+    private @Nullable PushedOutTablePolicy pushedOutTablePolicy() {
+      return policy instanceof PushedOutTablePolicy
+          ? (PushedOutTablePolicy) policy : null;
     }
 
     public void openDocument() {
@@ -286,18 +294,21 @@ public final class HtmlChangeReporter<T> {
       // attrs in place, and their values are wanted for the report.
       output.expectAttributes(attrs);
       if (mode == OpenTagMode.REOPENED_TABLE) {
-        if (!(policy instanceof ReopenedTablePolicy)) {
+        PushedOutTablePolicy tablePolicy = pushedOutTablePolicy();
+        if (tablePolicy == null
+            || !tablePolicy.supportsPushedOutTableOperations()) {
           throw new IllegalStateException(
               "Policy cannot safely reopen a table");
         }
-        ((ReopenedTablePolicy) policy).openReopenedTable(attrs);
+        tablePolicy.openReopenedTable(attrs);
       } else if (mode == OpenTagMode.SUPPRESS) {
-        if (!(policy instanceof OpenTagSuppressionPolicy)) {
+        PushedOutTablePolicy tablePolicy = pushedOutTablePolicy();
+        if (tablePolicy == null
+            || !tablePolicy.supportsPushedOutTableOperations()) {
           throw new IllegalStateException(
               "Policy cannot suppress a table-structure tag");
         }
-        ((OpenTagSuppressionPolicy) policy)
-            .openTagWithoutOutput(elementName, attrs);
+        tablePolicy.openTagWithoutOutput(elementName, attrs);
       } else {
         policy.openTag(elementName, attrs);
       }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -251,7 +251,7 @@ public final class HtmlSanitizer {
   }
 
   /** Tracks the tree-construction context needed for self-closing flags. */
-  private static final class ForeignContentContext {
+  static final class ForeignContentContext {
     /** Match the sanitizer's output nesting limit without growing unchecked. */
     private static final int MAX_DEPTH = 256;
 
@@ -292,12 +292,64 @@ public final class HtmlSanitizer {
      */
     private boolean unknown;
 
+    /** Whether the most recently processed tag used foreign-content rules. */
+    private boolean lastTagUsedForeignContentRules;
+
+    /**
+     * True when the most recent start or end tag was processed in SVG or
+     * MathML rather than under the HTML tree-building rules.
+     */
+    boolean lastTagUsedForeignContentRules() {
+      return lastTagUsedForeignContentRules;
+    }
+
+    /** Whether a known current node is in SVG or MathML. */
+    boolean isInForeignContent() {
+      OpenElement current = currentElement();
+      return !unknown && current != null && current.namespace != Namespace.HTML;
+    }
+
+    /** Whether this start tag would use foreign-content tree-building rules. */
+    boolean startTagUsesForeignContentRules(
+        String elementName, List<String> attrs) {
+      if (unknown) { return false; }
+      OpenElement current = currentElement();
+      return !usesHtmlRulesForStartTag(current, elementName)
+          && !breaksOutOfForeignContent(elementName, attrs);
+    }
+
+    /** The outermost SVG or MathML element in the tracked foreign region. */
+    @Nullable String outermostForeignElementName() {
+      if (unknown) { return null; }
+      for (OpenElement open : openElements) {
+        if (open.namespace != Namespace.HTML) { return open.elementName; }
+      }
+      return null;
+    }
+
+    /** Whether the foreign end-tag walk would find this local name. */
+    boolean hasForeignElementNamed(String elementName) {
+      if (!isInForeignContent()) { return false; }
+      for (int i = openElements.size(); --i >= 0;) {
+        OpenElement open = openElements.get(i);
+        if (open.namespace == Namespace.HTML) { return false; }
+        if (asciiEqualsIgnoreCase(open.elementName, elementName)) { return true; }
+      }
+      return false;
+    }
+
+    /** Records an HTML end tag known to be ignored without changing context. */
+    void ignoreEndTagUnderHtmlRules() {
+      lastTagUsedForeignContentRules = false;
+    }
+
     /**
      * Updates the context for a start tag and returns whether its self-closing
      * flag is honored by tree construction.
      */
     boolean processStartTag(
         String elementName, List<String> attrs, boolean selfClosing) {
+      lastTagUsedForeignContentRules = false;
       if (unknown) {
         return selfClosing && isForeignContentRoot(elementName);
       }
@@ -316,6 +368,7 @@ public final class HtmlSanitizer {
 
       // Any other start tag in foreign content inherits the current
       // namespace, even one named "svg" or "math".
+      lastTagUsedForeignContentRules = true;
       if (!selfClosing) {
         push(new OpenElement(elementName, current.namespace, attrs));
       }
@@ -324,6 +377,7 @@ public final class HtmlSanitizer {
 
     /** Updates the context using the foreign-content or HTML end-tag rules. */
     void processEndTag(String elementName) {
+      lastTagUsedForeignContentRules = false;
       if (unknown) { return; }
       if (openElements.isEmpty()) {
         if ("form".equals(elementName)) {
@@ -353,6 +407,7 @@ public final class HtmlSanitizer {
         OpenElement open = openElements.get(i);
         if (open.namespace == Namespace.HTML) { break; }
         if (asciiEqualsIgnoreCase(open.elementName, elementName)) {
+          lastTagUsedForeignContentRules = true;
           openElements.subList(i, openElements.size()).clear();
           return;
         }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -187,23 +187,20 @@ public class TagBalancingHtmlStreamEventReceiver
   }
 
   /**
-   * Implemented by a policy that can apply its element and text decisions to
-   * a start tag while deliberately emitting no tag for it.
+   * Optional policy operations used to keep output around a pushed-out table
+   * in a browser context that matches the logical input context.
    */
-  interface OpenTagSuppressionPolicy {
+  interface PushedOutTablePolicy {
+    /** Whether the operations below are available for the current policy. */
+    boolean supportsPushedOutTableOperations();
+
+    /** Applies element and text policy while deliberately emitting no tag. */
     void openTagWithoutOutput(String elementName, List<String> attrs);
-  }
 
-  /**
-   * Implemented by a policy that emits a synthetic table only when its element
-   * policy keeps it as a table, and otherwise retains it as a virtual element.
-   */
-  interface ReopenedTablePolicy {
+    /** Emits a synthetic table only if policy keeps it as a table. */
     void openReopenedTable(List<String> attrs);
-  }
 
-  /** Reports the browser context of the elements the policy actually emits. */
-  interface OutputContextPolicy {
+    /** Reports the browser context of the elements actually emitted. */
     boolean isOutputInForeignContent();
 
     @Nullable String outputForeignContentRootName();
@@ -391,24 +388,31 @@ public class TagBalancingHtmlStreamEventReceiver
    * behavior, including its nesting-limit accounting.
    */
   private boolean isOutputInForeignContent() {
-    return underlying instanceof OutputContextPolicy
-        && ((OutputContextPolicy) underlying).isOutputInForeignContent();
+    PushedOutTablePolicy policy = pushedOutTablePolicy();
+    return policy != null && policy.isOutputInForeignContent();
   }
 
   /** The outermost foreign root the policy has actually emitted, if known. */
   private @Nullable String outputForeignContentRootName() {
-    return underlying instanceof OutputContextPolicy
-        ? ((OutputContextPolicy) underlying).outputForeignContentRootName()
-        : null;
+    PushedOutTablePolicy policy = pushedOutTablePolicy();
+    return policy != null ? policy.outputForeignContentRootName() : null;
   }
 
   /** Whether the current output context applies foreign rules to this tag. */
   private boolean outputStartTagUsesForeignContentRules(
       String elementName, List<String> attrs) {
-    return underlying instanceof OutputContextPolicy
-        ? ((OutputContextPolicy) underlying)
-            .outputStartTagUsesForeignContentRules(elementName, attrs)
-        : false;
+    PushedOutTablePolicy policy = pushedOutTablePolicy();
+    return policy != null
+        && policy.outputStartTagUsesForeignContentRules(elementName, attrs);
+  }
+
+  /** The pushed-out-table operations supported by the current policy. */
+  private @Nullable PushedOutTablePolicy pushedOutTablePolicy() {
+    if (underlying instanceof PushedOutTablePolicy) {
+      PushedOutTablePolicy policy = (PushedOutTablePolicy) underlying;
+      if (policy.supportsPushedOutTableOperations()) { return policy; }
+    }
+    return null;
   }
 
   /** Opens one logical element, suppressing unsafe table structure if needed. */
@@ -423,10 +427,10 @@ public class TagBalancingHtmlStreamEventReceiver
   private int openElement(
       int inputElementIndex, List<String> attrs, boolean implied) {
     String inputElementName = METADATA.canonNameForIndex(inputElementIndex);
-    if (shouldSuppressTablePart(inputElementIndex, implied)
-        && underlying instanceof OpenTagSuppressionPolicy) {
-      ((OpenTagSuppressionPolicy) underlying)
-          .openTagWithoutOutput(inputElementName, attrs);
+    PushedOutTablePolicy policy = pushedOutTablePolicy();
+    if (policy != null
+        && shouldSuppressTablePart(inputElementIndex, implied)) {
+      policy.openTagWithoutOutput(inputElementName, attrs);
       return NO_OUTPUT_ELEMENT;
     }
     underlying.openTag(inputElementName, attrs);
@@ -701,13 +705,13 @@ public class TagBalancingHtmlStreamEventReceiver
       underlying.closeTag(foreignRootPendingTableReturn);
       foreignRootPendingTableReturn = null;
     }
+    PushedOutTablePolicy policy = pushedOutTablePolicy();
     for (int i = 0; i < n; ++i) {
       int outputElementIndex = NO_OUTPUT_ELEMENT;
       if (openElements.size() < nestingLimit) {
         List<String> attrs = new ArrayList<>();
-        if (run[i] == TABLE_TAG
-            && underlying instanceof ReopenedTablePolicy) {
-          ((ReopenedTablePolicy) underlying).openReopenedTable(attrs);
+        if (run[i] == TABLE_TAG && policy != null) {
+          policy.openReopenedTable(attrs);
           outputElementIndex = outputElementIndexForLastOpenTag(run[i]);
         } else {
           outputElementIndex = openElement(run[i], attrs);
@@ -715,7 +719,8 @@ public class TagBalancingHtmlStreamEventReceiver
       }
       openElements.add(run[i]);
       outputElements.add(outputElementIndex);
-      if (run[i] == TABLE_TAG && outputElementIndex != TABLE_TAG) {
+      if (policy != null
+          && run[i] == TABLE_TAG && outputElementIndex != TABLE_TAG) {
         reopenedWithoutTable.set(openElements.size() - 1);
       }
     }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -92,6 +92,10 @@ public class TagBalancingHtmlStreamEventReceiver
    * and returns to the table: its parts, which clear the stack back to the
    * table, and a table itself, which pops the open table and takes its
    * place.
+   * <p>
+   * These are the same elements whose end tags are scoped to a table in
+   * {@link #SCOPE_FOR_END_TAG}, which is built far below; the two lists are
+   * written out separately because that one is not initialized yet here.
    */
   private static final BitSet TABLE_PARTS = new BitSet();
   static {
@@ -313,9 +317,22 @@ public class TagBalancingHtmlStreamEventReceiver
         && TABLE_PARTS.get(elIndex)) {
       returnToPushedOutTable(elIndex);
     }
-    int nOpen = openElements.size();
+    // Push an open table out of the way before anything below asks what
+    // contains the content: a browser puts content a table cannot hold in
+    // front of the table, so what contains the table contains the content,
+    // and it is what decides which elements are implied and what must close.
+    if (isFosterParented(elIndex) && !endsAnOpenLink(elIndex)) {
+      int tableIndex = containerIndex();
+      if (tableIndex >= 0
+          && TABLE_CONTEXT.get(openElements.get(tableIndex))
+          && !canHold(elIndex, openElements.get(tableIndex), tableIndex)) {
+        pushOutTable(tableIndex);
+      }
+    }
+
     {
-      int top = nOpen != 0 ? openElements.get(nOpen - 1) : BODY_TAG;
+      int container = containerIndex();
+      int top = container >= 0 ? openElements.get(container) : BODY_TAG;
       // Open implied elements, such as list-items and table cells & rows.
       int[] impliedElIndices = METADATA.impliedElements(top, elIndex);
       if (impliedElIndices.length != 0) {
@@ -339,50 +356,47 @@ public class TagBalancingHtmlStreamEventReceiver
           openElements.add(impliedElIndex);
           outputElements.add(
               outputElementIndexForLastOpenTag(impliedElIndex));
-          top = impliedElIndex;
-          ++nOpen;
         }
       }
     }
 
-    if (nOpen != 0) {
-      int top = openElements.get(nOpen - 1);
-      // Close all the elements that cannot contain the content to open.
-      while (true) {
-        // A link ends the link open before it, wherever that is: nested
-        // links do not survive a browser's parse, so a table between them
-        // cannot stay open either.
-        boolean linkEndsLink =
-            elIndex == A_TAG && hasOpenLinkInFormattingScope();
-        boolean canContain = canContain(elIndex, top, nOpen - 1)
-            && !linkEndsLink;
-        if (canContain) {
-          break;
+    // Close all the elements that cannot contain the content to open.
+    while (true) {
+      int container = containerIndex();
+      if (container < 0) { break; }
+      int top = openElements.get(container);
+      // A link ends the link open before it, wherever that is: nested links
+      // do not survive a browser's parse, so a table between them cannot
+      // stay open either.
+      boolean endsLink = endsAnOpenLink(elIndex);
+      if (!endsLink && canContain(elIndex, top, container)) {
+        break;
+      }
+      if (!endsLink
+          && TABLE_CONTEXT.get(top) && isFosterParented(elIndex)) {
+        // As above, for a table uncovered by closing what held it.
+        pushOutTable(container);
+        continue;
+      }
+      // Close the container, and with it anything put in front of a table
+      // it holds, from the top down.
+      for (int i = openElements.size(); --i >= container;) {
+        int unclosed = openElements.get(i);
+        if (i + 1 < nestingLimit && !pushedOut.get(i)) {
+          underlying.closeTag(METADATA.canonNameForIndex(unclosed));
         }
-        if (!linkEndsLink
-            && TABLE_CONTEXT.get(top) && isFosterParented(elIndex)) {
-          // A browser puts the content in front of the table and keeps the
-          // table open.  Close the table in the output, keep it here, and
-          // open the content beside it.
-          pushOutTable(nOpen - 1);
-          break;
+        openElements.remove(i);
+        outputElements.remove(i);
+        pushedOut.clear(i);
+        if (METADATA.resumable(unclosed) && unclosed != elIndex) {
+          toResumeInReverse.add(unclosed);
         }
-        if (openElements.size() < nestingLimit && !pushedOut.get(nOpen - 1)) {
-          underlying.closeTag(METADATA.canonNameForIndex(top));
-        }
-        openElements.remove(--nOpen);
-        outputElements.remove(nOpen);
-        pushedOut.clear(nOpen);
-        if (METADATA.resumable(top) && top != elIndex) {
-          toResumeInReverse.add(top);
-        }
-        if (nOpen == 0) { break; }
-        top = openElements.get(nOpen - 1);
       }
     }
 
     while (!toResumeInReverse.isEmpty()) {
       int toResume = toResumeInReverse.getLast();
+      int nOpen;
       // If toResume can contain elInfo AND the top of the stack can contain
       // toResume, then we push toResume.  A link is not resumed around
       // another link, or where one is open: a browser ends a link when the
@@ -413,10 +427,50 @@ public class TagBalancingHtmlStreamEventReceiver
   /**
    * True if a browser puts content of this kind that arrives inside a table,
    * outside a cell or caption, in front of the table rather than in it: text,
-   * and any element that is not one of a table's own parts.
+   * and any element that is not one of a table's own parts.  What a table
+   * may hold directly, such as a {@code script} or a {@code form}, never
+   * reaches this: the containment tables say the table can contain it.
    */
   private static boolean isFosterParented(int elIndex) {
     return elIndex == HtmlElementTables.TEXT_NODE || !TABLE_PARTS.get(elIndex);
+  }
+
+  /** True if a link is open that a browser ends before opening this one. */
+  private boolean endsAnOpenLink(int elIndex) {
+    return elIndex == A_TAG && hasOpenLinkInFormattingScope();
+  }
+
+  /**
+   * The stack index of the element that content arriving now goes into: the
+   * top, unless a pushed-out table is at the top, in which case the content
+   * goes beside the table, so the element that contains the table is the one
+   * that contains the content.
+   */
+  private int containerIndex() {
+    int i = openElements.size();
+    while (--i >= 0 && pushedOut.get(i)) {
+      // Skip a table closed in the output but still open here.
+    }
+    return i;
+  }
+
+  /**
+   * True if {@code container} can hold {@code elIndex}, with elements
+   * implied between them where it needs them.  The implied path has to run
+   * through the container: one that does not is a fresh table, or list, to
+   * open inside it rather than a way into the one that is already open.
+   */
+  private boolean canHold(
+      int elIndex, int container, int containerIndexOnStack) {
+    int[] implied = METADATA.impliedElements(container, elIndex);
+    for (int i = 0, n = implied.length; i < n; ++i) {
+      if (implied[i] == container) {
+        return i + 1 < n
+            || canContain(elIndex, container, containerIndexOnStack);
+      }
+    }
+    return implied.length == 0
+        && canContain(elIndex, container, containerIndexOnStack);
   }
 
   /**
@@ -470,11 +524,7 @@ public class TagBalancingHtmlStreamEventReceiver
       }
     }
     while (top >= 0 && pushedOut.get(top)) {
-      int entry = openElements.get(top);
-      if (canContain(elIndex, entry, top)
-          || METADATA.impliedElements(entry, elIndex).length != 0) {
-        break;
-      }
+      if (canHold(elIndex, openElements.get(top), top)) { break; }
       openElements.remove(top);
       outputElements.remove(top);
       pushedOut.clear(top);

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -445,9 +445,20 @@ public class TagBalancingHtmlStreamEventReceiver
    * nearest pushed-out table, pops the pushed-out entries that cannot hold
    * the part, even by implying elements between, which for a table is all of
    * them, and writes the rest again as a new table for the part to go in.
+   * <p>
+   * Not across a boundary of table scope, such as a {@code template} in the
+   * pushed-out content: a browser looks for the table within that scope
+   * only, so the part is handled where it arrived, as it would be with no
+   * table pushed out.
    */
   private void returnToPushedOutTable(int elIndex) {
     int top = pushedOut.length() - 1;  // The nearest pushed-out entry.
+    byte tableScope = SCOPE_FOR_END_TAG[TABLE_TAG];
+    for (int i = openElements.size(); --i > top;) {
+      if ((SCOPES_BY_ELEMENT[openElements.get(i)] & tableScope) != 0) {
+        return;
+      }
+    }
     for (int i = openElements.size(); --i > top;) {
       int unclosed = openElements.remove(i);
       outputElements.remove(i);

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -56,12 +56,55 @@ public class TagBalancingHtmlStreamEventReceiver
    */
   private final IntVector outputElements = new IntVector();
   private final IntVector toResumeInReverse = new IntVector();
+  /**
+   * Bit {@code i} is set while the element at {@code i} of
+   * {@link #openElements} is closed in the output but still open here.
+   * <p>
+   * A browser keeps a table, and any row group and row open in it, on its
+   * stack when content arrives that cannot go inside a table: it puts the
+   * content in front of the table instead, foster parenting, and later table
+   * content pops that content and carries on in the same table.  The output
+   * cannot put anything in front of a tag already written, so the table is
+   * closed there and the content written after it, and the table is written
+   * again, as a new table, when its content resumes (#342).  Meanwhile its
+   * entries stay here, so that table content finds them and comes back to
+   * them, and so that they bound end tags for elements below them as they do
+   * in a browser.  Such entries are contiguous, from a {@code table} up, and
+   * are the only pushed-out entries below the content pushed out of them.
+   */
+  private final BitSet pushedOut = new BitSet();
   private static final HtmlElementTables METADATA = HtmlElementTables.get();
   private static final int UNRECOGNIZED_TAG =
       METADATA.indexForName(HtmlElementNames.CUSTOM_ELEMENT_NAME);
   private static final int A_TAG = METADATA.indexForName("a");
   private static final int BODY_TAG = METADATA.indexForName("body");
+  private static final int TABLE_TAG = METADATA.indexForName("table");
   private static final int NO_OUTPUT_ELEMENT = -1;
+  /**
+   * The elements a browser keeps open, and later clears its stack back to,
+   * when it foster-parents content that arrives inside them: a table and its
+   * row groups and rows.  Not the cell, caption or template, inside which
+   * content nests normally.
+   */
+  private static final BitSet TABLE_CONTEXT = new BitSet();
+  /**
+   * The elements whose arrival, in a browser, ends foster-parented content
+   * and returns to the table: its parts, which clear the stack back to the
+   * table, and a table itself, which pops the open table and takes its
+   * place.
+   */
+  private static final BitSet TABLE_PARTS = new BitSet();
+  static {
+    for (String name : new String[] { "table", "tbody", "tfoot", "thead", "tr" }) {
+      TABLE_CONTEXT.set(METADATA.indexForName(name));
+    }
+    for (String name : new String[] {
+             "caption", "col", "colgroup", "table", "tbody", "td", "tfoot",
+             "th", "thead", "tr",
+         }) {
+      TABLE_PARTS.set(METADATA.indexForName(name));
+    }
+  }
   /**
    * Elements on entering which a browser puts a marker on its list of
    * active formatting elements, so that an {@code a} opened inside one of
@@ -184,12 +227,14 @@ public class TagBalancingHtmlStreamEventReceiver
 
   public void closeDocument() {
     for (int i = Math.min(nestingLimit, openElements.size()); --i >= 0;) {
+      if (pushedOut.get(i)) { continue; }  // Already closed in the output.
       int elIndex = openElements.get(i);
       String elname = METADATA.canonNameForIndex(elIndex);
       underlying.closeTag(elname);
     }
     openElements.clear();
     outputElements.clear();
+    pushedOut.clear();
     toResumeInReverse.clear();
     underlying.closeDocument();
   }
@@ -263,6 +308,11 @@ public class TagBalancingHtmlStreamEventReceiver
   }
 
   private void prepareForContent(int elIndex) {
+    if (!pushedOut.isEmpty()
+        && elIndex != HtmlElementTables.TEXT_NODE
+        && TABLE_PARTS.get(elIndex)) {
+      returnToPushedOutTable(elIndex);
+    }
     int nOpen = openElements.size();
     {
       int top = nOpen != 0 ? openElements.get(nOpen - 1) : BODY_TAG;
@@ -299,16 +349,30 @@ public class TagBalancingHtmlStreamEventReceiver
       int top = openElements.get(nOpen - 1);
       // Close all the elements that cannot contain the content to open.
       while (true) {
+        // A link ends the link open before it, wherever that is: nested
+        // links do not survive a browser's parse, so a table between them
+        // cannot stay open either.
+        boolean linkEndsLink =
+            elIndex == A_TAG && hasOpenLinkInFormattingScope();
         boolean canContain = canContain(elIndex, top, nOpen - 1)
-            && !(elIndex == A_TAG && hasOpenLinkInFormattingScope());
+            && !linkEndsLink;
         if (canContain) {
           break;
         }
-        if (openElements.size() < nestingLimit) {
+        if (!linkEndsLink
+            && TABLE_CONTEXT.get(top) && isFosterParented(elIndex)) {
+          // A browser puts the content in front of the table and keeps the
+          // table open.  Close the table in the output, keep it here, and
+          // open the content beside it.
+          pushOutTable(nOpen - 1);
+          break;
+        }
+        if (openElements.size() < nestingLimit && !pushedOut.get(nOpen - 1)) {
           underlying.closeTag(METADATA.canonNameForIndex(top));
         }
         openElements.remove(--nOpen);
         outputElements.remove(nOpen);
+        pushedOut.clear(nOpen);
         if (METADATA.resumable(top) && top != elIndex) {
           toResumeInReverse.add(top);
         }
@@ -320,11 +384,16 @@ public class TagBalancingHtmlStreamEventReceiver
     while (!toResumeInReverse.isEmpty()) {
       int toResume = toResumeInReverse.getLast();
       // If toResume can contain elInfo AND the top of the stack can contain
-      // toResume, then we push toResume.
+      // toResume, then we push toResume.  A link is not resumed around
+      // another link, or where one is open: a browser ends a link when the
+      // next begins, and nested links do not survive a browser's parse, so
+      // the output would not read back as written.
       nOpen = openElements.size();
       if ((nOpen == 0
           || canContain(toResume, openElements.get(nOpen - 1), nOpen))
-          && canContain(elIndex, toResume, nOpen)) {
+          && canContain(elIndex, toResume, nOpen)
+          && !(toResume == A_TAG
+               && (elIndex == A_TAG || hasOpenLinkInFormattingScope()))) {
         toResumeInReverse.removeLast();
         int outputElementIndex = NO_OUTPUT_ELEMENT;
         if (openElements.size() < nestingLimit) {
@@ -338,6 +407,88 @@ public class TagBalancingHtmlStreamEventReceiver
       } else {
         break;
       }
+    }
+  }
+
+  /**
+   * True if a browser puts content of this kind that arrives inside a table,
+   * outside a cell or caption, in front of the table rather than in it: text,
+   * and any element that is not one of a table's own parts.
+   */
+  private static boolean isFosterParented(int elIndex) {
+    return elIndex == HtmlElementTables.TEXT_NODE || !TABLE_PARTS.get(elIndex);
+  }
+
+  /**
+   * Closes in the output, innermost first, the row, row group and table that
+   * the top of the stack is in, and marks them pushed out, keeping them here.
+   * Entries already pushed out, by earlier content beside the same table, are
+   * left as they are.
+   */
+  private void pushOutTable(int topIndex) {
+    for (int i = topIndex; i >= 0; --i) {
+      int elIndex = openElements.get(i);
+      if (!TABLE_CONTEXT.get(elIndex)) { break; }
+      if (!pushedOut.get(i)) {
+        if (i < nestingLimit) {
+          underlying.closeTag(METADATA.canonNameForIndex(elIndex));
+        }
+        pushedOut.set(i);
+      }
+      if (elIndex == TABLE_TAG) { break; }
+    }
+  }
+
+  /**
+   * Handles a table part, or a table, arriving while a table is pushed out,
+   * as a browser does: closes the content that was put in front of the
+   * nearest pushed-out table, pops the pushed-out entries that cannot hold
+   * the part, even by implying elements between, which for a table is all of
+   * them, and writes the rest again as a new table for the part to go in.
+   */
+  private void returnToPushedOutTable(int elIndex) {
+    int top = pushedOut.length() - 1;  // The nearest pushed-out entry.
+    for (int i = openElements.size(); --i > top;) {
+      int unclosed = openElements.remove(i);
+      outputElements.remove(i);
+      if (i < nestingLimit) {
+        underlying.closeTag(METADATA.canonNameForIndex(unclosed));
+      }
+      if (METADATA.resumable(unclosed)) {
+        toResumeInReverse.add(unclosed);
+      }
+    }
+    while (top >= 0 && pushedOut.get(top)) {
+      int entry = openElements.get(top);
+      if (canContain(elIndex, entry, top)
+          || METADATA.impliedElements(entry, elIndex).length != 0) {
+        break;
+      }
+      openElements.remove(top);
+      outputElements.remove(top);
+      pushedOut.clear(top);
+      --top;
+    }
+    if (top < 0 || !pushedOut.get(top)) { return; }
+    int start = top;
+    while (start > 0 && pushedOut.get(start - 1)) { --start; }
+    // Pop the run and push it back, outermost first, opening each again.
+    int n = top - start + 1;
+    int[] run = new int[n];
+    for (int i = n; --i >= 0;) {
+      run[i] = openElements.remove(start + i);
+      outputElements.remove(start + i);
+      pushedOut.clear(start + i);
+    }
+    for (int i = 0; i < n; ++i) {
+      int outputElementIndex = NO_OUTPUT_ELEMENT;
+      if (openElements.size() < nestingLimit) {
+        underlying.openTag(
+            METADATA.canonNameForIndex(run[i]), new ArrayList<>());
+        outputElementIndex = outputElementIndexForLastOpenTag(run[i]);
+      }
+      openElements.add(run[i]);
+      outputElements.add(outputElementIndex);
     }
   }
 
@@ -459,16 +610,18 @@ public class TagBalancingHtmlStreamEventReceiver
     while (--last > index) {
       int unclosed = openElements.remove(last);
       outputElements.remove(last);
-      if (last + 1 < nestingLimit) {
+      if (last + 1 < nestingLimit && !pushedOut.get(last)) {
         underlying.closeTag(METADATA.canonNameForIndex(unclosed));
       }
+      pushedOut.clear(last);
       if (METADATA.resumable(unclosed)) {
         toResumeInReverse.add(unclosed);
       }
     }
-    if (openElements.size() < nestingLimit) {
+    if (openElements.size() < nestingLimit && !pushedOut.get(index)) {
       underlying.closeTag(METADATA.canonNameForIndex(elIndex));
     }
+    pushedOut.clear(index);
     openElements.remove(index);
     outputElements.remove(index);
   }

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/TagBalancingHtmlStreamEventReceiver.java
@@ -48,6 +48,10 @@ public class TagBalancingHtmlStreamEventReceiver
     implements HtmlStreamEventReceiver {
   private final HtmlStreamEventReceiver underlying;
   private int nestingLimit = Integer.MAX_VALUE;
+  private HtmlSanitizer.ForeignContentContext foreignContent
+      = new HtmlSanitizer.ForeignContentContext();
+  /** Input name whose rendered foreign root closes before the table reopens. */
+  private @Nullable String foreignRootPendingTableReturn;
   private final IntVector openElements = new IntVector();
   /**
    * The element each entry in {@link #openElements} became after policy
@@ -73,6 +77,13 @@ public class TagBalancingHtmlStreamEventReceiver
    * are the only pushed-out entries below the content pushed out of them.
    */
   private final BitSet pushedOut = new BitSet();
+  /**
+   * Bit {@code i} is set when the policy did not emit a synthetic table while
+   * returning from {@link #pushedOut}.  Its table-structure descendants cannot
+   * be emitted in that output context without changing when a browser reparses
+   * them.
+   */
+  private final BitSet reopenedWithoutTable = new BitSet();
   private static final HtmlElementTables METADATA = HtmlElementTables.get();
   private static final int UNRECOGNIZED_TAG =
       METADATA.indexForName(HtmlElementNames.CUSTOM_ELEMENT_NAME);
@@ -176,6 +187,32 @@ public class TagBalancingHtmlStreamEventReceiver
   }
 
   /**
+   * Implemented by a policy that can apply its element and text decisions to
+   * a start tag while deliberately emitting no tag for it.
+   */
+  interface OpenTagSuppressionPolicy {
+    void openTagWithoutOutput(String elementName, List<String> attrs);
+  }
+
+  /**
+   * Implemented by a policy that emits a synthetic table only when its element
+   * policy keeps it as a table, and otherwise retains it as a virtual element.
+   */
+  interface ReopenedTablePolicy {
+    void openReopenedTable(List<String> attrs);
+  }
+
+  /** Reports the browser context of the elements the policy actually emits. */
+  interface OutputContextPolicy {
+    boolean isOutputInForeignContent();
+
+    @Nullable String outputForeignContentRootName();
+
+    boolean outputStartTagUsesForeignContentRules(
+        String elementName, List<String> attrs);
+  }
+
+  /**
    * How many elements whose content the policy would suppress -- {@code
    * <script>}, {@code <style>}, {@code <iframe>} and friends, plus any the
    * policy names through {@link TextSuppressionPolicy} -- have been dropped
@@ -226,6 +263,8 @@ public class TagBalancingHtmlStreamEventReceiver
 
   public void openDocument() {
     droppedSkippableDepth = 0;
+    foreignContent = new HtmlSanitizer.ForeignContentContext();
+    foreignRootPendingTableReturn = null;
     underlying.openDocument();
   }
 
@@ -239,6 +278,8 @@ public class TagBalancingHtmlStreamEventReceiver
     openElements.clear();
     outputElements.clear();
     pushedOut.clear();
+    reopenedWithoutTable.clear();
+    foreignRootPendingTableReturn = null;
     toResumeInReverse.clear();
     underlying.closeDocument();
   }
@@ -250,6 +291,39 @@ public class TagBalancingHtmlStreamEventReceiver
     String canonElementName = HtmlLexer.canonicalElementName(elementName);
 
     int elIndex = METADATA.indexForName(canonElementName);
+    String foreignRootBefore = foreignContent.outermostForeignElementName();
+    String outputForeignRootBefore = outputForeignContentRootName();
+    boolean outputUsesForeignContentRules =
+        outputStartTagUsesForeignContentRules(canonElementName, attrs);
+    foreignContent.processStartTag(canonElementName, attrs, false);
+    boolean usesForeignContentRules =
+        foreignContent.lastTagUsedForeignContentRules();
+    if (!pushedOut.isEmpty()
+        && foreignRootBefore != null
+        && !usesForeignContentRules
+        && foreignContent.outermostForeignElementName() == null) {
+      foreignRootPendingTableReturn = outputForeignRootBefore != null
+          ? foreignRootBefore : null;
+    }
+    if (isForeignContentRoot(canonElementName)
+        && needsFosterParenting(elIndex)) {
+      // SVG and MathML start tags use the generic foster-parenting rule in
+      // the table insertion modes.  They are absent from the legacy HTML
+      // containment metadata, so handle them before the unrecognized-tag
+      // fast path below.
+      prepareForContent(elIndex);
+    }
+    if ((usesForeignContentRules || foreignRootPendingTableReturn != null)
+        && outputUsesForeignContentRules
+        && TABLE_PARTS.get(elIndex)
+        && isOutputInForeignContent()) {
+      // HTML table balancing does not apply to SVG or MathML descendants, even
+      // when a local name happens to be a table part.
+      // An HTML integration point makes ForeignContentContext report HTML
+      // rules and deliberately does not take this path.
+      underlying.openTag(elementName, attrs);
+      return;
+    }
     // Treat unrecognized tags as void, but emit closing tags in closeTag().
     if (elIndex == UNRECOGNIZED_TAG) {
       if (openElements.size() < nestingLimit) {
@@ -264,10 +338,10 @@ public class TagBalancingHtmlStreamEventReceiver
     prepareForContent(elIndex);
 
     if (openElements.size() < nestingLimit) {
-      underlying.openTag(METADATA.canonNameForIndex(elIndex), attrs);
+      int outputElementIndex = openElement(elIndex, attrs);
       if (!HtmlTextEscapingMode.isVoidElement(canonElementName)) {
         openElements.add(elIndex);
-        outputElements.add(outputElementIndexForLastOpenTag(elIndex));
+        outputElements.add(outputElementIndex);
       }
     } else {
       if (contentIsSkippable(canonElementName)) { ++droppedSkippableDepth; }
@@ -311,6 +385,74 @@ public class TagBalancingHtmlStreamEventReceiver
     return inputElementIndex;
   }
 
+  /**
+   * Whether a foreign table-part token will actually be written in foreign
+   * content.  A receiver without policy feedback keeps the legacy balancing
+   * behavior, including its nesting-limit accounting.
+   */
+  private boolean isOutputInForeignContent() {
+    return underlying instanceof OutputContextPolicy
+        && ((OutputContextPolicy) underlying).isOutputInForeignContent();
+  }
+
+  /** The outermost foreign root the policy has actually emitted, if known. */
+  private @Nullable String outputForeignContentRootName() {
+    return underlying instanceof OutputContextPolicy
+        ? ((OutputContextPolicy) underlying).outputForeignContentRootName()
+        : null;
+  }
+
+  /** Whether the current output context applies foreign rules to this tag. */
+  private boolean outputStartTagUsesForeignContentRules(
+      String elementName, List<String> attrs) {
+    return underlying instanceof OutputContextPolicy
+        ? ((OutputContextPolicy) underlying)
+            .outputStartTagUsesForeignContentRules(elementName, attrs)
+        : false;
+  }
+
+  /** Opens one logical element, suppressing unsafe table structure if needed. */
+  private int openElement(int inputElementIndex, List<String> attrs) {
+    return openElement(inputElementIndex, attrs, false);
+  }
+
+  /**
+   * Opens one logical element, optionally treating an implied table as part
+   * of the structure below a synthetic table that the policy did not emit.
+   */
+  private int openElement(
+      int inputElementIndex, List<String> attrs, boolean implied) {
+    String inputElementName = METADATA.canonNameForIndex(inputElementIndex);
+    if (shouldSuppressTablePart(inputElementIndex, implied)
+        && underlying instanceof OpenTagSuppressionPolicy) {
+      ((OpenTagSuppressionPolicy) underlying)
+          .openTagWithoutOutput(inputElementName, attrs);
+      return NO_OUTPUT_ELEMENT;
+    }
+    underlying.openTag(inputElementName, attrs);
+    return outputElementIndexForLastOpenTag(inputElementIndex);
+  }
+
+  /**
+   * Whether the nearest logical table was not re-opened in the output, making
+   * an emitted row, cell, section or column invalid there.
+   */
+  private boolean shouldSuppressTablePart(int elIndex) {
+    return shouldSuppressTablePart(elIndex, false);
+  }
+
+  private boolean shouldSuppressTablePart(int elIndex, boolean includeTable) {
+    if ((elIndex == TABLE_TAG && !includeTable) || !TABLE_PARTS.get(elIndex)) {
+      return false;
+    }
+    for (int i = openElements.size(); --i >= 0;) {
+      if (openElements.get(i) == TABLE_TAG) {
+        return reopenedWithoutTable.get(i);
+      }
+    }
+    return false;
+  }
+
   private void prepareForContent(int elIndex) {
     if (!pushedOut.isEmpty()
         && elIndex != HtmlElementTables.TEXT_NODE
@@ -321,13 +463,9 @@ public class TagBalancingHtmlStreamEventReceiver
     // contains the content: a browser puts content a table cannot hold in
     // front of the table, so what contains the table contains the content,
     // and it is what decides which elements are implied and what must close.
-    if (isFosterParented(elIndex) && !endsAnOpenLink(elIndex)) {
+    if (needsFosterParenting(elIndex)) {
       int tableIndex = containerIndex();
-      if (tableIndex >= 0
-          && TABLE_CONTEXT.get(openElements.get(tableIndex))
-          && !canHold(elIndex, openElements.get(tableIndex), tableIndex)) {
-        pushOutTable(tableIndex);
-      }
+      pushOutTable(tableIndex);
     }
 
     {
@@ -348,14 +486,17 @@ public class TagBalancingHtmlStreamEventReceiver
         }
 
         for (int i = startPos, n = impliedElIndices.length; i < n; ++i) {
+          if (openElements.size() >= nestingLimit) { break; }
           int impliedElIndex = impliedElIndices[i];
-          String impliedElName = METADATA.canonNameForIndex(
-              impliedElIndex);
           attrs.clear();
-          underlying.openTag(impliedElName, attrs);
+          boolean suppressedImpliedTable = impliedElIndex == TABLE_TAG
+              && shouldSuppressTablePart(impliedElIndex, true);
+          int outputElementIndex = openElement(impliedElIndex, attrs, true);
           openElements.add(impliedElIndex);
-          outputElements.add(
-              outputElementIndexForLastOpenTag(impliedElIndex));
+          outputElements.add(outputElementIndex);
+          if (suppressedImpliedTable) {
+            reopenedWithoutTable.set(openElements.size() - 1);
+          }
         }
       }
     }
@@ -388,6 +529,7 @@ public class TagBalancingHtmlStreamEventReceiver
         openElements.remove(i);
         outputElements.remove(i);
         pushedOut.clear(i);
+        reopenedWithoutTable.clear(i);
         if (METADATA.resumable(unclosed) && unclosed != elIndex) {
           toResumeInReverse.add(unclosed);
         }
@@ -411,10 +553,7 @@ public class TagBalancingHtmlStreamEventReceiver
         toResumeInReverse.removeLast();
         int outputElementIndex = NO_OUTPUT_ELEMENT;
         if (openElements.size() < nestingLimit) {
-          underlying.openTag(
-              METADATA.canonNameForIndex(toResume),
-              new ArrayList<>());
-          outputElementIndex = outputElementIndexForLastOpenTag(toResume);
+          outputElementIndex = openElement(toResume, new ArrayList<>());
         }
         openElements.add(toResume);
         outputElements.add(outputElementIndex);
@@ -422,6 +561,15 @@ public class TagBalancingHtmlStreamEventReceiver
         break;
       }
     }
+  }
+
+  /** Whether a browser would foster-parent this token out of an open table. */
+  private boolean needsFosterParenting(int elIndex) {
+    if (!isFosterParented(elIndex) || endsAnOpenLink(elIndex)) { return false; }
+    int tableIndex = containerIndex();
+    return tableIndex >= 0
+        && TABLE_CONTEXT.get(openElements.get(tableIndex))
+        && !canHold(elIndex, openElements.get(tableIndex), tableIndex);
   }
 
   /**
@@ -433,6 +581,11 @@ public class TagBalancingHtmlStreamEventReceiver
    */
   private static boolean isFosterParented(int elIndex) {
     return elIndex == HtmlElementTables.TEXT_NODE || !TABLE_PARTS.get(elIndex);
+  }
+
+  /** Whether this name establishes SVG or MathML foreign content. */
+  private static boolean isForeignContentRoot(String canonElementName) {
+    return "svg".equals(canonElementName) || "math".equals(canonElementName);
   }
 
   /** True if a link is open that a browser ends before opening this one. */
@@ -522,12 +675,14 @@ public class TagBalancingHtmlStreamEventReceiver
       if (METADATA.resumable(unclosed)) {
         toResumeInReverse.add(unclosed);
       }
+      reopenedWithoutTable.clear(i);
     }
     while (top >= 0 && pushedOut.get(top)) {
       if (canHold(elIndex, openElements.get(top), top)) { break; }
       openElements.remove(top);
       outputElements.remove(top);
       pushedOut.clear(top);
+      reopenedWithoutTable.clear(top);
       --top;
     }
     if (top < 0 || !pushedOut.get(top)) { return; }
@@ -540,16 +695,29 @@ public class TagBalancingHtmlStreamEventReceiver
       run[i] = openElements.remove(start + i);
       outputElements.remove(start + i);
       pushedOut.clear(start + i);
+      reopenedWithoutTable.clear(start + i);
+    }
+    if (foreignRootPendingTableReturn != null) {
+      underlying.closeTag(foreignRootPendingTableReturn);
+      foreignRootPendingTableReturn = null;
     }
     for (int i = 0; i < n; ++i) {
       int outputElementIndex = NO_OUTPUT_ELEMENT;
       if (openElements.size() < nestingLimit) {
-        underlying.openTag(
-            METADATA.canonNameForIndex(run[i]), new ArrayList<>());
-        outputElementIndex = outputElementIndexForLastOpenTag(run[i]);
+        List<String> attrs = new ArrayList<>();
+        if (run[i] == TABLE_TAG
+            && underlying instanceof ReopenedTablePolicy) {
+          ((ReopenedTablePolicy) underlying).openReopenedTable(attrs);
+          outputElementIndex = outputElementIndexForLastOpenTag(run[i]);
+        } else {
+          outputElementIndex = openElement(run[i], attrs);
+        }
       }
       openElements.add(run[i]);
       outputElements.add(outputElementIndex);
+      if (run[i] == TABLE_TAG && outputElementIndex != TABLE_TAG) {
+        reopenedWithoutTable.set(openElements.size() - 1);
+      }
     }
   }
 
@@ -612,14 +780,47 @@ public class TagBalancingHtmlStreamEventReceiver
     }
     String canonElementName = HtmlLexer.canonicalElementName(elementName);
 
+    int elIndex = METADATA.indexForName(canonElementName);
+    String foreignRootBefore = foreignContent.outermostForeignElementName();
+    String outputForeignRootBefore = outputForeignContentRootName();
+    if (!pushedOut.isEmpty()
+        && foreignContent.isInForeignContent()
+        && !foreignContent.hasForeignElementNamed(canonElementName)
+        && !hasOpenElementInScope(elIndex)) {
+      // The foreign end-tag algorithm reprocesses this under HTML rules, but
+      // the pushed-out table bounds its scope and there is no target before
+      // that boundary, so the end tag is ignored.  Keeping the known foreign
+      // current node prevents later foreign names from being balanced as
+      // HTML or spuriously returning to the table.
+      foreignContent.ignoreEndTagUnderHtmlRules();
+    } else {
+      foreignContent.processEndTag(canonElementName);
+    }
+    boolean usesForeignContentRules =
+        foreignContent.lastTagUsedForeignContentRules();
+    if (!pushedOut.isEmpty()
+        && foreignRootBefore != null
+        && !usesForeignContentRules
+        && foreignContent.outermostForeignElementName() == null) {
+      foreignRootPendingTableReturn = outputForeignRootBefore != null
+          ? foreignRootBefore : null;
+    }
     if (droppedSkippableDepth != 0 && contentIsSkippable(canonElementName)) {
       --droppedSkippableDepth;
     }
 
-    int elIndex = METADATA.indexForName(canonElementName);
+    if (usesForeignContentRules
+        && TABLE_PARTS.get(elIndex)
+        && isOutputInForeignContent()) {
+      underlying.closeTag(elementName);
+      return;
+    }
     if (elIndex == UNRECOGNIZED_TAG) {  // Allow unrecognized end tags through.
       if (openElements.size() < nestingLimit) {
         underlying.closeTag(elementName);
+      }
+      if (canonElementName.equals(foreignRootPendingTableReturn)) {
+        foreignRootPendingTableReturn = null;
       }
       return;
     }
@@ -675,16 +876,35 @@ public class TagBalancingHtmlStreamEventReceiver
         underlying.closeTag(METADATA.canonNameForIndex(unclosed));
       }
       pushedOut.clear(last);
+      reopenedWithoutTable.clear(last);
       if (METADATA.resumable(unclosed)) {
         toResumeInReverse.add(unclosed);
       }
+    }
+    if (pushedOut.get(index) && foreignRootPendingTableReturn != null) {
+      underlying.closeTag(foreignRootPendingTableReturn);
+      foreignRootPendingTableReturn = null;
     }
     if (openElements.size() < nestingLimit && !pushedOut.get(index)) {
       underlying.closeTag(METADATA.canonNameForIndex(elIndex));
     }
     pushedOut.clear(index);
+    reopenedWithoutTable.clear(index);
     openElements.remove(index);
     outputElements.remove(index);
+  }
+
+  /** Whether {@code elIndex} occurs before its end-tag scope is bounded. */
+  private boolean hasOpenElementInScope(int elIndex) {
+    int blockingScopes = SCOPE_FOR_END_TAG[elIndex];
+    for (int i = openElements.size(); --i >= 0;) {
+      int openElementIndex = openElements.get(i);
+      if (openElementIndex == elIndex) { return true; }
+      if ((SCOPES_BY_ELEMENT[openElementIndex] & blockingScopes) != 0) {
+        return false;
+      }
+    }
+    return false;
   }
 
   /**

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
@@ -149,6 +149,47 @@ class HtmlChangeReporterTest {
     assertEquals("", log.toString());
   }
 
+  /** A public policy decorator cannot implement the package-private feedback. */
+  @Test
+  void testPolicyDecoratorDoesNotClaimPushedOutTableOperations() {
+    final Context testContext = new Context();
+    StringBuilder out = new StringBuilder();
+    final StringBuilder log = new StringBuilder();
+    HtmlStreamRenderer renderer = HtmlStreamRenderer.create(
+        out, Handler.DO_NOTHING);
+    HtmlChangeReporter<Context> hcr = new HtmlChangeReporter<>(
+        renderer, loggingListener(testContext, log), testContext);
+    final HtmlSanitizer.Policy delegate = new HtmlPolicyBuilder()
+        .allowElements("table", "tbody", "tr", "td", "div")
+        .toFactory()
+        .apply(hcr.getWrappedRenderer());
+    hcr.setPolicy(new HtmlSanitizer.Policy() {
+      public void openDocument() { delegate.openDocument(); }
+
+      public void closeDocument() { delegate.closeDocument(); }
+
+      public void openTag(String elementName, List<String> attrs) {
+        delegate.openTag(elementName, attrs);
+      }
+
+      public void closeTag(String elementName) {
+        delegate.closeTag(elementName);
+      }
+
+      public void text(String textChunk) { delegate.text(textChunk); }
+    });
+
+    HtmlSanitizer.sanitize(
+        "<table><div>x<tr><td>y</td></tr></table>tail",
+        hcr.getWrappedPolicy());
+
+    assertEquals(
+        "<table></table><div>x</div>"
+            + "<table><tbody><tr><td>y</td></tr></tbody></table>tail",
+        out.toString());
+    assertEquals("", log.toString());
+  }
+
   /**
    * {@link ElementPolicy#apply} may return another element name, and the
    * reporter used to decide whether a tag survived by comparing names, so a

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1958,6 +1958,29 @@ class HtmlSanitizerTest {
         p.sanitize("<table>x<tr><td>y</td></tr></table>"));
   }
 
+  /**
+   * A browser looks for the table to return to within table scope only, so
+   * a table or row inside a {@code template} in the pushed-out content
+   * stays in the template, and the pushed-out table waits for a part
+   * arriving outside it.
+   */
+  @Test
+  void testReturnToAPushedOutTableStopsAtATableScopeBoundary() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("table", "tbody", "tr", "td", "div", "template")
+        .toFactory();
+    String out = p.sanitize(
+        "<table><div><template><table><tr><td>y</td></tr></table></template>"
+        + "z</div>w<tr><td>v</td></tr></table>u");
+
+    assertEquals(
+        "<table></table><div><template>"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table></template>z</div>w"
+        + "<table><tbody><tr><td>v</td></tr></tbody></table>u",
+        out);
+    assertEquals(out, p.sanitize(out));
+  }
+
   /** Pushed-out content is bounded by the nesting limit like any other. */
   @Test
   void testPushedOutContentRespectsTheNestingLimit() {

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1932,6 +1932,145 @@ class HtmlSanitizerTest {
   }
 
   /**
+   * Table-part names in SVG and MathML stay in foreign content.  Treating
+   * them as HTML used to close the foreign ancestors and move the elements
+   * into the pushed-out table.  At an HTML integration point the same names
+   * do use HTML rules and still return to the table.
+   */
+  @Test
+  void testForeignTablePartsDoNotReturnToAPushedOutTable() throws Exception {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements(
+            "b", "caption", "colgroup", "table", "thead", "tbody",
+            "tr", "td", "div", "svg", "g", "textArea", "foreignObject",
+            "math", "mrow", "mtext")
+        .toFactory();
+    String input = "<table><svg><g><tr><td>s</td></tr>"
+        + "<textArea><tr><td>t</td></tr></textArea></g></svg>"
+        + "<math><mrow><tr><td>m</td></tr></mrow></math>"
+        + "<tr><td>h</td></tr></table>tail";
+    String out = p.sanitize(input);
+
+    assertEquals(
+        "<table></table><svg><g><tr><td>s</td></tr>"
+        + "<textArea><tr><td>t</td></tr></textArea></g></svg>"
+        + "<math><mrow><tr><td>m</td></tr></mrow></math>"
+        + "<table><tbody><tr><td>h</td></tr></tbody></table>tail",
+        out);
+    assertEquals(out, p.sanitize(out));
+    assertEquals(parseAsBrowser("<table></table>" + input), parseAsBrowser(out));
+
+    for (String[] integrationPoint : new String[][] {
+            { "<svg><foreignObject>", "</foreignObject></svg>" },
+            { "<math><mtext>", "</mtext></math>" },
+         }) {
+      input = "<table><div>" + integrationPoint[0]
+          + "<tr><td>i</td></tr>" + integrationPoint[1]
+          + "<tr><td>h</td></tr></table>tail";
+      out = p.sanitize(input);
+      assertEquals(out, p.sanitize(out), integrationPoint[0]);
+      assertEquals(
+          parseAsBrowser("<table></table>" + input), parseAsBrowser(out),
+          integrationPoint[0]);
+    }
+
+    // An emitted HTML breakout leaves the rendered foreign root before the
+    // table is written again.  Its later end tag must not close that table in
+    // the policy's stack and strand the following section outside it.
+    input = "<table><svg><b><thead></svg>"
+        + "<tbody><tr><td>y</td></tr></table>tail";
+    out = p.sanitize(input);
+    assertEquals(
+        "<table></table><svg><b></b></svg>"
+        + "<table><thead></thead><tbody><tr><td><b>y</b></td></tr>"
+        + "</tbody></table><b>tail</b>",
+        out);
+    assertEquals(out, p.sanitize(out));
+
+    // A stray table end tag cannot lose foreign context and send a later
+    // table part back into the pushed-out table.
+    String foreign = "<table><svg><colgroup></thead>"
+        + "<caption>c</caption></colgroup></svg>"
+        + "<tr><td>y</td></tr></table>tail";
+    out = p.sanitize(foreign);
+    assertEquals(out, p.sanitize(out));
+    assertEquals(
+        parseAsBrowser("<table></table>" + foreign), parseAsBrowser(out));
+  }
+
+  /** Raw-text and RCDATA elements stay bounded by a pushed-out run. */
+  @Test
+  void testLiteralContentInPushedOutTableContent() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements(
+            "table", "tbody", "tr", "td", "div", "span", "style",
+            "script", "textarea", "noscript")
+        .allowTextIn("style", "script", "noscript")
+        .toFactory();
+    String input = "<table><textarea>&lt;tr&gt;</textarea><div>"
+        + "<style>x{}</style><script>x()</script>"
+        + "<noscript><span>n</span></noscript></div>"
+        + "<tr><td>y</td></tr></table>tail";
+    String out = p.sanitize(input);
+
+    assertEquals(
+        "<table></table><textarea>&lt;tr&gt;</textarea><div>"
+        + "<style>x{}</style><script>x()</script>"
+        + "<noscript>n</noscript></div>"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table>tail",
+        out);
+    assertEquals(out, p.sanitize(out));
+  }
+
+  /**
+   * A policy may drop or rename the attribute-free table written when table
+   * content resumes.  A renamed synthetic table and its row structure cannot
+   * safely be emitted, but allowed cell text still survives.  This includes
+   * replacements with table, void, select, raw-text and foreign parsing rules.
+   */
+  @Test
+  void testTableStructureIsSuppressedUnderRenamedReopenedTable() {
+    String input = "<table class=t><div>x<tr><td>"
+        + "a&lt;/script&gt;&lt;svg onload=x&gt;b"
+        + "</td></tr></table>tail";
+    String[] replacements = {
+        "", "div", "tbody", "tr", "td", "caption", "colgroup", "col",
+        "br", "select", "option", "script", "style", "textarea",
+        "noscript", "xmp", "plaintext", "iframe", "svg", "math",
+    };
+    HtmlChangeListener<Object> ignore = new HtmlChangeListener<Object>() {
+      public void discardedTag(Object context, String elementName) {
+        // Output is under test, notifications are not.
+      }
+
+      public void discardedAttributes(
+          Object context, String tagName, String... attributeNames) {
+        // Output is under test, notifications are not.
+      }
+    };
+    for (String c : replacements) {
+      final String replacement = c.isEmpty() ? null : c;
+      PolicyFactory p = new HtmlPolicyBuilder()
+          .allowElements(
+              (elementName, attrs) -> attrs.isEmpty()
+                  ? replacement : elementName,
+              "table")
+          .allowElements("tbody", "tr", "td", "div")
+          .allowAttributes("class").onElements("table")
+          .allowTextIn("table")
+          .toFactory();
+      String out = p.sanitize(input);
+
+      assertEquals(
+          "<table class=\"t\"></table><div>x</div>"
+              + "a&lt;/script&gt;&lt;svg onload&#61;x&gt;btail",
+          out, c);
+      assertEquals(out, p.sanitize(out), c);
+      assertEquals(out, p.sanitize(input, ignore, null), c);
+    }
+  }
+
+  /**
    * A link pushed out of a table is closed when the table resumes, and is
    * not written again around another link or inside one: nested links do
    * not survive a browser's parse.  Text is pushed out likewise, and needs

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1779,6 +1779,216 @@ class HtmlSanitizerTest {
     assertEquals(renamedInto, intoMarker.sanitize(renamedInto));
   }
 
+  /**
+   * A browser puts content that cannot go inside a table in front of the
+   * table and keeps the table open, so that the next row pops the content
+   * and carries on in the same table (#342).  The output cannot put anything
+   * in front of a tag already written, so the table is closed there, the
+   * content written after it, and the table written again for its rows.
+   * The content used to stay open until the end of the document, taking the
+   * rows and everything after the table with it.  A browser now reads the
+   * output as it reads the input, but for the empty table in front.
+   */
+  @Test
+  void testContentPushedOutOfATableIsClosedWhenTheTableResumes()
+      throws Exception {
+    PolicyFactory p = tablePolicy();
+    String input = "<table><div>x<tr><td>y</td></tr></div></table>tail";
+    String out = p.sanitize(input);
+
+    assertEquals(
+        "<table></table><div>x</div>"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table>tail",
+        out);
+    assertEquals(out, p.sanitize(out));
+    assertEquals(parseAsBrowser("<table></table>" + input), parseAsBrowser(out));
+  }
+
+  /**
+   * The shape reported in #342: the table had rows before the content and
+   * attributes of its own.  The rows before stay in the first table, and the
+   * table written again for the rows after has no attributes, as a formatting
+   * element written again after being closed has none.
+   */
+  @Test
+  void testRowsAfterPushedOutContentContinueInANewTable() throws Exception {
+    PolicyFactory p = tablePolicy();
+    String input = "<table class=t><tbody><tr><td>a</td></tr>"
+        + "<div class=d>x<tr><td>y</td></tr></div></table>tail";
+    String out = p.sanitize(input);
+
+    assertEquals(
+        "<table class=\"t\"><tbody><tr><td>a</td></tr></tbody></table>"
+        + "<div class=\"d\">x</div>"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table>tail",
+        out);
+    assertEquals(out, p.sanitize(out));
+  }
+
+  /**
+   * Content pushed out of a table nests as usual until a part of the table
+   * arrives, which closes all of it.  End tags for that content arriving
+   * later find nothing to close, as in a browser, and the text after them
+   * is pushed out as well.  A browser puts that text in front of the table;
+   * the output, written in order, can only put it after.
+   */
+  @Test
+  void testPushedOutContentNestsUntilATablePartArrives() {
+    PolicyFactory p = tablePolicy();
+    String input = "<table><div><p>x<span>s<tr><td>y</td></tr></span>t</div>u"
+        + "</table>v";
+    String out = p.sanitize(input);
+
+    assertEquals(
+        "<table></table><div><p>x<span>s</span></p></div>"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table>tuv",
+        out);
+    assertEquals(out, p.sanitize(out));
+  }
+
+  /**
+   * A browser keeps the table open below the content it pushed out, so an
+   * end tag for an element enclosing the table is ignored meanwhile, and the
+   * text after it lands in the pushed-out content.  The balancer used to
+   * close the table and let the end tag through.
+   */
+  @Test
+  void testEndTagBelowAPushedOutTableIsIgnoredWhileItIsOpen()
+      throws Exception {
+    PolicyFactory p = tablePolicy();
+    String input = "<div><table><span>x</div>y</table>z";
+    String out = p.sanitize(input);
+
+    assertEquals("<div><table></table><span>xy</span>z</div>", out);
+    assertEquals(out, p.sanitize(out));
+    assertEquals(
+        parseAsBrowser("<div><table></table><span>xy</span>z</div>"),
+        parseAsBrowser(out));
+  }
+
+  /**
+   * The table's own end tag ends the content pushed out of it.  A browser
+   * has the content in front of the table and the text after both; the
+   * output has the same nodes with the table first.
+   */
+  @Test
+  void testTableEndTagEndsPushedOutContent() {
+    PolicyFactory p = tablePolicy();
+    String out = p.sanitize("<table><div>x</table>tail");
+
+    assertEquals("<table></table><div>x</div>tail", out);
+    assertEquals(out, p.sanitize(out));
+  }
+
+  /**
+   * A table arriving inside pushed-out content pops the open table in a
+   * browser and takes its place, rather than nesting in the content; and
+   * with tables pushed out at two levels, a row returns to the nearest.
+   */
+  @Test
+  void testTableInsidePushedOutContentReplacesTheOpenTable()
+      throws Exception {
+    PolicyFactory p = tablePolicy();
+    String input = "<table><div>x<table><tr><td>y</td></tr></table>tail";
+    String out = p.sanitize(input);
+    assertEquals(
+        "<table></table><div>x</div>"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table>tail",
+        out);
+    assertEquals(out, p.sanitize(out));
+
+    String nested = "<table><div>x<table><span>y<tr><td>z</td></tr></table>"
+        + "</div>w</table>v";
+    out = p.sanitize(nested);
+    assertEquals(
+        "<table></table><div>x</div><table></table><span>y</span>"
+        + "<table><tbody><tr><td>z</td></tr></tbody></table>wv",
+        out);
+    assertEquals(out, p.sanitize(out));
+    assertEquals(parseAsBrowser("<table></table>" + nested), parseAsBrowser(out));
+  }
+
+  /** Every part of a table brings the pushed-out table back. */
+  @Test
+  void testEveryTablePartReturnsToThePushedOutTable() throws Exception {
+    PolicyFactory p = tablePolicy();
+    String[][] cases = {
+        { "<caption>c</caption>", "<caption>c</caption>" },
+        { "<thead><tr><th>h</th></tr></thead>", "<thead><tr><th>h</th></tr></thead>" },
+        { "<tbody><tr><td>y</td></tr></tbody>", "<tbody><tr><td>y</td></tr></tbody>" },
+        { "<tr><td>y</td></tr>", "<tbody><tr><td>y</td></tr></tbody>" },
+        { "<td>y</td>", "<tbody><tr><td>y</td></tr></tbody>" },
+        { "<th>h</th>", "<tbody><tr><th>h</th></tr></tbody>" },
+    };
+    for (String[] c : cases) {
+      String input = "<table><div>x" + c[0] + "</table>";
+      String out = p.sanitize(input);
+      assertEquals(
+          "<table></table><div>x</div><table>" + c[1] + "</table>", out, c[0]);
+      assertEquals(out, p.sanitize(out), c[0]);
+      assertEquals(
+          parseAsBrowser("<table></table>" + input), parseAsBrowser(out), c[0]);
+    }
+  }
+
+  /**
+   * A link pushed out of a table is closed when the table resumes, and is
+   * not written again around another link or inside one: nested links do
+   * not survive a browser's parse.  Text is pushed out likewise, and needs
+   * nothing closed.
+   */
+  @Test
+  void testPushedOutLinkIsNotResumedAroundAnotherLink() throws Exception {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("table", "tbody", "tr", "td", "a")
+        .allowAttributes("href").onElements("a")
+        .allowWithoutAttributes("a")
+        .toFactory();
+    String out = p.sanitize(
+        "<table><a href=u>x<tr><td><a href=v>y</a>z</td></tr></table>w");
+
+    assertEquals(
+        "<table></table><a href=\"u\">x</a>"
+        + "<table><tbody><tr><td><a href=\"v\">y</a><a>z</a></td></tr></tbody>"
+        + "</table><a>w</a>",
+        out);
+    assertEquals(out, p.sanitize(out));
+    assertEquals(
+        "<table></table>x<table><tbody><tr><td>y</td></tr></tbody></table>",
+        p.sanitize("<table>x<tr><td>y</td></tr></table>"));
+  }
+
+  /** Pushed-out content is bounded by the nesting limit like any other. */
+  @Test
+  void testPushedOutContentRespectsTheNestingLimit() {
+    PolicyFactory p = tablePolicy();
+    StringBuilder sb = new StringBuilder("<table>");
+    for (int i = 0; i < 300; ++i) { sb.append("<div>"); }
+    sb.append("<tr><td>y</td></tr></table>z");
+    String out = p.sanitize(sb.toString());
+    assertTrue(
+        out.endsWith("</div><table><tbody><tr><td>y</td></tr></tbody></table>z"),
+        out.substring(out.length() - 80));
+    assertEquals(out, p.sanitize(out));
+
+    sb = new StringBuilder();
+    for (int i = 0; i < 300; ++i) { sb.append("<table><div>"); }
+    sb.append("<tr><td>y</td></tr></table>z");
+    out = p.sanitize(sb.toString());
+    assertTrue(out.startsWith("<table></table><div></div><table></table>"), out);
+    assertEquals(out, p.sanitize(out));
+  }
+
+  private static PolicyFactory tablePolicy() {
+    return new HtmlPolicyBuilder()
+        .allowElements(
+            "table", "caption", "thead", "tbody", "tfoot", "tr", "td", "th",
+            "div", "p", "span")
+        .allowAttributes("class").onElements("table", "div")
+        .allowWithoutAttributes("span")
+        .toFactory();
+  }
+
   /** The tree a browser builds from html, one node per line. */
   private static String parseAsBrowser(String html) throws Exception {
     Node fragment = new HtmlDocumentBuilder().parseFragment(

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -1981,6 +1981,131 @@ class HtmlSanitizerTest {
     assertEquals(out, p.sanitize(out));
   }
 
+  /**
+   * Content is judged by what holds the table it was pushed out of, since
+   * that is where a browser puts it.  An element that cannot hold the
+   * content closes instead of nesting it: a heading inside a heading does
+   * not survive a browser's parse, so the output would read back as a
+   * different tree.
+   */
+  @Test
+  void testPushedOutContentIsJudgedByWhatHoldsTheTable() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("table", "tbody", "tr", "td", "h1", "button")
+        .toFactory();
+    String heading = p.sanitize(
+        "<h1><table><tr><td>a</td></tr><h1>b</h1></table>");
+    assertEquals(
+        "<h1><table><tbody><tr><td>a</td></tr></tbody></table></h1>"
+        + "<h1>b</h1>",
+        heading);
+    assertEquals(heading, p.sanitize(heading));
+
+    String button = p.sanitize(
+        "<button><table><tr><td>a</td></tr><button>b</button></table>");
+    assertEquals(
+        "<button><table><tbody><tr><td>a</td></tr></tbody></table></button>"
+        + "<button>b</button>",
+        button);
+    assertEquals(button, p.sanitize(button));
+  }
+
+  /**
+   * And it gets the elements a browser would imply around it there: an
+   * option needs its select whether or not a table was pushed out of the
+   * way, which the tables never leave to chance, since the sanitizer does
+   * not know what the output will be embedded in.
+   */
+  @Test
+  void testContentBesideAPushedOutTableStillGetsItsImpliedWrapper() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("table", "tbody", "tr", "td", "select", "option")
+        .toFactory();
+    String out = p.sanitize("<table>x<option>o</option></table>z");
+
+    assertEquals("<table></table>x<select><option>o</option></select>z", out);
+    assertEquals(out, p.sanitize(out));
+  }
+
+  /**
+   * Text that follows a pushed-out table reaches the output even where the
+   * element holding the table cannot hold text: that element closes, as it
+   * would for text arriving anywhere else, rather than the text going into
+   * it and being dropped.  The table inside the {@code colgroup} here is a
+   * separate, older mis-implication (#483); what this pins is that
+   * {@code tail} survives.
+   */
+  @Test
+  void testTextAfterAPushedOutTableSurvivesAContainerThatCannotHoldIt() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("table", "colgroup", "col", "tbody", "tr", "td")
+        .toFactory();
+    String out = p.sanitize("<table><col><tr><td>a</td></tr>tail</table>");
+
+    assertEquals(
+        "<table><colgroup><col />"
+        + "<table><tbody><tr><td>a</td></tr></tbody></table>"
+        + "</colgroup></table>tail",
+        out);
+  }
+
+  /**
+   * A cell returning to a pushed-out table lands in the table, not in a
+   * fresh one: the row group it arrives in cannot hold a cell without a row
+   * between, and the path to that row runs through a table, so the row group
+   * goes and the table takes the cell.
+   */
+  @Test
+  void testACellReturningToAPushedOutSectionDoesNotOpenANewTable() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("table", "thead", "tfoot", "tbody", "tr", "td", "th")
+        .toFactory();
+    String head = p.sanitize("<table><thead>x<td>y</td></table>tail");
+    assertEquals(
+        "<table><thead></thead></table>x"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table>tail",
+        head);
+    assertEquals(head, p.sanitize(head));
+
+    String foot = p.sanitize("<table><tfoot>x<th>h</th></table>tail");
+    assertEquals(
+        "<table><tfoot></tfoot></table>x"
+        + "<table><tbody><tr><th>h</th></tr></tbody></table>tail",
+        foot);
+    assertEquals(foot, p.sanitize(foot));
+  }
+
+  /**
+   * The rule that a link is not written again around or inside another link
+   * is not about tables: an end tag that closes the element a link was
+   * misnested in queues the link for resumption, and resuming it around the
+   * next link used to produce nested links, which a browser's parse
+   * unnests, so the output read back as a different tree.
+   */
+  @Test
+  void testLinkIsNotResumedAroundAnotherLinkWithoutATable() {
+    PolicyFactory p = new HtmlPolicyBuilder()
+        .allowElements("div", "p", "a")
+        .allowAttributes("href").onElements("a")
+        .allowUrlProtocols("http")
+        .allowWithoutAttributes("a")
+        .toFactory();
+    String out = p.sanitize(
+        "<div><a href=http://u>x</div><a href=http://v>y");
+    assertEquals(
+        "<div><a href=\"http://u\">x</a></div><a href=\"http://v\">y</a>",
+        out);
+    assertEquals(out, p.sanitize(out));
+
+    String nested = p.sanitize(
+        "<div><a href=http://u>x<p><a href=http://v>y</a></p></a>");
+    assertEquals(
+        "<div><a href=\"http://u\">x<p></p></a>"
+        + "<a href=\"http://v\">y</a></div>",
+        nested);
+    assertEquals(nested, p.sanitize(nested));
+  }
+
   /** Pushed-out content is bounded by the nesting limit like any other. */
   @Test
   void testPushedOutContentRespectsTheNestingLimit() {
@@ -1993,12 +2118,27 @@ class HtmlSanitizerTest {
         out.endsWith("</div><table><tbody><tr><td>y</td></tr></tbody></table>z"),
         out.substring(out.length() - 80));
     assertEquals(out, p.sanitize(out));
+  }
 
-    sb = new StringBuilder();
+  /**
+   * A table arriving beside a pushed-out table replaces it, so a long run
+   * of them leaves nothing behind: the stack stays flat however many there
+   * are, where the content used to nest one run inside the next.
+   */
+  @Test
+  void testRepeatedPushOutAndReturnDoesNotAccumulate() {
+    PolicyFactory p = tablePolicy();
+    StringBuilder sb = new StringBuilder();
     for (int i = 0; i < 300; ++i) { sb.append("<table><div>"); }
     sb.append("<tr><td>y</td></tr></table>z");
-    out = p.sanitize(sb.toString());
-    assertTrue(out.startsWith("<table></table><div></div><table></table>"), out);
+    String out = p.sanitize(sb.toString());
+
+    StringBuilder expected = new StringBuilder();
+    for (int i = 0; i < 300; ++i) { expected.append("<table></table><div></div>"); }
+    expected.setLength(expected.length() - "<table></table><div></div>".length());
+    expected.append("<table></table><div></div>")
+        .append("<table><tbody><tr><td>y</td></tr></tbody></table>z");
+    assertEquals(expected.toString(), out);
     assertEquals(out, p.sanitize(out));
   }
 

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -246,6 +246,95 @@ class TagBalancingHtmlStreamRendererTest {
         htmlOutputBuffer.toString());
   }
 
+  /**
+   * A browser puts content that cannot go inside a table in front of the
+   * table and keeps the table open, so that the next row pops the content
+   * and carries on in the same table (#342).  The output cannot put anything
+   * in front of a tag already written, so the table is closed there and
+   * written again for the row; the content is closed when the row comes,
+   * where it used to stay open and swallow the row and everything after.
+   */
+  @Test
+  void testContentPushedOutOfATableIsClosedWhenTheTableResumes() {
+    balancer.openDocument();
+    balancer.openTag("table", j8().listOf());
+    balancer.openTag("div", j8().listOf());
+    balancer.text("x");
+    balancer.openTag("tr", j8().listOf());
+    balancer.openTag("td", j8().listOf());
+    balancer.text("y");
+    balancer.closeTag("td");
+    balancer.closeTag("tr");
+    balancer.closeTag("div");  // Ignored: no div in table scope.
+    balancer.closeTag("table");
+    balancer.text("tail");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<table></table><div>x</div>"
+        + "<table><tbody><tr><td>y</td></tr></tbody></table>tail",
+        htmlOutputBuffer.toString());
+  }
+
+  /** The row group and row the content was pushed out of return as well. */
+  @Test
+  void testPushedOutRowAndRowGroupReturnWithTheTable() {
+    balancer.openDocument();
+    balancer.openTag("table", j8().listOf());
+    balancer.openTag("tbody", j8().listOf());
+    balancer.openTag("tr", j8().listOf());
+    balancer.openTag("td", j8().listOf());
+    balancer.text("a");
+    balancer.closeTag("td");
+    balancer.openTag("div", j8().listOf());
+    balancer.text("x");
+    balancer.openTag("td", j8().listOf());
+    balancer.text("b");
+    balancer.closeTag("td");
+    balancer.closeTag("tr");
+    balancer.closeTag("table");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<table><tbody><tr><td>a</td></tr></tbody></table><div>x</div>"
+        + "<table><tbody><tr><td>b</td></tr></tbody></table>",
+        htmlOutputBuffer.toString());
+  }
+
+  /** The table's own end tag ends the content pushed out of it. */
+  @Test
+  void testPushedOutTableEndsWithItsEndTag() {
+    balancer.openDocument();
+    balancer.openTag("table", j8().listOf());
+    balancer.openTag("div", j8().listOf());
+    balancer.text("x");
+    balancer.closeTag("table");
+    balancer.text("tail");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<table></table><div>x</div>tail", htmlOutputBuffer.toString());
+  }
+
+  /**
+   * A pushed-out table is closed in the output but still counts toward the
+   * nesting limit, which is a conservative reading of the limit.
+   */
+  @Test
+  void testPushedOutTableCountsTowardTheNestingLimit() {
+    balancer.setNestingLimit(3);
+    balancer.openDocument();
+    balancer.openTag("table", j8().listOf());
+    balancer.openTag("div", j8().listOf());
+    balancer.openTag("p", j8().listOf());
+    balancer.openTag("span", j8().listOf());  // Past the limit.
+    balancer.text("x");
+    balancer.closeDocument();
+
+    assertEquals(
+        "<table></table><div><p>x</p></div>", htmlOutputBuffer.toString());
+  }
+
   @Test
   void testNestingLimits() {
     // Some browsers can be DoSed by deeply nested structures.

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/TagBalancingHtmlStreamRendererTest.java
@@ -335,6 +335,41 @@ class TagBalancingHtmlStreamRendererTest {
         "<table></table><div><p>x</p></div>", htmlOutputBuffer.toString());
   }
 
+  /** Implied table structure never opens past a small nesting limit. */
+  @Test
+  void testPushedOutTableImpliedElementsRespectSmallNestingLimits() {
+    String[] expected = {
+        "xytail",
+        "<table></table>x<table></table>ytail",
+        "<table></table><div>x</div>"
+            + "<table><tbody></tbody></table>ytail",
+        "<table></table><div>x</div>"
+            + "<table><tbody><tr></tr></tbody></table>ytail",
+    };
+    for (int limit = 0; limit < expected.length; ++limit) {
+      StringBuilder out = new StringBuilder();
+      TagBalancingHtmlStreamEventReceiver limited =
+          new TagBalancingHtmlStreamEventReceiver(
+              HtmlStreamRenderer.create(
+                  out, x -> fail("Unexpected renderer error: " + x)));
+      limited.setNestingLimit(limit);
+      limited.openDocument();
+      limited.openTag("table", j8().listOf());
+      limited.openTag("div", j8().listOf());
+      limited.text("x");
+      limited.openTag("tr", j8().listOf());
+      limited.openTag("td", j8().listOf());
+      limited.text("y");
+      limited.closeTag("td");
+      limited.closeTag("tr");
+      limited.closeTag("table");
+      limited.text("tail");
+      limited.closeDocument();
+
+      assertEquals(expected[limit], out.toString(), "limit " + limit);
+    }
+  }
+
   @Test
   void testNestingLimits() {
     // Some browsers can be DoSed by deeply nested structures.


### PR DESCRIPTION
Fixes #342.

A browser puts content that cannot go inside a table, such as a `div` between its rows, in front of the table and keeps the table open, so the next row pops the content and carries on in the same table. The balancer closed the table to make room for the content, and when the row came it opened a new table inside the content, which then stayed open until its parent closed and swallowed every row and everything after the table. With the reporter's own HTML, the `div` with `display:none` wrapped the whole rest of the message.

```
<table><div>x<tr><td>y</td></tr></div></table>tail
before: <table></table><div>x<table><tbody><tr><td>y</td></tr></tbody></table>tail</div>
after:  <table></table><div>x</div><table><tbody><tr><td>y</td></tr></tbody></table>tail
```

## Design

`TagBalancingHtmlStreamEventReceiver` gains a `pushedOut` bit set over its open-element stack. When content a browser would foster-parent arrives and the open table cannot hold it, the table and any row group and row are closed in the output but kept on the stack and marked. While marked they still bound end tags for elements below them, as in a browser, so `</div>` for a `div` enclosing the table is ignored until the table ends. When a part of the table arrives, the pushed-out content is closed, the marked entries that cannot hold the part are dropped, and the rest are written again as a new table for the part to go in. A `table` start tag pops the pushed-out table instead, as in a browser. The table's own end tag closes the content and pops the marked entries without writing anything. The return stops at a table-scope boundary, such as a `template` in the pushed-out content, where a browser would not look past it.

The element that holds the table is the element that holds the content, since that is where a browser puts it. So the push-out happens before anything asks what contains the content, and a container index skips a pushed-out run: the implied elements and the containment checks see the real container, and close it when it cannot hold the content.

The output cannot put anything in front of a tag already written, so the table is written twice, once empty and once with the later rows, and the second copy has no attributes, like a formatting element written again after being closed. Text pushed out of a table follows it rather than preceding it. Apart from those two things a browser now reads the output as it reads the input, which the tests check with the validator.nu parser.

## Second commit: the review's findings

An independent review of the first commit found four shapes where content beside a pushed-out table was still handled as if the table contained it, three of them regressions against `main`. All four are fixed in `77fc910` with a test each, verified against a `main` build case by case:

| Shape | Was | Now |
| --- | --- | --- |
| `<table>x<option>o</option></table>z` | bare `<option>`, not idempotent | `<select>` wrapper restored, idempotent |
| `<h1><table><tr><td>a</td></tr><h1>b</h1></table>` | nested `h1`, not idempotent | outer `h1` closes, idempotent |
| `<table><col><tr><td>a</td></tr>tail</table>` | `tail` silently dropped | `tail` kept, as on `main` |
| `<table><thead>x<td>y</td></table>tail` | fresh table inside the re-opened `thead`, not idempotent | cell returns to the table, idempotent |

A 52-shape differential sweep against `main` now shows no idempotence or balance regressions, two fewer non-idempotent shapes than `main`, and two shapes where `main` loses text that this keeps. The two that remain non-idempotent are the pre-existing `col` mis-implication, filed as #483.

## Links

Two guards, since nested links do not survive a browser's parse and would make the output read back differently: a link that ends the link open before it still does so through a table between them rather than pushing the table out (an existing test with a dropped `caption` caught this), and a link closed on the way back to a table is not written again around or inside another link. The second also fixes a table-free case on `main`, where `<div><a href=u>x</div><a href=v>y` produced nested links, and has its own regression test.

## Known limitation

A formatting element pushed out of a table is queued by the pre-existing resume mechanism and can be written again inside the table's next cell, where a browser's cell marker would stop it: `<table><b>x<tr><td>y</td></tr></table>z` puts a `<b>` around the cell text. `main` has the cell text inside the outer `<b>` instead, so it renders the same either way, and the output is stable. Teaching the resume queue about formatting markers would change `testTablesGuarded`, which pins resumption across cells, so it is left alone.

## Tests

Four at the balancer level and fifteen through `PolicyFactory`: the issue's shape, the reporter's shape with row groups and attributes, nesting inside pushed-out content, end tags below the table, the table's own end tag, a nested table, two levels of pushed-out tables, the scope boundary, every table part, pushed-out links and text, the four review shapes, the table-free link case, and the nesting limit with 300 pushed-out elements and 300 push-out cycles. All 583 tests pass on JDK 11, 17, 21 and 25, and the three fuzzers pass at six fixed seeds.

## Out of scope, filed separately

A table part arriving in a container that was never pushed out still implies a new table there (#483), a `form` directly inside a table stays open as a container (#484), and the element at the nesting limit is written but its end tag is not (#485). Each is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ydng7gBm6Ax5zfwt4vZip
