### PR TITLE
Preserve text gates in renamed literal-content elements

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -2,6 +2,10 @@
 
 Most recent at top.
   * Next release
+    * A nested element inside one renamed to a literal-content element no
+      longer opens its own text gate.  Its text now follows the outer element's
+      gate, so it cannot reach `style` or similar content where text was not
+      allowed (#482).
     * Docs: Add focused README files for each Maven module and an index for
       supporting documentation, including safe build and regeneration steps.
     * Table parts inside cell content now return to the existing table, and a

--- a/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
+++ b/owasp-java-html-sanitizer/src/main/java/org/owasp/html/ElementAndAttributePolicyBasedSanitizerPolicy.java
@@ -86,6 +86,12 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    */
   transient boolean skipText = true;
   /**
+   * True while an emitted element whose content the renderer writes literally
+   * is open.  A nested start tag cannot be emitted in that context, so it must
+   * be treated as dropped before it can become a text container in the policy.
+   */
+  private boolean inKeptLiteralElement;
+  /**
    * True while a kept element whose text the renderer emits unescaped, such
    * as {@code <style>}, {@code <script>} or {@code <iframe>}, is open as an
    * allowed text container, so {@link #text} knows to strip the tags the
@@ -129,6 +135,8 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
    * {@code k} elements restores it.
    */
   private final BitSet skipTextBeforeOpen = new BitSet();
+  /** The same for {@link #inKeptLiteralElement}. */
+  private final BitSet inKeptLiteralBeforeOpen = new BitSet();
   /** The same for {@link #inKeptCdataElement}. */
   private final BitSet inKeptCdataBeforeOpen = new BitSet();
   /** The same for {@link #inForeignContent}. */
@@ -188,6 +196,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
 
   public void openDocument() {
     skipText = false;
+    inKeptLiteralElement = false;
     inKeptCdataElement = false;
     keptCdataElementName = null;
     inForeignContent = false;
@@ -199,6 +208,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     skippedLastTagAsAttributeless = false;
     openElementStack.clear();
     skipTextBeforeOpen.clear();
+    inKeptLiteralBeforeOpen.clear();
     inKeptCdataBeforeOpen.clear();
     inForeignContentBeforeOpen.clear();
     keptCdataNameBeforeOpen.clear();
@@ -215,10 +225,12 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
     }
     openElementStack.clear();
     skipTextBeforeOpen.clear();
+    inKeptLiteralBeforeOpen.clear();
     inKeptCdataBeforeOpen.clear();
     inForeignContentBeforeOpen.clear();
     keptCdataNameBeforeOpen.clear();
     skipText = true;
+    inKeptLiteralElement = false;
     inKeptCdataElement = false;
     keptCdataElementName = null;
     inForeignContent = false;
@@ -798,6 +810,11 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   private void openTag(
       String elementName, List<String> attrs, OpenTagMode mode) {
     outputElementNameForLastOpenTag = null;
+    if (inKeptLiteralElement) {
+      skippedLastTagAsAttributeless = false;
+      deferOpenTag(elementName);
+      return;
+    }
     ElementAndAttributePolicies policies = elAndAttrPolicies.get(elementName);
     String adjustedElementName = applyPolicies(elementName, attrs, policies);
     skippedLastTagAsAttributeless = false;
@@ -902,6 +919,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
         }
         openElementStack.subList(i, n).clear();
         skipText = skipTextBeforeOpen.get(i / 2);
+        inKeptLiteralElement = inKeptLiteralBeforeOpen.get(i / 2);
         inKeptCdataElement = inKeptCdataBeforeOpen.get(i / 2);
         inForeignContent = inForeignContentBeforeOpen.get(i / 2);
         keptCdataElementName = keptCdataNameBeforeOpen.get(i / 2);
@@ -962,6 +980,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
       keptCdataElementName = adjustedElementName;
       literalTextTail = "";
     }
+    inKeptLiteralElement = inKeptLiteralElement || literal;
     inKeptCdataElement = inKeptCdataElement || enteringKeptCdata;
     // Judged before this element is in foreign content itself: a browser
     // parses the content of an svg or math element as markup, but the
@@ -989,6 +1008,7 @@ class ElementAndAttributePolicyBasedSanitizerPolicy
   private void push(String elementName, @Nullable String adjustedElementName) {
     int depth = openElementStack.size() / 2;
     skipTextBeforeOpen.set(depth, skipText);
+    inKeptLiteralBeforeOpen.set(depth, inKeptLiteralElement);
     inKeptCdataBeforeOpen.set(depth, inKeptCdataElement);
     inForeignContentBeforeOpen.set(depth, inForeignContent);
     keptCdataNameBeforeOpen.add(keptCdataElementName);

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlChangeReporterTest.java
@@ -722,8 +722,8 @@ class HtmlChangeReporterTest {
 
   /**
    * A tag arriving inside literal content the renderer is writing is dropped
-   * as content that cannot appear there, which a policy that renames an
-   * element into {@code style} brings about.  Reported under the input name.
+   * before its attributes are judged, which a policy that renames an element
+   * into {@code style} brings about.  Reported under the input name.
    */
   @Test
   void testTagInsideRenamedLiteralContentElementIsReported() {
@@ -732,7 +732,8 @@ class HtmlChangeReporterTest {
         .allowElements("b")
         .allowTextIn("style")
         .toFactory();
-    Result result = sanitizeVerbose(policy, "<div>a<b>bold</b>c</div>");
+    Result result = sanitizeVerbose(
+        policy, "<div>a<b onclick=alert(1)>bold</b>c</div>");
 
     assertEquals("<style>aboldc</style>", result.html);
     assertEquals("<b> ", result.log);

--- a/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/owasp-java-html-sanitizer/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -2059,6 +2059,20 @@ class HtmlPolicyBuilderTest {
         apply(divToStyle.allowTextIn("style"), "<div>a{b:c}</div>"));
   }
 
+  /** A nested kept element does not override a literal element's text gate. */
+  @Test
+  void testNestedElementInsideRenamedLiteralContentUsesOuterTextGate() {
+    HtmlPolicyBuilder divToStyle = new HtmlPolicyBuilder()
+        .allowElements((name, attrs) -> "style", "div")
+        .allowElements("b", "style");
+    String html = "<div>a<b>bold</b>c</div><b>after</b>";
+
+    assertEquals("<style></style><b>after</b>", apply(divToStyle, html));
+    assertEquals(
+        "<style>aboldc</style><b>after</b>",
+        apply(divToStyle.allowTextIn("style"), html));
+  }
+
   /**
    * A void element renamed to one that is not void is closed at once (#450).
    * The lexer never produces a close tag for {@code br}, and the balancer,


### PR DESCRIPTION
## Summary

Fixes #482.

When an `ElementPolicy` renamed a container to an element such as `style`, a
nested allowed element could become the policy's active text container even
though the renderer could not emit its tag inside literal content. That let the
nested text bypass the outer element's text gate.

This change tracks whether a kept literal-content element is open separately
from whether its text is allowed. Nested start tags are treated as dropped
before they can establish another text gate, so their text remains governed by
the outer element. The state is restored when that element closes.

## Tests

- Added negative coverage showing nested text is removed when the renamed
  literal-content element does not allow text.
- Added positive coverage showing explicitly allowed text still survives while
  the nested tag is removed.
- Verified a following sibling is unaffected after the literal-content element
  closes.
- Verified change reporting treats the nested tag as discarded without
  separately reporting its attributes.
- `./mvnw -ntp -B clean verify` passes on JDK 25: 604 library tests and 7 example
  tests.
